### PR TITLE
Add x86_64 CUDA support with separate profile

### DIFF
--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -1,5 +1,6 @@
 version: "3.0"
 services:
+  # NVIDIA Jetson devices (Xavier, Orin) - ARM64 with Tegra GPU
   backend_tegra_gpu_enabled:
     network_mode: "host"
     build: ./backend
@@ -45,6 +46,7 @@ services:
               count: all
               capabilities: [gpu]
     profiles: [tegra]
+  # CPU-only systems (x86_64, ARM64) - no GPU acceleration
   backend_generic:
     network_mode: "host"
     build: ./backend
@@ -82,6 +84,55 @@ services:
       - GRPC_ENABLE_FORK_SUPPORT=1
       - PYTHONPATH=/opt/tritonserver/backends/python:/
     profiles: [generic]
+  # x86_64 systems with NVIDIA GPU (Tesla T4, RTX, etc.)
+  backend_x86_cuda:
+    network_mode: "host"
+    build: ./backend
+    image: flask-app
+    privileged: true
+    expose:
+      - "5000"
+      - "5443"
+      - "8000"
+      - "8001"
+      - "80002"
+    volumes:
+      - /aws_dda:/aws_dda
+      - /tmp:/tmp
+      - /dev/shm:/dev/shm
+      - /usr/local/cuda:/usr/local/cuda:ro
+      - /usr/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:ro
+    environment:
+      - DDA_SYSTEM_USER_ID=$DDA_SYSTEM_USER_ID
+      - DDA_SYSTEM_GROUP_ID=$DDA_SYSTEM_GROUP_ID
+      - DDA_ADMIN_USER_ID=$DDA_ADMIN_USER_ID
+      - DDA_ADMIN_GROUP_ID=$DDA_ADMIN_GROUP_ID
+      - AWS_REGION
+      - SVCUID
+      - AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT
+      - AWS_CONTAINER_AUTHORIZATION_TOKEN
+      - AWS_CONTAINER_CREDENTIALS_FULL_URI
+      - AWS_IOT_THING_NAME
+      - COMPONENT_WORK_PATH
+      - KERNEL_ROOT_PATH
+      - INFERENCE_COMPONENT_DECOMPRESED_PATH
+      - LOCAL_SERVER_COMPONENT_DECOMPRESSED_PATH
+      - JETSON_CUDA=$JETSON_CUDA
+      - JETSON_TENSORRT=$JETSON_TENSORRT
+      - CUDA_HOME=/usr/local/cuda
+      - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64
+      - GRPC_POLL_STRATEGY=poll
+      - GRPC_ENABLE_FORK_SUPPORT=1
+      - PYTHONPATH=/opt/tritonserver/backends/python:/
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    profiles: [x86_cuda]
+  # React web interface - runs on all configurations
   frontend:
     build: ./frontend
     image: react-webapp

--- a/src/host_scripts/get_nvidia_libs_versions.sh
+++ b/src/host_scripts/get_nvidia_libs_versions.sh
@@ -143,9 +143,11 @@ echo "JETSON_TENSORRT=${JETSON_TENSORRT}" >> /tmp/.dda.env
 if [ -f /sys/devices/soc0/soc_id ]; then
     is_gpu=0
 fi
-#Use gpu if aarch64 and CUDA is present
+#Use gpu profile based on architecture and CUDA presence
 if [ $is_gpu -eq 1 ] && [ $arch = "aarch64" ]; then
     echo DOCKER_PROFILE='tegra' >> /tmp/.dda.env
+elif [ $is_gpu -eq 1 ] && [ $arch = "x86_64" ]; then
+    echo DOCKER_PROFILE='x86_cuda' >> /tmp/.dda.env
 else
     echo DOCKER_PROFILE='generic' >> /tmp/.dda.env
 fi


### PR DESCRIPTION
Added x86_64 NVIDIA GPU support to resolve CUDA runtime library errors: New Docker Compose Profile: Added backend_x86_cuda service for x86_64 systems with NVIDIA GPUs. Mounts CUDA libraries from host system (/usr/local/cuda, /usr/lib/x86_64-linux-gnu). Sets CUDA environment variables (CUDA_HOME, LD_LIBRARY_PATH). Enables NVIDIA GPU device access for Docker containers

Enhanced Hardware Detection: Updated get_nvidia_libs_versions.sh to automatically detect x86_64 + CUDA systems

Added logic to set DOCKER_PROFILE='x86_cuda' for x86_64 systems with GPU libraries

Maintains existing detection for Jetson (tegra) and CPU-only (generic) systems

Documentation: Added clear comments to Docker Compose services explaining target hardware:

backend_tegra_gpu_enabled: NVIDIA Jetson devices (Xavier, Orin) - ARM64 with Tegra GPU

backend_generic: CPU-only systems - no GPU acceleration

backend_x86_cuda: x86_64 systems with NVIDIA GPU (Tesla T4, RTX, etc.)

Problem Solved: Compiled models expecting CUDA 10.2 runtime libraries now have access to host system CUDA installation, eliminating "libcudart.so.10.2: cannot open shared object file" errors.

Testing: Automatic profile selection ensures correct configuration based on detected hardware without manual intervention.