### PR TITLE
Merge jp5v2: unified JP4/JP5/x86 build with ECR deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Build artifacts
+*.log
+custom-build/
+greengrass-build/
+.gdk/
+src/backend/edgemlsdk/
+src/edgemlsdk/extracted-debs/
+src/edgemlsdk/cached-debs/
+
+# OS files
+.DS_Store
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -170,13 +170,13 @@ DDA consists of several key components:
 - **Minimum**: 4GB RAM, 20GB storage, x86_64 or ARM64 processor
 - **Recommended**: 8GB RAM, 64GB storage, GPU acceleration (optional)
 - **Supported Platforms**:
-  - x86_64 CPU systems
-  - ARM64 CPU systems
-  - NVIDIA Jetson devices (Xavier Only with Jetpack 4.X, JP5+ coming soon)
+  - x86_64 CPU systems (Ubuntu 20.04)
+  - NVIDIA Jetson devices with JetPack 4.6 (Ubuntu 18.04, aarch64)
+  - NVIDIA Jetson devices with JetPack 5 (Ubuntu 20.04, aarch64)
 - **Supported Operating Systems**:
-  - X86 Ubuntu 20.04, 22.04, (24.04 coming soon)
-  - Jetson devices currently Jetpack 4.X
-  - ARM64 - Ubuntu 18.04-22.04
+  - x86_64: Ubuntu 20.04, 22.04
+  - ARM64 JetPack 4.6: Ubuntu 18.04
+  - ARM64 JetPack 5: Ubuntu 20.04
 
 ### Supported Cameras and Sensors
 
@@ -250,6 +250,59 @@ DDA consists of several key components:
    }
    ```
 
+2. **Create ECR publish policy** (required for large Docker images that exceed the 2 GB Greengrass artifact limit):
+   - Policy name: `dda-ecr-publish`
+   - This policy allows the build server to push Docker images to ECR and create Greengrass component versions that pull from ECR at deployment time.
+   - Replace `[AWS account id]` with your account ID:
+   ```json
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Sid": "ECRAuth",
+               "Effect": "Allow",
+               "Action": "ecr:GetAuthorizationToken",
+               "Resource": "*"
+           },
+           {
+               "Sid": "ECRRepoManage",
+               "Effect": "Allow",
+               "Action": [
+                   "ecr:CreateRepository",
+                   "ecr:DescribeRepositories",
+                   "ecr:TagResource"
+               ],
+               "Resource": "arn:aws:ecr:*:[AWS account id]:repository/dda/*"
+           },
+           {
+               "Sid": "ECRPush",
+               "Effect": "Allow",
+               "Action": [
+                   "ecr:BatchCheckLayerAvailability",
+                   "ecr:InitiateLayerUpload",
+                   "ecr:UploadLayerPart",
+                   "ecr:CompleteLayerUpload",
+                   "ecr:PutImage",
+                   "ecr:BatchGetImage",
+                   "ecr:GetDownloadUrlForLayer"
+               ],
+               "Resource": "arn:aws:ecr:*:[AWS account id]:repository/dda/*"
+           },
+           {
+               "Sid": "GreengrassPublish",
+               "Effect": "Allow",
+               "Action": [
+                   "greengrass:CreateComponentVersion",
+                   "greengrass:ListComponentVersions"
+               ],
+               "Resource": "arn:aws:greengrass:*:[AWS account id]:components:aws.edgeml.dda.*"
+           }
+       ]
+   }
+   ```
+
+   > **Note**: The JetPack 5 (ARM64) backend Docker image exceeds the Greengrass 2 GB artifact size limit. The build script automatically detects this and pushes images to ECR instead. The edge devices will pull from ECR during component installation, so the device's token exchange role also needs `ecr:GetAuthorizationToken`, `ecr:BatchGetImage`, and `ecr:GetDownloadUrlForLayer` permissions (see edge device policy below).
+
 2. **Create edge device policy**:
    - Policy name: `dda-greengrass-policy`
 ```json
@@ -273,6 +326,16 @@ DDA consists of several key components:
                 "arn:aws:s3:::*/*",
                 "arn:aws:s3:::*"
             ]
+        },
+        {
+            "Sid": "ECRPull",
+            "Effect": "Allow",
+            "Action": [
+                "ecr:GetAuthorizationToken",
+                "ecr:BatchGetImage",
+                "ecr:GetDownloadUrlForLayer"
+            ],
+            "Resource": "*"
         },
         {
             "Effect": "Allow",
@@ -301,32 +364,80 @@ DDA consists of several key components:
     ]
 }
 ```   
-   - Attach S3 permissions for component downloads
 
 3. **Create IAM roles**:
-   - Build server role: `dda-build-role` (attach `dda-build-policy` + `AmazonSSMManagedInstanceCore`)
+   - Build server role: `dda-build-role` (attach `dda-build-policy` + `dda-ecr-publish` + `AmazonSSMManagedInstanceCore`)
    - Edge device role: `dda-greengrass-role` (attach `dda-greengrass-policy` + `AmazonSSMManagedInstanceCore`)
+
+4. **Update the Greengrass Token Exchange Role** (created automatically during Greengrass provisioning):
+   
+   The `GreengrassV2TokenExchangeRole` is the role that Greengrass components use at runtime to access AWS services. After provisioning the edge device, add these inline policies to it:
+
+   **Inline policy: `ECRPullAccess`** (required for JP5 ECR-based deployments):
+   ```json
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Sid": "ECRPull",
+               "Effect": "Allow",
+               "Action": [
+                   "ecr:GetAuthorizationToken",
+                   "ecr:BatchGetImage",
+                   "ecr:GetDownloadUrlForLayer"
+               ],
+               "Resource": "*"
+           }
+       ]
+   }
+   ```
+
+   **Inline policy: `GreengrassComponentS3Access`** (required for downloading component artifacts):
+   ```json
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Effect": "Allow",
+               "Action": [
+                   "s3:GetObject",
+                   "s3:GetObjectVersion"
+               ],
+               "Resource": [
+                   "arn:aws:s3:::dda-component-*/*"
+               ]
+           }
+       ]
+   }
+   ```
+
+   > **Note**: The `GreengrassV2TokenExchangeRole` is separate from the `dda-greengrass-role` used for device provisioning. It's created by the Greengrass installer and used by components at runtime.
 
 #### Step 1: Set up Build Environment
 
 1. **Launch EC2 build instance**:
    
-   **The EC2 build instance depends on the edge device configuration:**
+   **The EC2 build instance must match the target edge device architecture:**
    
-   **If your edge device is ARM64 (Jetson Xavier, ARM64 systems):**
+   **If your edge device is ARM64 JetPack 4.6 (Jetson Xavier, L4T r32.x):**
    ```bash
-   # Launch Ubuntu 18.04 ARM64, g4dn.2xlarge
+   # Launch Ubuntu 18.04 ARM64 (e.g., a1.2xlarge or c6g.2xlarge)
    # Storage: 512GB, Security: SSH (port 22)
    # Attach IAM role: dda-build-role
-   # AMI: Find Ubuntu 18.04 in AWS Marketplace → [Ryan to add details]
+   ```
+   
+   **If your edge device is ARM64 JetPack 5 (Jetson Orin, L4T r35.x):**
+   ```bash
+   # Launch Ubuntu 20.04 ARM64 (e.g., a1.2xlarge or c6g.2xlarge)
+   # Storage: 512GB, Security: SSH (port 22)
+   # Attach IAM role: dda-build-role
    ```
    
    **If your edge device is x86_64 CPU (Intel/AMD systems):**
    ```bash
-   # Launch Ubuntu 20.04 x86_64, g4dn.2xlarge
+   # Launch Ubuntu 20.04 x86_64 (e.g., c5.2xlarge or g4dn.2xlarge)
    # Storage: 512GB, Security: SSH (port 22)
    # Attach IAM role: dda-build-role
-   # AMI: Ubuntu 20.04 → [Ryan to add details]
    ```
 
 2. **Connect and setup**:
@@ -365,8 +476,20 @@ DDA consists of several key components:
 
 2. **Build and publish**:
    ```bash
-  ./gdk-component-build-and-publish.sh >logfile.log 2>&1 &
+   # For x86_64 builds (auto-detects architecture):
+   ./gdk-component-build-and-publish.sh > build.log 2>&1 &
+
+   # For ARM64 JetPack 4.6 builds:
+   ./gdk-component-build-and-publish.sh aarch64 4 > build.log 2>&1 &
+
+   # For ARM64 JetPack 5 builds:
+   ./gdk-component-build-and-publish.sh aarch64 5 > build.log 2>&1 &
+
+   # Monitor build progress:
+   tail -f build.log
    ```
+
+   > **Note**: For JetPack 5 builds, the Docker image exceeds the Greengrass 2 GB artifact limit. The build script automatically pushes to ECR and creates a component that pulls images at install time. Ensure the `dda-ecr-publish` policy is attached to your build role.
 
 #### Step 3: Set up Edge Device
 

--- a/build-custom.sh
+++ b/build-custom.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 # Copyright 2025 Amazon Web Services, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,26 +14,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ $# -ne 2 ]; then
-  echo 1>&2 "Usage: $0 COMPONENT-NAME COMPONENT-VERSION"
+if [ $# -ne 3 ]; then
+  echo 1>&2 "Usage: $0 COMPONENT-NAME COMPONENT-VERSION ARCH"
   exit 3
 fi
 
 COMPONENT_NAME=$1
 VERSION=$2
-ARCHITECTURE=`uname -m`
-# change to 20.04 or 18.04
-# TODO add 20.04 for JP5
-IMAGE_VER="18.04"
-#IMAGE_VER="20.04"
+ARCHITECTURE=$3
+
 BUILDKIT_PROGRESS=plain
 export BUILDKIT_PROGRESS
+
+# Detect Ubuntu version from host
 IMAGE_VER=$(grep "DISTRIB_RELEASE" /etc/lsb-release | cut -d'=' -f2)
-
-# Export as environment variable
-export IMAGE_VER 
-
+export IMAGE_VER
 echo "Ubuntu version: $IMAGE_VER"
+
+# Determine if this is a JP5 build based on component name
+IS_JP5=0
+if echo "$COMPONENT_NAME" | grep -q "JP5"; then
+    IS_JP5=1
+fi
+
+echo "Architecture: $ARCHITECTURE"
+echo "JetPack 5: $IS_JP5"
+
 # copy recipe to greengrass-build
 cp recipe.yaml ./greengrass-build/recipes
 
@@ -41,40 +48,89 @@ rm -rf ./custom-build
 mkdir -p ./custom-build/$COMPONENT_NAME
 
 # build Docker images
-# to save build time, remove "--no-cache" parameter
 cd src
-#edgemlsdk
+
+# edgemlsdk build
 cd edgemlsdk/
-./build.sh -p $(uname -m) -u $IMAGE_VER 3.9
+if [ "$IS_JP5" = "1" ]; then
+    ./build.sh -p $ARCHITECTURE -u $IMAGE_VER -y 3.9 -j 5
+else
+    ./build.sh -p $ARCHITECTURE -u $IMAGE_VER -y 3.9
+fi
 cd ..
-mkdir backend/edgemlsdk
-cp -r edgemlsdk backend/edgemlsdk
-echo copying $id
-id=$(docker create edgemlsdk)
-docker cp $id:/debs/PanoramaSDK.deb $(pwd)/backend/edgemlsdk/
-docker cp $id:/debs/aws-c-iot.deb $(pwd)/backend/edgemlsdk/
-docker cp $id:/debs/aws-crt-cpp.deb $(pwd)/backend/edgemlsdk/
-docker cp $id:/debs/aws-iot-device-sdk-cpp-v2.deb $(pwd)/backend/edgemlsdk/
-docker cp $id:/debs/aws-sdk-cpp.deb $(pwd)/backend/edgemlsdk/
-docker cp $id:/debs/libgstreamer-plugins-base1.0-dev.deb $(pwd)/backend/edgemlsdk/
-docker cp $id:/debs/libgstreamer1.0-dev.deb $(pwd)/backend/edgemlsdk/
-docker cp $id:/debs/libgstreamer1.0.deb $(pwd)/backend/edgemlsdk/
-docker cp $id:/debs/liborc-0.4-0.deb $(pwd)/backend/edgemlsdk/
-docker cp $id:/debs/libstdc++6.deb $(pwd)/backend/edgemlsdk/
-docker cp $id:/debs/openssl.deb $(pwd)/backend/edgemlsdk/
-docker cp $id:/debs/panorama.whl $(pwd)/backend/edgemlsdk/panorama-1.0-py3-none-any.whl
-docker cp $id:/debs/triton-core.deb $(pwd)/backend/edgemlsdk/
-docker cp $id:/debs/triton-python-backend.deb $(pwd)/backend/edgemlsdk/
-docker cp $id:/tars/triton_installation_files.tar.gz  $(pwd)/backend/edgemlsdk/
-docker rm -v $id
-echo done copying binaries
-# rest of the application
-docker-compose --profile tegra --profile generic -f docker-compose.yaml build --build-arg OS=$IMAGE_VER --no-cache
+
+# Copy edgemlsdk artifacts to backend build context
+mkdir -p backend/edgemlsdk
+# Clean stale debs from previous builds
+rm -f backend/edgemlsdk/*.deb backend/edgemlsdk/*.whl backend/edgemlsdk/*.tar.gz
+
+# Copy debs/tars from extracted-debs directory (populated by build.sh)
+EXTRACTED_DIR=$(pwd)/edgemlsdk/extracted-debs
+if [ ! -d "$EXTRACTED_DIR/debs" ]; then
+    echo "ERROR: extracted-debs/debs not found at $EXTRACTED_DIR"
+    echo "The edgemlsdk build.sh should have extracted debs to this directory."
+    exit 1
+fi
+echo "Copying debs from $EXTRACTED_DIR..."
+cp $EXTRACTED_DIR/debs/PanoramaSDK.deb $(pwd)/backend/edgemlsdk/
+cp $EXTRACTED_DIR/debs/aws-c-iot.deb $(pwd)/backend/edgemlsdk/
+cp $EXTRACTED_DIR/debs/aws-crt-cpp.deb $(pwd)/backend/edgemlsdk/
+cp $EXTRACTED_DIR/debs/aws-iot-device-sdk-cpp-v2.deb $(pwd)/backend/edgemlsdk/
+cp $EXTRACTED_DIR/debs/aws-sdk-cpp.deb $(pwd)/backend/edgemlsdk/
+cp $EXTRACTED_DIR/debs/libgstreamer-plugins-base1.0-dev.deb $(pwd)/backend/edgemlsdk/
+cp $EXTRACTED_DIR/debs/libgstreamer1.0-dev.deb $(pwd)/backend/edgemlsdk/
+cp $EXTRACTED_DIR/debs/libgstreamer1.0.deb $(pwd)/backend/edgemlsdk/
+cp $EXTRACTED_DIR/debs/liborc-0.4-0.deb $(pwd)/backend/edgemlsdk/
+cp $EXTRACTED_DIR/debs/libstdc++6.deb $(pwd)/backend/edgemlsdk/
+cp $EXTRACTED_DIR/debs/openssl.deb $(pwd)/backend/edgemlsdk/
+cp $EXTRACTED_DIR/debs/panorama.whl $(pwd)/backend/edgemlsdk/panorama-1.0-py3-none-any.whl
+cp $EXTRACTED_DIR/debs/triton-core.deb $(pwd)/backend/edgemlsdk/
+cp $EXTRACTED_DIR/debs/triton-python-backend.deb $(pwd)/backend/edgemlsdk/
+cp $EXTRACTED_DIR/tars/triton_installation_files.tar.gz $(pwd)/backend/edgemlsdk/
+echo "Done copying binaries"
+
+# Verify all required artifacts are present
+for f in aws-c-iot.deb aws-crt-cpp.deb aws-iot-device-sdk-cpp-v2.deb aws-sdk-cpp.deb \
+         PanoramaSDK.deb openssl.deb liborc-0.4-0.deb triton-core.deb \
+         triton-python-backend.deb panorama-1.0-py3-none-any.whl triton_installation_files.tar.gz; do
+    if [ ! -f "$(pwd)/backend/edgemlsdk/$f" ]; then
+        echo "ERROR: Required file backend/edgemlsdk/$f not found after copy"
+        exit 1
+    fi
+done
+echo "All required edgemlsdk artifacts verified"
+
+# Build backend and frontend Docker images
+# Select the correct Dockerfile for the backend
+if [ "$IS_JP5" = "1" ]; then
+    export BACKEND_DOCKERFILE="Dockerfile.jp5"
+else
+    export BACKEND_DOCKERFILE="Dockerfile"
+fi
+export OS=$IMAGE_VER
+
+echo "Building backend with $BACKEND_DOCKERFILE..."
+if [ "$ARCHITECTURE" = "x86_64" ]; then
+    # x86_64 only needs the generic profile (no Tegra/GPU support)
+    docker-compose --profile generic -f docker-compose.yaml build --no-cache
+else
+    # aarch64 builds both profiles
+    docker-compose --profile generic -f docker-compose.yaml build --no-cache
+    docker-compose --profile tegra -f docker-compose.yaml build --no-cache
+fi
 cd ..
-# save Docker images as tar
-echo "save docker images as tarvballs"
-docker save --output ./custom-build/$COMPONENT_NAME/flask-app.tar flask-app
-docker save --output ./custom-build/$COMPONENT_NAME/react-webapp.tar react-webapp
+
+# save Docker images separately for Greengrass (each artifact must be < 2GB)
+echo "Saving docker images as separate artifacts..."
+docker save react-webapp | gzip > ./custom-build/$COMPONENT_NAME/react-webapp.tar.gz
+
+FLASK_TAR="./custom-build/$COMPONENT_NAME/flask-app.tar"
+docker save flask-app --output "$FLASK_TAR"
+FLASK_SIZE=$(stat --format=%s "$FLASK_TAR")
+echo "flask-app.tar size: $(numfmt --to=iec $FLASK_SIZE)"
+
+echo "Image sizes:"
+ls -lh ./custom-build/$COMPONENT_NAME/*.tar* 
 
 # include docker-compose.yaml in archive
 cp src/docker-compose.yaml ./custom-build/$COMPONENT_NAME/
@@ -89,14 +145,30 @@ mkdir -p ./greengrass-build/artifacts/$COMPONENT_NAME/$VERSION/
 cp src/backend/triggers/outputs/dio.py ./custom-build/$COMPONENT_NAME/
 cp -r src/host_scripts ./custom-build/$COMPONENT_NAME/
 
-# zip up archive
-zip -r -X ./custom-build/$COMPONENT_NAME-$ARCHITECTURE.zip ./custom-build/$COMPONENT_NAME
+# Package as separate artifacts to stay under 2GB Greengrass limit
+# Artifact 1: backend Docker image (large)
+echo "Creating backend artifact..."
+zip -r -X ./greengrass-build/artifacts/$COMPONENT_NAME/$VERSION/$COMPONENT_NAME-backend-$ARCHITECTURE.zip \
+    ./custom-build/$COMPONENT_NAME/flask-app.tar
 
-# dev test, create temp zip file for supported architecture not in development
-for arch in "aarch64" "x86_64"; do
-  touch $COMPONENT_NAME-$arch.zip
-  mv $COMPONENT_NAME-$arch.zip ./greengrass-build/artifacts/$COMPONENT_NAME/$VERSION/
+# Artifact 2: frontend image + scripts + compose (small)
+echo "Creating frontend+scripts artifact..."
+zip -r -X ./greengrass-build/artifacts/$COMPONENT_NAME/$VERSION/$COMPONENT_NAME-app-$ARCHITECTURE.zip \
+    ./custom-build/$COMPONENT_NAME/react-webapp.tar.gz \
+    ./custom-build/$COMPONENT_NAME/docker-compose.yaml \
+    ./custom-build/$COMPONENT_NAME/host_scripts \
+    ./custom-build/$COMPONENT_NAME/dio.py \
+    ./custom-build/$COMPONENT_NAME/backend \
+    ./custom-build/$COMPONENT_NAME/frontend
+
+echo "Artifact sizes:"
+ls -lh ./greengrass-build/artifacts/$COMPONENT_NAME/$VERSION/*.zip
+
+# Check if any artifact exceeds 2GB
+for zipfile in ./greengrass-build/artifacts/$COMPONENT_NAME/$VERSION/*.zip; do
+    SIZE=$(stat --format=%s "$zipfile")
+    if [ "$SIZE" -gt 2147483648 ]; then
+        echo "NOTE: $zipfile is $(numfmt --to=iec $SIZE) - exceeds 2GB Greengrass artifact limit."
+        echo "The publish script will use ECR-based deployment instead."
+    fi
 done
-
-# copy archive to greengrass-build
-cp ./custom-build/$COMPONENT_NAME-$ARCHITECTURE.zip ./greengrass-build/artifacts/$COMPONENT_NAME/$VERSION/

--- a/gdk-component-build-and-publish.sh
+++ b/gdk-component-build-and-publish.sh
@@ -1,16 +1,92 @@
 #!/bin/bash
 set -e
 
-# Get architecture and determine recipe file
-ARCH=$(uname -m)
-case $ARCH in
+# ── Pre-flight: verify AWS credentials ────────────────────────────────────
+echo "Checking AWS credentials..."
+CALLER_IDENTITY=$(aws sts get-caller-identity 2>&1) || {
+    echo ""
+    echo "ERROR: AWS credentials not configured or expired."
+    echo ""
+    echo "Please configure credentials before building:"
+    echo "  aws configure                    # for long-term credentials"
+    echo "  aws sso login --profile <name>   # for SSO"
+    echo "  export AWS_PROFILE=<name>        # to select a profile"
+    echo ""
+    echo "The build requires valid credentials to publish the Greengrass component."
+    exit 1
+}
+
+AWS_ACCOUNT_ID=$(echo "$CALLER_IDENTITY" | python3 -c "import sys,json; print(json.load(sys.stdin)['Account'])")
+AWS_ARN=$(echo "$CALLER_IDENTITY" | python3 -c "import sys,json; print(json.load(sys.stdin)['Arn'])")
+AWS_REGION=$(aws configure get region 2>/dev/null || echo "${AWS_DEFAULT_REGION:-}")
+
+if [ -z "$AWS_REGION" ]; then
+    echo ""
+    echo "ERROR: No AWS region configured."
+    echo ""
+    echo "Set a region before building:"
+    echo "  aws configure set region us-east-2"
+    echo "  export AWS_DEFAULT_REGION=us-east-2"
+    exit 1
+fi
+
+export AWS_REGION
+export AWS_DEFAULT_REGION="$AWS_REGION"
+
+echo "  Account: $AWS_ACCOUNT_ID"
+echo "  Role/User: $AWS_ARN"
+echo "  Region: $AWS_REGION"
+echo ""
+
+# Usage: ./gdk-component-build-and-publish.sh [ARCH] [JETPACK]
+# ARCH: x86_64 or aarch64 (default: auto-detect from host)
+# JETPACK: 4 or 5 (required for aarch64 builds)
+#
+# Supported configurations:
+#   x86_64              -> aws.edgeml.dda.LocalServer.amd64      (Ubuntu 20.04)
+#   aarch64 + JP4       -> aws.edgeml.dda.LocalServer.arm64      (Ubuntu 18.04, L4T r32.x)
+#   aarch64 + JP5       -> aws.edgeml.dda.LocalServer.arm64JP5   (Ubuntu 20.04, L4T r35.x)
+#
+# Examples:
+#   ./gdk-component-build-and-publish.sh                  # x86_64 (auto-detect)
+#   ./gdk-component-build-and-publish.sh aarch64 4        # ARM64 JetPack 4.6
+#   ./gdk-component-build-and-publish.sh aarch64 5        # ARM64 JetPack 5
+
+# Get architecture
+ARCH="${1:-$(arch)}"
+echo "Architecture: $ARCH"
+
+# Determine JetPack version for aarch64
+if [ "$ARCH" = "aarch64" ]; then
+    if [ -z "$2" ]; then
+        echo "ERROR: JetPack version is required for aarch64 builds."
+        echo "Usage: $0 aarch64 <4|5>"
+        echo "  4 = JetPack 4.6 (Ubuntu 18.04, L4T r32.x)"
+        echo "  5 = JetPack 5   (Ubuntu 20.04, L4T r35.x)"
+        exit 1
+    fi
+    JETPACK="$2"
+    if [ "$JETPACK" != "4" ] && [ "$JETPACK" != "5" ]; then
+        echo "ERROR: JETPACK must be 4 or 5, got: $JETPACK"
+        exit 1
+    fi
+    echo "JetPack version: $JETPACK"
+fi
+
+# Determine recipe file and component name
+case "$ARCH" in
     x86_64)
         RECIPE_FILE="recipe-amd64.yaml"
         COMPONENT_NAME="aws.edgeml.dda.LocalServer.amd64"
         ;;
     aarch64)
-        RECIPE_FILE="recipe-arm64.yaml"
-        COMPONENT_NAME="aws.edgeml.dda.LocalServer.arm64"
+        if [ "$JETPACK" = "5" ]; then
+            RECIPE_FILE="recipe-arm64-jp5.yaml"
+            COMPONENT_NAME="aws.edgeml.dda.LocalServer.arm64JP5"
+        else
+            RECIPE_FILE="recipe-arm64.yaml"
+            COMPONENT_NAME="aws.edgeml.dda.LocalServer.arm64"
+        fi
         ;;
     *)
         echo "Unsupported architecture: $ARCH"
@@ -21,7 +97,6 @@ esac
 echo "Building component for architecture: $ARCH"
 echo "Component name: $COMPONENT_NAME"
 echo "Using recipe: $RECIPE_FILE"
-
 
 # Use architecture-specific recipe
 cp $RECIPE_FILE recipe.yaml
@@ -39,12 +114,13 @@ cat > gdk-config.json << EOF
           "bash",
           "build-custom.sh",
           "${COMPONENT_NAME}",
-          "NEXT_PATCH"
+          "NEXT_PATCH",
+          "${ARCH}"
         ]
       },
       "publish": {
-        "bucket": "dda-component",
-        "region": "us-east-1"
+        "bucket": "dda-component-${AWS_REGION}-${AWS_ACCOUNT_ID}",
+        "region": "${AWS_REGION}"
       }
     }
   },
@@ -56,12 +132,157 @@ EOF
 rm -rf greengrass-build/
 rm -rf .gdk/
 
-# Build and publish component
+# Build component
 echo "Building component..."
 gdk component build
 
-echo "Publishing component..."
-gdk component publish
+# Check total artifact size
+TOTAL_SIZE=0
+for artifact in greengrass-build/artifacts/$COMPONENT_NAME/NEXT_PATCH/*.zip; do
+    if [ -s "$artifact" ]; then
+        SIZE=$(stat --format=%s "$artifact")
+        TOTAL_SIZE=$((TOTAL_SIZE + SIZE))
+    fi
+done
+echo "Total artifact size: $(numfmt --to=iec $TOTAL_SIZE)"
 
+if [ "$TOTAL_SIZE" -gt 2147483648 ]; then
+    echo ""
+    echo "WARNING: Total artifacts exceed Greengrass 2GB limit ($(numfmt --to=iec $TOTAL_SIZE))."
+    echo "Using ECR for Docker images + S3 for scripts/config."
+    echo ""
 
-echo "Component ${COMPONENT_NAME} built and published successfully!"
+    # Push Docker images to ECR instead
+    REGION="$AWS_REGION"
+    ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+    ECR_REPO_BACKEND="${ECR_REGISTRY}/dda/flask-app"
+    ECR_REPO_FRONTEND="${ECR_REGISTRY}/dda/react-webapp"
+
+    # Login to ECR
+    aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ECR_REGISTRY
+
+    # Create repos if they don't exist
+    aws ecr describe-repositories --repository-names dda/flask-app --region $REGION 2>/dev/null || \
+        aws ecr create-repository --repository-name dda/flask-app --region $REGION
+    aws ecr describe-repositories --repository-names dda/react-webapp --region $REGION 2>/dev/null || \
+        aws ecr create-repository --repository-name dda/react-webapp --region $REGION
+
+    # Determine version tag
+    LATEST_VERSION=$(aws greengrassv2 list-component-versions \
+        --arn "arn:aws:greengrass:${REGION}:${AWS_ACCOUNT_ID}:components:${COMPONENT_NAME}" \
+        --query 'componentVersions[0].componentVersion' --output text 2>/dev/null || echo "0.0.0")
+    if [ "$LATEST_VERSION" = "None" ] || [ "$LATEST_VERSION" = "0.0.0" ]; then
+        COMPONENT_VERSION="1.0.0"
+    else
+        MAJOR=$(echo $LATEST_VERSION | cut -d. -f1)
+        MINOR=$(echo $LATEST_VERSION | cut -d. -f2)
+        PATCH=$(echo $LATEST_VERSION | cut -d. -f3)
+        COMPONENT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+    fi
+    echo "Component version: $COMPONENT_VERSION"
+
+    # Tag and push images
+    echo "Pushing flask-app to ECR..."
+    docker tag flask-app:latest "${ECR_REPO_BACKEND}:${COMPONENT_VERSION}"
+    docker push "${ECR_REPO_BACKEND}:${COMPONENT_VERSION}"
+
+    echo "Pushing react-webapp to ECR..."
+    docker tag react-webapp:latest "${ECR_REPO_FRONTEND}:${COMPONENT_VERSION}"
+    docker push "${ECR_REPO_FRONTEND}:${COMPONENT_VERSION}"
+
+    # Upload the small app artifact (scripts + docker-compose) to S3
+    # Remove the large backend zip, keep only the app zip
+    BUCKET="dda-component-${REGION}-${AWS_ACCOUNT_ID}"
+    APP_ARTIFACT="${COMPONENT_NAME}-app-$(arch).zip"
+    APP_ZIP="greengrass-build/artifacts/${COMPONENT_NAME}/NEXT_PATCH/${APP_ARTIFACT}"
+    S3_KEY="${COMPONENT_NAME}/${COMPONENT_VERSION}/${APP_ARTIFACT}"
+
+    if [ -f "$APP_ZIP" ] && [ -s "$APP_ZIP" ]; then
+        echo "Uploading app artifact to S3 ($(numfmt --to=iec $(stat --format=%s "$APP_ZIP")))..."
+        aws s3 cp "$APP_ZIP" "s3://${BUCKET}/${S3_KEY}" --region "$REGION"
+    else
+        echo "ERROR: App artifact not found at $APP_ZIP"
+        exit 1
+    fi
+
+    # Update recipe: ECR for docker pull in Install, keep S3 artifact for scripts
+    RECIPE_FILE="greengrass-build/recipes/recipe.yaml"
+    S3_ARTIFACT_URI="s3://${BUCKET}/${S3_KEY}"
+
+    python3 - "$RECIPE_FILE" "$ECR_REPO_BACKEND" "$ECR_REPO_FRONTEND" "$COMPONENT_VERSION" "$REGION" "$AWS_ACCOUNT_ID" "$S3_ARTIFACT_URI" "$APP_ARTIFACT" << 'PYEOF'
+import sys, yaml
+
+recipe_file = sys.argv[1]
+ecr_backend = sys.argv[2]
+ecr_frontend = sys.argv[3]
+version = sys.argv[4]
+region = sys.argv[5]
+account_id = sys.argv[6]
+s3_artifact_uri = sys.argv[7]
+app_artifact_name = sys.argv[8]
+
+with open(recipe_file) as f:
+    recipe = yaml.safe_load(f)
+
+recipe['ComponentVersion'] = version
+
+ecr_registry = f"{account_id}.dkr.ecr.{region}.amazonaws.com"
+
+# Add DockerApplicationManager and TokenExchangeService as dependencies
+# These handle ECR authentication automatically
+if 'ComponentDependencies' not in recipe:
+    recipe['ComponentDependencies'] = {}
+recipe['ComponentDependencies']['aws.greengrass.DockerApplicationManager'] = {
+    'VersionRequirement': '~2.0.0'
+}
+recipe['ComponentDependencies']['aws.greengrass.TokenExchangeService'] = {
+    'VersionRequirement': '~2.0.0'
+}
+
+# Derive the artifact decompressed path prefix from the app artifact name
+# e.g. aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64
+app_artifact_base = app_artifact_name.replace('.zip', '')
+
+# Update lifecycle and artifacts
+for manifest in recipe.get('Manifests', []):
+    lifecycle = manifest.get('Lifecycle', {})
+
+    # Install: tag the ECR images as local names, clean dangling images
+    lifecycle['Install'] = {
+        'RequiresPrivilege': True,
+        'Script': (
+            f'docker images --quiet --filter=dangling=true | xargs --no-run-if-empty docker rmi -f ; '
+            f'docker tag {ecr_backend}:{version} flask-app:latest ; '
+            f'docker tag {ecr_frontend}:{version} react-webapp:latest'
+        )
+    }
+
+    # Artifacts: docker: URIs for ECR images + S3 URI for scripts/compose
+    manifest['Artifacts'] = [
+        {'URI': f'docker:{ecr_backend}:{version}'},
+        {'URI': f'docker:{ecr_frontend}:{version}'},
+        {'URI': s3_artifact_uri, 'Unarchive': 'ZIP'}
+    ]
+
+with open(recipe_file, 'w') as f:
+    yaml.dump(recipe, f, default_flow_style=False, sort_keys=False)
+
+print(f"Updated recipe: docker: artifacts + S3 app artifact")
+print(f"  Docker: {ecr_backend}:{version}")
+print(f"  Docker: {ecr_frontend}:{version}")
+print(f"  S3:     {s3_artifact_uri}")
+PYEOF
+
+    # Create component version via API
+    echo "Creating component version in Greengrass..."
+    aws greengrassv2 create-component-version \
+        --inline-recipe fileb://"$RECIPE_FILE" \
+        --region "$REGION"
+
+    echo "Component ${COMPONENT_NAME} v${COMPONENT_VERSION} published successfully (ECR + S3)!"
+else
+    # Under 2GB - use standard GDK publish
+    echo "Publishing component via GDK..."
+    gdk component publish
+    echo "Component ${COMPONENT_NAME} built and published successfully!"
+fi

--- a/gdk-config.json
+++ b/gdk-config.json
@@ -1,6 +1,6 @@
 {
   "component": {
-    "aws.edgeml.dda.LocalServer.arm64": {
+    "aws.edgeml.dda.LocalServer.arm64JP5": {
       "author": "Amazon",
       "version": "NEXT_PATCH",
       "build": {
@@ -8,13 +8,14 @@
         "custom_build_command": [
           "bash",
           "build-custom.sh",
-          "aws.edgeml.dda.LocalServer.arm64",
-          "NEXT_PATCH"
+          "aws.edgeml.dda.LocalServer.arm64JP5",
+          "NEXT_PATCH",
+          "aarch64"
         ]
       },
       "publish": {
-        "bucket": "dda-component",
-        "region": "us-east-1"
+        "bucket": "dda-component-us-east-2-948285518686",
+        "region": "us-east-2"
       }
     }
   },

--- a/recipe-arm64-jp5.yaml
+++ b/recipe-arm64-jp5.yaml
@@ -1,8 +1,8 @@
 ---
 RecipeFormatVersion: "2020-01-25"
-ComponentName: "aws.edgeml.dda.LocalServer.amd64"
+ComponentName: "aws.edgeml.dda.LocalServer.arm64JP5"
 ComponentVersion: "1.0.0"
-ComponentDescription: DDA Local Web Server App - AMD64
+ComponentDescription: DDA Local Web Server App - ARM64 JetPack 5
 ComponentPublisher: Amazon
 ComponentDependencies:
   aws.greengrass.Nucleus:
@@ -13,9 +13,11 @@ ComponentConfiguration:
   DefaultConfiguration:
     StreamShadowName: "streamConfigurationShadow"
     AppRunnerShadowName: "appRunnerShadow"
+    StationName: "DDA_Station_ARM64_JP5"
+    ComponentName: "aws.edgeml.dda.LocalServer.arm64JP5"
     accessControl:
       aws.greengrass.ShadowManager:
-        'aws.edgeml.dda.LocalServer.amd64:shadow:1':
+        'aws.edgeml.dda.LocalServer.arm64JP5:shadow:1':
           policyDescription: 'Allows access to shadows'
           operations:
             - 'aws.greengrass#GetThingShadow'
@@ -23,14 +25,14 @@ ComponentConfiguration:
           resources:
             - $aws/things/*/shadow
             - $aws/things/*/shadow/name/*
-        'aws.edgeml.dda.LocalServer.amd64:shadow:2':
+        'aws.edgeml.dda.LocalServer.arm64JP5:shadow:2':
           policyDescription: 'Allows access to things with shadows'
           operations:
             - 'aws.greengrass#ListNamedShadowsForThing'
           resources:
             - '*'
       aws.greengrass.ipc.mqttproxy:
-        'aws.edgeml.dda.LocalServer.amd64:mqttproxy:1':
+        'aws.edgeml.dda.LocalServer.arm64JP5:mqttproxy:1':
           policyDescription: Allows access to shadow pubsub topics
           operations:
             - "aws.greengrass#SubscribeToIoTCore"
@@ -38,7 +40,7 @@ ComponentConfiguration:
           resources:
             - $aws/things/*/shadow/name/*
       aws.greengrass.Cli:
-        'aws.edgeml.dda.LocalServer.amd64:cli:1':
+        'aws.edgeml.dda.LocalServer.arm64JP5:cli:1':
           policyDescription: 'Allows access to restart and stop DDA greengrass components'
           operations:
             - 'aws.greengrass#RestartComponent'
@@ -46,7 +48,7 @@ ComponentConfiguration:
           resources:
             - 'aws.edgeml.dda.*'
             - 'model*'
-        'aws.edgeml.dda.LocalServer.amd64:cli:2':
+        'aws.edgeml.dda.LocalServer.arm64JP5:cli:2':
           policyDescription: 'Allows access to list and get details for greengrass components on device'
           operations:
             - 'aws.greengrass#ListComponents'
@@ -56,14 +58,14 @@ ComponentConfiguration:
 Manifests:
   - Platform:
       os: linux
-      architecture: amd64
+      architecture: aarch64
     Lifecycle:
       Install:
         RequiresPrivilege: true
         Script: |
           docker images --quiet --filter=dangling=true | xargs --no-run-if-empty docker rmi -f ;
-          BACKEND_DIR="{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-backend-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64" ;
-          APP_DIR="{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-app-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64" ;
+          BACKEND_DIR="{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-backend-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5" ;
+          APP_DIR="{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5" ;
           docker load -i $BACKEND_DIR/flask-app.tar ;
           docker load -i $APP_DIR/react-webapp.tar.gz
       Run:
@@ -72,19 +74,19 @@ Manifests:
           COMPONENT_WORK_PATH: "{work:path}"
           KERNEL_ROOT_PATH: "{kernel:rootPath}"
           INFERENCE_COMPONENT_DECOMPRESED_PATH: "{aws.edgeml.dda.InferenceApp:artifacts:decompressedPath}"
-          LOCAL_SERVER_COMPONENT_DECOMPRESSED_PATH: "{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-app-x86_64"
+          LOCAL_SERVER_COMPONENT_DECOMPRESSED_PATH: "{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64"
         Script: |
-          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-app-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64/host_scripts/setup_dda_users.sh ;
-          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-app-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64/host_scripts/get_nvidia_libs_versions.sh;
-          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-app-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64/host_scripts/setup_paths.sh;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/setup_dda_users.sh ;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/get_nvidia_libs_versions.sh;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/setup_paths.sh;
           export $(grep -v '^#' /tmp/.dda.env | xargs) ;
-          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-app-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64/docker-compose.yaml up --no-build ;
+          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/docker-compose.yaml up --no-build ;
       Shutdown:
         RequiresPrivilege: true
         Script: |
-          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-app-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64/docker-compose.yaml down
+          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/docker-compose.yaml down
     Artifacts:
-      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/aws.edgeml.dda.LocalServer.amd64-backend-x86_64.zip
+      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/aws.edgeml.dda.LocalServer.arm64JP5-backend-aarch64.zip
         Unarchive: ZIP
-      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/aws.edgeml.dda.LocalServer.amd64-app-x86_64.zip
+      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64.zip
         Unarchive: ZIP

--- a/recipe-arm64.yaml
+++ b/recipe-arm64.yaml
@@ -63,24 +63,30 @@ Manifests:
       Install:
         RequiresPrivilege: true
         Script: |
-          docker images --quiet --filter=dangling=true | xargs --no-run-if-empty docker rmi -f && docker load -i {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/flask-app.tar && docker load -i {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/react-webapp.tar
+          docker images --quiet --filter=dangling=true | xargs --no-run-if-empty docker rmi -f ;
+          BACKEND_DIR="{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-backend-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64" ;
+          APP_DIR="{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64" ;
+          docker load -i $BACKEND_DIR/flask-app.tar ;
+          docker load -i $APP_DIR/react-webapp.tar.gz
       Run:
         RequiresPrivilege: true
         SetEnv:
           COMPONENT_WORK_PATH: "{work:path}"
           KERNEL_ROOT_PATH: "{kernel:rootPath}"
           INFERENCE_COMPONENT_DECOMPRESED_PATH: "{aws.edgeml.dda.InferenceApp:artifacts:decompressedPath}"
-          LOCAL_SERVER_COMPONENT_DECOMPRESSED_PATH: "{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-aarch64"          
+          LOCAL_SERVER_COMPONENT_DECOMPRESSED_PATH: "{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-app-aarch64"
         Script: |
-          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/host_scripts/setup_dda_users.sh ;
-          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/host_scripts/get_nvidia_libs_versions.sh;
-          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/host_scripts/setup_paths.sh;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/host_scripts/setup_dda_users.sh ;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/host_scripts/get_nvidia_libs_versions.sh;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/host_scripts/setup_paths.sh;
           export $(grep -v '^#' /tmp/.dda.env | xargs) ;
-          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/docker-compose.yaml up --no-build ;
+          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/docker-compose.yaml up --no-build ;
       Shutdown:
         RequiresPrivilege: true
         Script: |
-          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/docker-compose.yaml down
+          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/docker-compose.yaml down
     Artifacts:
-      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/aws.edgeml.dda.LocalServer.arm64-aarch64.zip
+      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/aws.edgeml.dda.LocalServer.arm64-backend-aarch64.zip
+        Unarchive: ZIP
+      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/aws.edgeml.dda.LocalServer.arm64-app-aarch64.zip
         Unarchive: ZIP

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,8 +1,8 @@
 ---
 RecipeFormatVersion: "2020-01-25"
-ComponentName: "aws.edgeml.dda.LocalServer.amd64"
+ComponentName: "aws.edgeml.dda.LocalServer.arm64JP5"
 ComponentVersion: "1.0.0"
-ComponentDescription: DDA Local Web Server App - AMD64
+ComponentDescription: DDA Local Web Server App - ARM64 JetPack 5
 ComponentPublisher: Amazon
 ComponentDependencies:
   aws.greengrass.Nucleus:
@@ -13,9 +13,11 @@ ComponentConfiguration:
   DefaultConfiguration:
     StreamShadowName: "streamConfigurationShadow"
     AppRunnerShadowName: "appRunnerShadow"
+    StationName: "DDA_Station_ARM64_JP5"
+    ComponentName: "aws.edgeml.dda.LocalServer.arm64JP5"
     accessControl:
       aws.greengrass.ShadowManager:
-        'aws.edgeml.dda.LocalServer.amd64:shadow:1':
+        'aws.edgeml.dda.LocalServer.arm64JP5:shadow:1':
           policyDescription: 'Allows access to shadows'
           operations:
             - 'aws.greengrass#GetThingShadow'
@@ -23,14 +25,14 @@ ComponentConfiguration:
           resources:
             - $aws/things/*/shadow
             - $aws/things/*/shadow/name/*
-        'aws.edgeml.dda.LocalServer.amd64:shadow:2':
+        'aws.edgeml.dda.LocalServer.arm64JP5:shadow:2':
           policyDescription: 'Allows access to things with shadows'
           operations:
             - 'aws.greengrass#ListNamedShadowsForThing'
           resources:
             - '*'
       aws.greengrass.ipc.mqttproxy:
-        'aws.edgeml.dda.LocalServer.amd64:mqttproxy:1':
+        'aws.edgeml.dda.LocalServer.arm64JP5:mqttproxy:1':
           policyDescription: Allows access to shadow pubsub topics
           operations:
             - "aws.greengrass#SubscribeToIoTCore"
@@ -38,7 +40,7 @@ ComponentConfiguration:
           resources:
             - $aws/things/*/shadow/name/*
       aws.greengrass.Cli:
-        'aws.edgeml.dda.LocalServer.amd64:cli:1':
+        'aws.edgeml.dda.LocalServer.arm64JP5:cli:1':
           policyDescription: 'Allows access to restart and stop DDA greengrass components'
           operations:
             - 'aws.greengrass#RestartComponent'
@@ -46,7 +48,7 @@ ComponentConfiguration:
           resources:
             - 'aws.edgeml.dda.*'
             - 'model*'
-        'aws.edgeml.dda.LocalServer.amd64:cli:2':
+        'aws.edgeml.dda.LocalServer.arm64JP5:cli:2':
           policyDescription: 'Allows access to list and get details for greengrass components on device'
           operations:
             - 'aws.greengrass#ListComponents'
@@ -56,14 +58,14 @@ ComponentConfiguration:
 Manifests:
   - Platform:
       os: linux
-      architecture: amd64
+      architecture: aarch64
     Lifecycle:
       Install:
         RequiresPrivilege: true
         Script: |
           docker images --quiet --filter=dangling=true | xargs --no-run-if-empty docker rmi -f ;
-          BACKEND_DIR="{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-backend-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64" ;
-          APP_DIR="{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-app-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64" ;
+          BACKEND_DIR="{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-backend-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5" ;
+          APP_DIR="{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5" ;
           docker load -i $BACKEND_DIR/flask-app.tar ;
           docker load -i $APP_DIR/react-webapp.tar.gz
       Run:
@@ -72,19 +74,19 @@ Manifests:
           COMPONENT_WORK_PATH: "{work:path}"
           KERNEL_ROOT_PATH: "{kernel:rootPath}"
           INFERENCE_COMPONENT_DECOMPRESED_PATH: "{aws.edgeml.dda.InferenceApp:artifacts:decompressedPath}"
-          LOCAL_SERVER_COMPONENT_DECOMPRESSED_PATH: "{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-app-x86_64"
+          LOCAL_SERVER_COMPONENT_DECOMPRESSED_PATH: "{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64"
         Script: |
-          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-app-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64/host_scripts/setup_dda_users.sh ;
-          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-app-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64/host_scripts/get_nvidia_libs_versions.sh;
-          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-app-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64/host_scripts/setup_paths.sh;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/setup_dda_users.sh ;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/get_nvidia_libs_versions.sh;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/setup_paths.sh;
           export $(grep -v '^#' /tmp/.dda.env | xargs) ;
-          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-app-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64/docker-compose.yaml up --no-build ;
+          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/docker-compose.yaml up --no-build ;
       Shutdown:
         RequiresPrivilege: true
         Script: |
-          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-app-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64/docker-compose.yaml down
+          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/docker-compose.yaml down
     Artifacts:
-      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/aws.edgeml.dda.LocalServer.amd64-backend-x86_64.zip
+      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/aws.edgeml.dda.LocalServer.arm64JP5-backend-aarch64.zip
         Unarchive: ZIP
-      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/aws.edgeml.dda.LocalServer.amd64-app-x86_64.zip
+      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64.zip
         Unarchive: ZIP

--- a/setup-build-server.sh
+++ b/setup-build-server.sh
@@ -52,12 +52,13 @@ fi
 echo "Installing Pip"
 sudo apt-get install python3-pip -y
 python3.9 -m pip install --upgrade pip
-python3.9 -m pip install --force-reinstall requests==2.32.3
-python3.9 -m pip install protobuf
+python3.9 -m pip install --no-compile --force-reinstall requests==2.32.3
+python3.9 -m pip install --no-compile protobuf
+python3.9 -m pip install --no-compile "botocore[crt]"
 
 
 # Install AWS CLI v2 and GDK
-python3.9 -m pip install git+https://github.com/aws-greengrass/aws-greengrass-gdk-cli.git
+python3.9 -m pip install --no-compile git+https://github.com/aws-greengrass/aws-greengrass-gdk-cli.git
 sudo snap install aws-cli --classic
 # Add ~/.local/bin to PATH for GDK
 if ! grep -q 'export PATH="$HOME/.local/bin:$PATH"' ~/.bashrc; then

--- a/src/backend/Dockerfile.jp5
+++ b/src/backend/Dockerfile.jp5
@@ -1,0 +1,129 @@
+ARG OS
+ARG PLATFORM
+FROM nvcr.io/nvidia/l4t-jetpack:r35.4.1
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Disable py3compile during apt installs to prevent segfaults in l4t-jetpack base image
+RUN if [ -f /usr/bin/py3compile ]; then mv /usr/bin/py3compile /usr/bin/py3compile.bak && \
+    echo '#!/bin/sh' > /usr/bin/py3compile && chmod +x /usr/bin/py3compile; fi && \
+    if [ -f /usr/bin/py3clean ]; then mv /usr/bin/py3clean /usr/bin/py3clean.bak && \
+    echo '#!/bin/sh' > /usr/bin/py3clean && chmod +x /usr/bin/py3clean; fi
+
+RUN apt-get update && \
+    dpkg --configure -a || true && \
+    apt-get install -f -y || true && \
+    dpkg --purge --force-depends python3-distro-info unattended-upgrades python3-urllib3 python3-requests python3-requests-unixsocket python3-six software-properties-common python3-software-properties || true && \
+    apt-get install -y --no-install-recommends wget build-essential libffi-dev zlib1g-dev libssl-dev libsqlite3-dev gdb python3.9 python3.9-dev
+
+RUN apt-get update
+
+# Add toolchain PPA directly to avoid add-apt-repository Python issues
+RUN echo "deb https://ppa.launchpadcontent.net/ubuntu-toolchain-r/test/ubuntu focal main" > /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F && \
+    apt-get update && \
+    apt install gcc-11 g++-11 -y && \
+    rm /usr/bin/gcc && \
+    rm /usr/bin/g++ && \
+    ln -s /usr/bin/gcc-11 /usr/bin/gcc && \
+    ln -s /usr/bin/g++-11 /usr/bin/g++
+
+RUN apt-get install --only-upgrade ncurses-base
+RUN apt-get install --only-upgrade ncurses-bin
+RUN apt-get update && apt-get install -y libb64-0d && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt ./
+
+COPY edge_ml1_p_camera_management ./edge_ml1_p_camera_management
+COPY edgeagent ./edgeagent
+
+# Run apt installs from prereqs while python3 is still 3.8 (avoids py3compile segfault)
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+    pkgconf libcairo2-dev libgirepository1.0-dev libgl1-mesa-glx libsm6 libxext6
+
+# Install aravis apt dependencies before switching python3 (avoids py3compile segfault)
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends wget build-essential ninja-build \
+    gstreamer1.0-plugins-bad libxml2-dev libglib2.0-dev libusb-1.0-0-dev gobject-introspection \
+    libgtk-3-dev gtk-doc-tools xsltproc libgstreamer1.0-dev \
+    libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-good \
+    libgirepository1.0-dev gettext pkg-config libcairo2-dev
+
+# Install remaining apt packages before switching python3
+RUN apt update -y && \
+    apt-get install -y libssl1.1 libexif12 libcurl4 libarchive13 \
+    gstreamer1.0-tools gstreamer1.0-libav ffmpeg
+
+# CVE fixes - also before python3 switch
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    libgnutls28-dev libuv1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Restore py3compile/py3clean now that all apt installs are done
+RUN if [ -f /usr/bin/py3compile.bak ]; then mv /usr/bin/py3compile.bak /usr/bin/py3compile; fi && \
+    if [ -f /usr/bin/py3clean.bak ]; then mv /usr/bin/py3clean.bak /usr/bin/py3clean; fi
+
+# NOW switch python3 to 3.9 — all apt installs are done, no more py3compile under 3.9
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1 \
+    && update-alternatives --set python3 /usr/bin/python3.9
+RUN wget -q https://bootstrap.pypa.io/pip/3.9/get-pip.py && python3 get-pip.py && rm get-pip.py
+
+# Install pip packages (native build, no QEMU workarounds needed)
+RUN pip install --no-cache-dir pycairo==1.23.0
+RUN pip install --no-cache-dir --no-build-isolation PyGObject==3.42.2
+RUN pip install --no-cache-dir psutil==5.9.5
+RUN pip install --no-cache-dir -r ./requirements.txt
+RUN pip install --no-cache-dir --upgrade requests
+
+# Build aravis from source (apt deps already installed above)
+RUN pip install --no-cache-dir meson ninja
+# Downgrade setuptools so g-ir-scanner can find distutils.msvccompiler (removed in setuptools>=71)
+RUN pip install --no-cache-dir 'setuptools<71'
+# Fix g-ir-scanner to use python3.8 (its _giscanner C extension is built for 3.8)
+RUN cp /usr/bin/g-ir-scanner /usr/bin/g-ir-scanner.bak && \
+    echo '#!/usr/bin/python3.8' > /usr/bin/g-ir-scanner && \
+    tail -n +2 /usr/bin/g-ir-scanner.bak >> /usr/bin/g-ir-scanner && \
+    chmod +x /usr/bin/g-ir-scanner && \
+    head -1 /usr/bin/g-ir-scanner
+RUN ./edge_ml1_p_camera_management/install_aravis.sh
+# Restore latest setuptools after aravis build
+RUN pip install --no-cache-dir --upgrade setuptools
+RUN python3.9 -m grpc_tools.protoc --proto_path=./edgeagent --python_out=. --grpc_python_out=. edgeagent/edge-agent.proto
+
+RUN find / -name "libpython3.9.so.1.0" -print
+
+RUN apt clean -y
+
+COPY app.py ./
+COPY logging.conf ./
+COPY dao ./dao
+COPY utils ./utils
+COPY metrics ./metrics
+COPY model ./model
+COPY mqtt ./mqtt
+COPY resources ./resources
+COPY gstreamer ./gstreamer
+COPY triggers ./triggers
+COPY exceptions ./exceptions
+COPY snapshot ./snapshot
+COPY defect_detection_config ./defect_detection_config
+COPY dda_logging ./dda_logging
+COPY endpoints ./endpoints
+COPY data_models ./data_models
+COPY alembic ./alembic
+COPY alembic.ini ./
+COPY dda_triton ./dda_triton
+COPY lyra_anomalies_mask_utils ./lyra_anomalies_mask_utils
+COPY lyra_science_processing_utils ./lyra_science_processing_utils
+CMD ["python3.9", "app.py"]
+
+## TODO: Remove copy edgemlsdk files here. Change to direct build in Docker
+# To test and build - Copy artifacts file to /src/backend/edgemlsdk
+COPY edgemlsdk ./edgemlsdk
+RUN ./edge_ml1_p_camera_management/install_edgemlsdk.sh
+COPY dlr_disable_phone_home.py ./
+RUN python3.9 dlr_disable_phone_home.py
+
+#TODO:change to user to scope the permission. Currently needed to persist the TinyDB data
+USER root

--- a/src/backend/edge_ml1_p_camera_management/install_aravis.sh
+++ b/src/backend/edge_ml1_p_camera_management/install_aravis.sh
@@ -22,12 +22,6 @@ set -e  # Exit on any error
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR
 
-# echo "Adding Debian repository..."
-# echo "deb http://archive.debian.org/debian buster-backports main" >> /etc/apt/sources.list || {
-#     echo "Failed to add repository"
-#     exit 1
-# }
-
 echo "Updating package lists..."
 apt-get update -y || {
     echo "Failed to update package lists"
@@ -35,13 +29,10 @@ apt-get update -y || {
 }
 
 echo "Installing wget and build tools..."
-apt-get install -y --no-install-recommends wget build-essential ninja-build meson || {
+apt-get install -y --no-install-recommends wget build-essential ninja-build || {
     echo "Failed to install build tools"
     exit 1
 }
-
-#echo "Cleaning up previous installation..."
-#rm -rf aravis-0.8.26 aravis-0.8.26.tar.xz
 
 echo "Downloading Aravis..."
 wget https://github.com/AravisProject/aravis/releases/download/0.8.26/aravis-0.8.26.tar.xz || {
@@ -74,7 +65,14 @@ cd aravis-0.8.26 || {
     exit 1
 }
 
-meson setup -Dprefix=/usr build || {
+# On aarch64 with l4t-jetpack base, remove static .a libraries that cause linker issues
+# (missing pthread/pcre symbols). Force meson to use shared .so libraries instead.
+ARCH=$(uname -m)
+if [ "$ARCH" = "aarch64" ]; then
+    rm -f /usr/lib/aarch64-linux-gnu/libglib-2.0.a /usr/lib/aarch64-linux-gnu/libcairo.a
+fi
+
+meson setup -Dprefix=/usr -Dviewer=disabled build || {
     echo "Failed to setup meson build"
     exit 1
 }

--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -2,8 +2,14 @@ version: "3.0"
 services:
   backend_tegra_gpu_enabled:
     network_mode: "host"
-    build: ./backend
+    build:
+      context: ./backend
+      dockerfile: ${BACKEND_DOCKERFILE:-Dockerfile}
+      args:
+        OS: ${OS:-20.04}
+        PLATFORM: ${PLATFORM:-aarch64}
     image: flask-app
+    platform: linux/arm64/v8
     privileged: true
     expose:
       - "5000"
@@ -47,7 +53,12 @@ services:
     profiles: [tegra]
   backend_generic:
     network_mode: "host"
-    build: ./backend
+    build:
+      context: ./backend
+      dockerfile: ${BACKEND_DOCKERFILE:-Dockerfile}
+      args:
+        OS: ${OS:-20.04}
+        PLATFORM: ${PLATFORM:-x86_64}
     image: flask-app
     privileged: true
     expose:

--- a/src/edgemlsdk/Dockerfile.jp5
+++ b/src/edgemlsdk/Dockerfile.jp5
@@ -1,0 +1,280 @@
+FROM nvcr.io/nvidia/l4t-jetpack:r35.4.1 AS builder
+ARG OS
+ARG PLATFORM
+ARG PWSH_ARCH
+ARG PYTHON_VERSION
+ENV DEBIAN_FRONTEND noninteractive
+
+# ── Build environment (native only, no QEMU) ──────────────────────────────
+RUN NCPU=$(nproc) && \
+    printf "JOBS=$NCPU\nMAKE_CMD=\"make -j$NCPU\"\nNINJA_CMD=\"ninja -j$NCPU\"\nB2_CMD=\"./b2 -j$NCPU\"\nTRITON_PARALLEL=$NCPU\n" > /tmp/build-env.sh && \
+    echo "=== Build environment ===" && cat /tmp/build-env.sh
+
+# ── 1. System packages ─────────────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential software-properties-common lsb-release git curl wget gpg unzip rsync \
+    clang \
+    libcurl4 libcurl4-openssl-dev libsqlite3-dev gnupg pkg-config libudev-dev libssl-dev \
+    libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev \
+    gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools gstreamer1.0-x \
+    gstreamer1.0-alsa gstreamer1.0-gl gstreamer1.0-gtk3 gstreamer1.0-qt5 \
+    libgstrtspserver-1.0-dev libgstreamer-plugins-good1.0-dev \
+    libgirepository1.0-dev gobject-introspection \
+    libxml2-dev libglib2.0-dev libusb-1.0-0-dev libgtk-3-dev libjpeg-dev \
+    gtk-doc-tools xsltproc gettext \
+    libcairo2 libcairo2-dev libexif-dev libarchive-dev libnuma-dev libb64-dev \
+    rapidjson-dev libre2-dev python-dev \
+    ninja-build checkinstall ffmpeg swig lcov \
+    libavcodec-dev libavformat-dev libavutil-dev libswscale-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LD_LIBRARY_PATH=/usr/local/lib/
+
+# ── 2. CMake 3.21.3 from Kitware ──────────────────────────────────────────
+RUN wget -O /etc/apt/trusted.gpg.d/kitware.asc https://apt.kitware.com/keys/kitware-archive-latest.asc && \
+    echo "deb https://apt.kitware.com/ubuntu/ focal main" > /etc/apt/sources.list.d/kitware.list && \
+    apt-get update && \
+    apt-get install -y cmake-data=3.21.3-0kitware1ubuntu20.04.1 cmake=3.21.3-0kitware1ubuntu20.04.1 && \
+    rm -f /etc/apt/sources.list.d/kitware.list /etc/apt/trusted.gpg.d/kitware.asc && \
+    rm -rf /var/lib/apt/lists/*
+
+# ── 3. Python 3.9 + pip tooling ───────────────────────────────────────────
+RUN rm -f /etc/apt/sources.list.d/*kitware* && \
+    sed -i '/kitware/d' /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y python${PYTHON_VERSION}-dev libpython${PYTHON_VERSION} \
+    python${PYTHON_VERSION} python${PYTHON_VERSION}-venv python3-pip && \
+    rm -rf /var/lib/apt/lists/* && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 && \
+    update-alternatives --set python3 /usr/bin/python${PYTHON_VERSION} && \
+    rm -f /usr/bin/python && ln -s /usr/bin/python3.9 /usr/bin/python && \
+    python${PYTHON_VERSION} -m pip install --user --upgrade pip && \
+    python${PYTHON_VERSION} -m pip install --upgrade build
+
+ENV PYTHON_EXECUTABLE=/usr/bin/python3.9
+ENV Python3_EXECUTABLE=/usr/bin/python3.9
+ENV Python3_INCLUDE_DIR=/usr/include/python3.9
+ENV Python3_LIBRARY=/usr/lib/libpython3.9.so
+
+# ── 4. Python packages ────────────────────────────────────────────────────
+RUN pip3 install --upgrade pip setuptools==64.0.3 wheel build hatchling packaging==24.2 && \
+    pip3 install --ignore-installed PyYAML && \
+    pip3 install conan && conan profile detect && \
+    pip3 install --upgrade pydantic setuptools==64.0.3 meson && \
+    pip3 install Cython boto3 awscrt multiprocess coverage pylint && \
+    pip3 install pygobject==3.44.1
+
+# ── 5. AWS CLI ─────────────────────────────────────────────────────────────
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-${PLATFORM}.zip" -o awscliv2.zip && \
+    unzip -q awscliv2.zip && ./aws/install && rm -rf awscliv2.zip aws/
+
+# ── 6. PowerShell ─────────────────────────────────────────────────────────
+RUN curl -L -o /tmp/powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v7.2.3/powershell-7.2.3-linux-$PWSH_ARCH.tar.gz && \
+    mkdir -p /opt/microsoft/powershell/7 && \
+    tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7 && \
+    chmod +x /opt/microsoft/powershell/7/pwsh && \
+    ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh && \
+    rm /tmp/powershell.tar.gz
+
+# ── 7. OpenSSL 3.x (cached or built from source) ──────────────────────────
+RUN mkdir -p /dependencies/debs
+COPY cached-debs/ /dependencies/cached-debs/
+RUN . /tmp/build-env.sh && \
+    if ls /dependencies/cached-debs/openssl*.deb 1>/dev/null 2>&1; then \
+        echo "=== Using cached OpenSSL deb ===" && \
+        cp /dependencies/cached-debs/openssl*.deb /dependencies/debs/ && \
+        dpkg -i /dependencies/debs/openssl*.deb; \
+    else \
+        echo "=== Building OpenSSL from source ===" && \
+        cd /dependencies && \
+        git clone --depth 1 -b openssl-3.3.0 https://github.com/openssl/openssl.git && \
+        cd openssl && \
+        ./Configure --prefix=/usr/local/ssl --openssldir=/usr/local/ssl \
+            shared zlib no-docs no-tests && \
+        $MAKE_CMD && \
+        test -f libssl.so || (echo "OpenSSL build failed" && exit 1) && \
+        checkinstall -y && \
+        mv /dependencies/openssl/openssl*.deb /dependencies/debs && \
+        rm -rf /dependencies/openssl; \
+    fi
+RUN rm -rf /usr/local/include/openssl
+
+# ── 8. aws-crt-cpp ────────────────────────────────────────────────────────
+COPY patches/aws-crt-cpp-s2n.diff /tmp/aws-crt-cpp-s2n.diff
+RUN . /tmp/build-env.sh && \
+    cd /dependencies && \
+    git clone https://github.com/awslabs/aws-crt-cpp.git && \
+    cd aws-crt-cpp && \
+    git checkout 6158ecefd0e0d53b2cf5e9d09f8c42f57e741e35 && \
+    git submodule update --init --recursive && \
+    cp /tmp/aws-crt-cpp-s2n.diff crt/s2n/aws-crt-cpp-s2n.diff && \
+    cd crt/s2n && git apply aws-crt-cpp-s2n.diff && \
+    mkdir /dependencies/aws-crt-cpp/build && \
+    cd /dependencies/aws-crt-cpp/build && \
+    cmake -GNinja -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/ \
+        -DCMAKE_INSTALL_PREFIX=/usr/ -DUSE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON ../ && \
+    $NINJA_CMD install
+
+# ── 9. aws-sdk-cpp ────────────────────────────────────────────────────────
+RUN . /tmp/build-env.sh && \
+    cd /dependencies && \
+    PLATFORM=$(uname -m) && \
+    git clone https://github.com/aws/aws-sdk-cpp && \
+    cd aws-sdk-cpp && \
+    git checkout c63eb9e5f059ae2595cae8c79732c6938ca36b7d && \
+    git submodule update --init --recursive && \
+    mkdir build && cd build && \
+    cmake -GNinja -DBUILD_TESTING=OFF \
+        -DCMAKE_MODULE_PATH=/usr/lib/$PLATFORM-linux-gnu/cmake \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/usr/ -DCMAKE_INSTALL_PREFIX=/usr/ \
+        -DBUILD_DEPS=OFF -DBUILD_ONLY="s3;sts;transfer;iot;iot-data;sagemaker-edge;secretsmanager" ../ && \
+    $NINJA_CMD install
+
+# ── 10. aws-c-iot ─────────────────────────────────────────────────────────
+RUN . /tmp/build-env.sh && \
+    cd /dependencies && \
+    git clone https://github.com/awslabs/aws-c-iot.git && \
+    cd aws-c-iot && \
+    git checkout 6e59b4660fecbc20c74493aee7da8a7b486b2966 && \
+    git submodule update --init --recursive && \
+    mkdir build && cd build && \
+    cmake -GNinja -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_PREFIX_PATH=/usr/ \
+        -DCMAKE_INSTALL_PREFIX=/usr/ -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_BUILD_TYPE="Release" -DBUILD_TESTING=OFF \
+        -DCMAKE_HAVE_THREADS_LIBRARY=1 -DCMAKE_USE_PTHREADS_INIT=1 -DTHREADS_PREFER_PTHREAD_FLAG=ON ../ && \
+    $NINJA_CMD install
+
+# ── 11. Aravis SDK ────────────────────────────────────────────────────────
+RUN . /tmp/build-env.sh && \
+    cd /dependencies && \
+    git clone https://github.com/AravisProject/aravis.git && \
+    cd aravis && \
+    git checkout 96cea9835ce1535547d8680c8b0be33e97f6cb30 && \
+    git submodule update --init --recursive && \
+    meson setup build -Dtests=false -Dintrospection=disabled && \
+    cd build && \
+    $NINJA_CMD && \
+    ninja install
+
+# ── 12. aws-iot-device-sdk-cpp-v2 ─────────────────────────────────────────
+RUN . /tmp/build-env.sh && \
+    cd /dependencies && \
+    PLATFORM=$(uname -m) && \
+    git clone https://github.com/aws/aws-iot-device-sdk-cpp-v2.git && \
+    cd aws-iot-device-sdk-cpp-v2 && \
+    git checkout f7cbf0982d2f23902406a0ba696a1a900b732a7e && \
+    git submodule update --init --recursive && \
+    mkdir build && cd build && \
+    cmake -GNinja -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -DCMAKE_MODULE_PATH=/usr/lib/$PLATFORM-linux-gnu/cmake \
+        -DCMAKE_INSTALL_PREFIX=/usr/ -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_DEPS=OFF -DCMAKE_BUILD_TYPE="Release" -DBUILD_TESTING=OFF ../ && \
+    $NINJA_CMD install
+
+# ── 13. Boost 1.81 ────────────────────────────────────────────────────────
+RUN . /tmp/build-env.sh && \
+    cd /dependencies && \
+    wget --no-check-certificate https://github.com/boostorg/boost/releases/download/boost-1.81.0/boost-1.81.0.tar.gz && \
+    tar -xzf boost-1.81.0.tar.gz && rm boost-1.81.0.tar.gz && \
+    cd boost-1.81.0 && ./bootstrap.sh && \
+    $B2_CMD install && \
+    cd / && rm -rf /dependencies/boost-1.81.0
+
+# ── 14. Triton Inference Server ────────────────────────────────────────────
+COPY patches/edgeml-triton-server.diff /tmp/edgeml-triton-server.diff
+COPY patches/edgeml-triton-core.diff /tmp/edgeml-triton-core.diff
+RUN . /tmp/build-env.sh && \
+    cd /dependencies && \
+    git clone https://github.com/triton-inference-server/server.git && \
+    cd server && git checkout tags/v2.45.0 && \
+    cp /tmp/edgeml-triton-server.diff . && \
+    cp /tmp/edgeml-triton-core.diff . && \
+    export PYBIND11_FINDPYTHON=ON && \
+    export MAKEFLAGS="-j$JOBS" && \
+    git apply edgeml-triton-server.diff && \
+    python3.9 build.py --enable-logging --enable-stats --enable-metrics --enable-cpu-metrics --no-container-build \
+        --build-parallel $TRITON_PARALLEL \
+        --extra-core-cmake-arg=TRITON_ENABLE_ENSEMBLE=ON \
+        --extra-core-cmake-arg=PYBIND11_FINDPYTHON=ON \
+        --extra-core-cmake-arg=-DPYBIND11_FINDPYTHON=ON \
+        --extra-core-cmake-arg=CMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        --extra-core-cmake-arg=TRITON_CORE_ENABLE_TESTS=OFF \
+        --extra-core-cmake-arg=PYTHON_EXECUTABLE=/usr/bin/python3.9 \
+        --extra-core-cmake-arg=-DPYTHON_EXECUTABLE=/usr/bin/python3.9 \
+        --extra-core-cmake-arg=PYTHON_INCLUDE_DIR=/usr/include/python3.9 \
+        --extra-core-cmake-arg=PYTHON_LIBRARY=/usr/lib/libpython3.9.so \
+        --extra-core-cmake-arg=PYTHON_LIBRARIES=/usr/lib/libpython3.9.so \
+        --extra-core-cmake-arg=-DPYTHON_INCLUDE_DIR=/usr/include/python3.9 \
+        --extra-core-cmake-arg=PYBIND11_PYTHON_VERSION=3.9 \
+        --backend python --build-dir=$(pwd)/build && \
+    mv build/python/install/backends/python build/tritonserver/install/backends && \
+    cp -a build/tritonserver/install/backends/python build/python/install/backends/python && \
+    cd build/opt/ && \
+    tar cvzf triton_installation_files.tar.gz tritonserver/ && \
+    mkdir -p /dependencies/tars/ && \
+    cp triton_installation_files.tar.gz /dependencies/tars/
+
+# ── 15. c-periphery (GPIO) ────────────────────────────────────────────────
+RUN . /tmp/build-env.sh && \
+    cd /dependencies && \
+    git clone https://github.com/vsergeev/c-periphery && \
+    cd c-periphery && \
+    git checkout 91f9678d2a35a3af3c633f20165bdde8bea32209 && \
+    mkdir build && cd build && cmake ../ && \
+    $MAKE_CMD && \
+    make install
+
+# ── 16. EdgeML SDK build + package all debs ────────────────────────────────
+COPY src ./src
+COPY create_aws_triton_deps_pkg.sh /dependencies/debs/
+RUN cd /dependencies/debs && chmod +x create_aws_triton_deps_pkg.sh && ./create_aws_triton_deps_pkg.sh
+
+# Download system packages needed by backend
+RUN cd /dependencies/debs && \
+    apt-get update && \
+    apt-get download libgstreamer1.0-dev && \
+    apt-get download libgstreamer1.0 && \
+    apt-get download libgstreamer-plugins-base1.0 && \
+    apt-get download libgstreamer-plugins-base1.0-dev && \
+    apt-get download liborc-0.4-0 && \
+    apt-get download libstdc++6
+
+# Build EdgeML SDK (conan + cmake)
+# civetweb SSL disabled — the SDK uses mg_init_library(0) so SSL is not needed.
+RUN . /tmp/build-env.sh && \
+    cd src/ && \
+    MAKEFLAGS="-j$JOBS" CONAN_CPU_COUNT=$JOBS \
+    conan build . --build=missing \
+      -o civetweb/*:with_ssl=False && \
+    cd build/Release && \
+    export LD_LIBRARY_PATH=$(pwd)/lib && \
+    $MAKE_CMD install && \
+    cd ./install/ && \
+    chmod a+x create_debian.sh && \
+    ./create_debian.sh && \
+    pwsh ./create_whl.ps1 -InstallDirectory ./lib -Version 1.0
+
+# ── 17. Collect all output artifacts ───────────────────────────────────────
+RUN mkdir -p /debs/ /tars/ && \
+    cp src/build/Release/install/Panorama*.deb /debs/PanoramaSDK.deb && \
+    cp src/build/Release/install/lib/python_package/dist/*.whl /debs/panorama.whl && \
+    cp /dependencies/debs/aws-c-iot.deb /debs/aws-c-iot.deb && \
+    cp /dependencies/debs/aws-crt-cpp.deb /debs/aws-crt-cpp.deb && \
+    cp /dependencies/debs/libgstreamer1.0-0_*.deb /debs/libgstreamer1.0.deb && \
+    cp /dependencies/debs/libgstreamer1.0-dev*.deb /debs/libgstreamer1.0-dev.deb && \
+    cp /dependencies/debs/aws-iot-device-sdk-cpp-v2.deb /debs/aws-iot-device-sdk-cpp-v2.deb && \
+    cp /dependencies/debs/liborc-0.4-0*.deb /debs/liborc-0.4-0.deb && \
+    cp /dependencies/debs/aws-sdk-cpp.deb /debs/aws-sdk-cpp.deb && \
+    cp /dependencies/debs/libstdc++6*.deb /debs/libstdc++6.deb && \
+    cp /dependencies/debs/libgstreamer-plugins-base1.0-0*.deb /debs/libgstreamer-plugins-base1.0.deb && \
+    cp /dependencies/debs/openssl_*.deb /debs/openssl.deb && \
+    cp /dependencies/debs/libgstreamer-plugins-base1.0-dev*.deb /debs/libgstreamer-plugins-base1.0-dev.deb && \
+    cp /dependencies/debs/triton-core.deb /debs/triton-core.deb && \
+    cp /dependencies/debs/triton-python-backend.deb /debs/triton-python-backend.deb && \
+    cp /dependencies/tars/triton_installation_files.tar.gz /tars/
+
+RUN apt-get clean
+
+### End of EdgeML SDK

--- a/src/edgemlsdk/build.sh
+++ b/src/edgemlsdk/build.sh
@@ -19,38 +19,84 @@
 
 platform=$(uname -m)
 python=3.9
-ubuntu=20.04
 ubuntu=$(grep "DISTRIB_RELEASE" /etc/lsb-release | cut -d'=' -f2)
+jetpack=""
 BUILDKIT_PROGRESS=plain
 export BUILDKIT_PROGRESS
-# Export as environment variable
 export ubuntu
 
-echo "Ubuntu version: $UBUNTU_VERSION" 
-while getopts p:y:u: flag
+echo "Ubuntu version: $ubuntu"
+while getopts p:y:u:j: flag
 do
     case "${flag}" in
         p) platform=${OPTARG};;
         y) python=${OPTARG};;
         u) ubuntu=${OPTARG};;
+        j) jetpack=${OPTARG};;
     esac
 done
- 
+
 echo "Platform=$platform"
 echo "Python=$python"
 echo "Ubuntu=$ubuntu"
- 
-if [ $platform = "x86_64" ];
-then
+echo "JetPack=$jetpack"
+
+if [ $platform = "x86_64" ]; then
     pwsh_arch="x64"
 else
     pwsh_arch="arm64"
 fi
- 
+
 rootDir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 pushd $rootDir
- 
- 
-echo "Begin building Docker image. For OS=$ubuntu platform=$platform arch=$pwsh_arch"
-docker build --build-arg OS=$ubuntu --build-arg PLATFORM=$platform --build-arg PWSH_ARCH=$pwsh_arch --build-arg PYTHON_VERSION=$python -t edgemlsdk .
+
+# Clean previous extraction
+rm -rf $rootDir/extracted-debs
+
+# Ensure cached-debs directory exists (may be empty on first build)
+mkdir -p $rootDir/cached-debs
+
+# Select Dockerfile based on JetPack version
+if [ "$jetpack" = "5" ]; then
+    DOCKERFILE="Dockerfile.jp5"
+    echo "Using JP5 Dockerfile (l4t-jetpack:r35.4.1 base, native build)"
+else
+    DOCKERFILE="Dockerfile"
+    echo "Using standard Dockerfile (Ubuntu ${ubuntu} base)"
+fi
+
+echo "Begin building Docker image. For OS=$ubuntu platform=$platform arch=$pwsh_arch dockerfile=$DOCKERFILE"
+
+# Build the edgemlsdk image
+docker build \
+    --load \
+    --build-arg OS=$ubuntu \
+    --build-arg PLATFORM=$platform \
+    --build-arg PWSH_ARCH=$pwsh_arch \
+    --build-arg PYTHON_VERSION=$python \
+    -f $DOCKERFILE \
+    -t edgemlsdk . || { echo "ERROR: edgemlsdk Docker build failed"; exit 1; }
+
+# Extract debs/tars from the built image using docker cp
+mkdir -p $rootDir/extracted-debs/debs $rootDir/extracted-debs/tars
+CONTAINER_ID=$(docker create edgemlsdk /bin/true)
+if [ -z "$CONTAINER_ID" ]; then
+    echo "ERROR: Failed to create container from edgemlsdk image"
+    exit 1
+fi
+docker cp $CONTAINER_ID:/debs/. $rootDir/extracted-debs/debs/
+docker cp $CONTAINER_ID:/tars/. $rootDir/extracted-debs/tars/
+docker rm $CONTAINER_ID
+
+echo "Extraction complete. Checking extracted files..."
+ls -la $rootDir/extracted-debs/debs/ 2>/dev/null || echo "WARNING: No debs found in extracted-debs/"
+ls -la $rootDir/extracted-debs/tars/ 2>/dev/null || echo "WARNING: No tars found in extracted-debs/"
+
+# Cache the openssl deb for future builds
+if ls $rootDir/extracted-debs/debs/openssl*.deb 1>/dev/null 2>&1; then
+    mkdir -p $rootDir/cached-debs
+    cp $rootDir/extracted-debs/debs/openssl*.deb $rootDir/cached-debs/
+    echo "Cached openssl deb to $rootDir/cached-debs/ for future builds"
+fi
+
 popd

--- a/src/edgemlsdk/patches/edgeml-triton-core.diff
+++ b/src/edgemlsdk/patches/edgeml-triton-core.diff
@@ -1,14 +1,13 @@
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index ba027a5..c82b3e4 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -49,7 +49,9 @@ FetchContent_Declare(
+@@ -47,6 +47,9 @@ FetchContent_Declare(
  set(TRITON_COMMON_ENABLE_PROTOBUF ON)
  
  FetchContent_MakeAvailable(repo-common)
 +# Set static-libstdc++ static linking
- 
 +set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libstdc++")
++
  #
  # CUDA
  #

--- a/src/edgemlsdk/patches/edgeml-triton-server.diff
+++ b/src/edgemlsdk/patches/edgeml-triton-server.diff
@@ -1,19 +1,18 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index ff578c97..368e888f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -139,6 +139,14 @@ endif()
  set(TRITON_CORE_HEADERS_ONLY OFF)
  
  FetchContent_MakeAvailable(repo-third-party repo-core)
-+# Apply patch to triton core repo, update with versions of triton as needed.
-+# Define a custom command to apply a Git patch before the target is built
-+execute_process(
-+  COMMAND git apply --ignore-whitespace ${CMAKE_CURRENT_SOURCE_DIR}/edgeml-triton-core.diff
-+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/_deps/repo-core-src/
-+  COMMAND_ERROR_IS_FATAL ANY
-+)
-+message(STATUS ${CMAKE_CURRENT_BINARY_DIR}/_deps/repo-core-src/)
++# Disable triton-core tests (std::filesystem issue under QEMU)
++set(CORE_TEST_CMAKE "${CMAKE_CURRENT_BINARY_DIR}/_deps/repo-core-src/src/test/CMakeLists.txt")
++if(EXISTS ${CORE_TEST_CMAKE})
++  file(READ ${CORE_TEST_CMAKE} _test_content)
++  file(WRITE ${CORE_TEST_CMAKE} "return()\n${_test_content}")
++endif()
++set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libstdc++")
++message(STATUS "Applied triton-core patches")
  
  #
  # Triton server executable and examples
@@ -21,5 +20,5 @@ index ff578c97..368e888f 100644
      -DTRITON_VERSION:STRING=${TRITON_VERSION}
    DEPENDS ${TRITON_DEPENDS}
  )
-+# install the model config prototbuf python file
++# install the model config protobuf python file
 +install(FILES "${CMAKE_CURRENT_BINARY_DIR}/_deps/repo-core-build/triton-core/_deps/repo-common-src/protobuf/model_config.proto" DESTINATION "${CMAKE_INSTALL_PREFIX}/protobuf/")

--- a/src/edgemlsdk/src/README.md
+++ b/src/edgemlsdk/src/README.md
@@ -36,7 +36,7 @@
 ## Push Updated Docker image to ECR Part of Build Process
 This step will build and push docker images(ubuntu 20.04, 18.04) correspodning to docker container platform (x86 or aarch64)
 
-0. Make sure AWS Tokens for account 691462484548 are valid before running below steps
+0. Make sure AWS Tokens for your build account are valid before running below steps
 1. Runing below command will build docker image part of build process and publishes to corresponding ECR repositiory
 ```
 conan build . --build=missing -o publish_docker_image=True

--- a/src/edgemlsdk/src/cmake/FindSwig.cmake
+++ b/src/edgemlsdk/src/cmake/FindSwig.cmake
@@ -1,11 +1,8 @@
-set(SWIG_BIN_DIR "/usr/local/bin")
+find_program(Swig_EXE NAMES swig swig4.0 PATHS /usr/local/bin /usr/bin NO_DEFAULT_PATH)
+find_program(Swig_EXE NAMES swig swig4.0)
 
-if(EXISTS "${SWIG_BIN_DIR}/swig")
-    set(Swig_EXE "${SWIG_BIN_DIR}/swig")
-endif()
-
-if(NOT DEFINED Swig_EXE)
-    message(FATAL_ERROR "Could not find ${SWIG_BIN_DIR}/swig")
+if(NOT Swig_EXE)
+    message(FATAL_ERROR "Could not find swig")
 else()
     message(STATUS "Found Swig: ${Swig_EXE}")
     set(Swig_FOUND true)

--- a/src/edgemlsdk/src/src/bindings/python/CMakeLists.txt
+++ b/src/edgemlsdk/src/src/bindings/python/CMakeLists.txt
@@ -59,5 +59,5 @@ FILECOPY(FILE ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/panorama_projections.py DESTINAT
 add_dependencies(COPY_panorama_projections COPY_python_package panorama_projections_python)
 
 FILECOPY(FILE ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/_panorama_projections.so DESTINATION ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/python_package/src/panorama)
-add_dependencies(COPY__panorama_projections panorama_projections_python)
+add_dependencies(COPY__panorama_projections COPY_python_package panorama_projections_python)
 install(DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/python_package DESTINATION ./lib)

--- a/src/edgemlsdk/src/test/aws/aws_variable_expansion_tests.cpp
+++ b/src/edgemlsdk/src/test/aws/aws_variable_expansion_tests.cpp
@@ -77,7 +77,7 @@ void SecretsManagerExpansionTest()
 
     {
         ComPtr<IStringProperty> property;
-        ASSERT_S(CreateStringProperty(property.AddressOf(), "id", "{\"type\":\"secretsmanager\", \"value\":\"arn:aws:secretsmanager:us-west-2:691462484548:secret:panorama-sdk-v2/test/test_camera_credential-8tWMKC;username\"}"));
+        ASSERT_S(CreateStringProperty(property.AddressOf(), "id", "{\"type\":\"secretsmanager\", \"value\":\"arn:aws:secretsmanager:us-west-2:123456789012:secret:panorama-sdk-v2/test/test_camera_credential-8tWMKC;username\"}"));
 
         ComPtr<IVariableExpansion> variable;
         ASSERT_S(CreateSecretsManagerExpansion(variable.AddressOf(), property, credProvider));
@@ -93,7 +93,7 @@ void SecretsManagerExpansionTest()
         new_value["username"] = "MyUsername";
         new_value["password"] = "MyPassword";
         ASSERT_FALSE(variable->Stale());
-        ASSERT_S(WriteSecretsManagerValue("arn:aws:secretsmanager:us-west-2:691462484548:secret:panorama-sdk-v2/test/test_camera_credential-8tWMKC", new_value.dump().c_str(), credProvider));
+        ASSERT_S(WriteSecretsManagerValue("arn:aws:secretsmanager:us-west-2:123456789012:secret:panorama-sdk-v2/test/test_camera_credential-8tWMKC", new_value.dump().c_str(), credProvider));
         ASSERT_TRUE(variable->Stale());
 
         property->Set("{\"type\":\"secretsmanager\", \"value\":\"invalid_arn\"}");

--- a/src/edgemlsdk/src/test/longevity/README.md
+++ b/src/edgemlsdk/src/test/longevity/README.md
@@ -5,7 +5,7 @@
  - install aws cli 
  - install python3 and python3-pip
  - install boto3
- - paste admin/ReadOnly credentials for account `691462484548` on terminal
+ - paste admin/ReadOnly credentials for your AWS account on terminal
  ### Run Longevity Tests
  
  ```

--- a/src/edgemlsdk/src/test/longevity/deploy.py
+++ b/src/edgemlsdk/src/test/longevity/deploy.py
@@ -12,7 +12,7 @@ secret_name = "edgeml-sdk-longevity-tests"
 ec2_instance_type = 't4g.2xlarge'
 ec2_image_id = 'ami-073614ec1eee63d19' # Amazon Linux 2023 AMI 2023.1.20230912.0 arm64 HVM kernel-6.1
 
-iam_instance_profile_arn =  'arn:aws:iam::691462484548:instance-profile/iam_role_for_edgemlsdk_longevity_tests'
+iam_instance_profile_arn =  'arn:aws:iam::ACCOUNT_ID:instance-profile/iam_role_for_edgemlsdk_longevity_tests'
  
 class DeployLongevity:
     def __init__(self, instance_type="ec2"):
@@ -176,13 +176,13 @@ def main(args):
         "aws s3 cp s3://edgeml-sdk-longevity-tests/longevity.json /edgemlsdk/",
         "aws s3 cp s3://edgeml-sdk-longevity-tests/delegates.json /edgemlsdk/",
         f"aws s3 sync s3://edgeml-sdk-longevity-tests/{source_folder} /edgemlsdk/{source_folder}",
-        "aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 691462484548.dkr.ecr.us-west-2.amazonaws.com",
-        f"docker pull 691462484548.dkr.ecr.us-west-2.amazonaws.com/edgemlsdk:{args.ubuntu_version}-{args.platform}-{args.python_version}-latest",
+        "aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com",
+        f"docker pull ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/edgemlsdk:{args.ubuntu_version}-{args.platform}-{args.python_version}-latest",
     ]
 
     if args.mqtt:
         run_mqtt_longevity = [f"docker run -v /edgemlsdk:/edgemlsdk -idt --log-driver=awslogs --log-opt awslogs-region=us-west-2 --log-opt awslogs-group=edgemlsdk-{args.ubuntu_version}-{args.platform}-{args.python_version}-{args.mqtt} --log-opt awslogs-create-group=true \
-            691462484548.dkr.ecr.us-west-2.amazonaws.com/edgemlsdk:{args.ubuntu_version}-{args.platform}-{args.python_version}-latest \
+            ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/edgemlsdk:{args.ubuntu_version}-{args.platform}-{args.python_version}-latest \
             bash -c '''cd /edgemlsdk; dpkg -i Panorama_1.0.{args.release_date}.deb;apt-get install tmux -y; python3 -m pip install panorama-1.0-py3-none-any.whl; bash /edgemlsdk/mqtt/run_mqtt_longevity.sh -l {args.longevity_hours} -r {args.region} -m {args.mqtt_endpoint} -n {args.payload_size} -a {credentials.access_key} -s {credentials.secret_key}'''"]
     task = DeployLongevity("ec2")
     instance_id = task.create_instance(

--- a/src/edgemlsdk/src/test/longevity/longevity.json
+++ b/src/edgemlsdk/src/test/longevity/longevity.json
@@ -3,14 +3,14 @@
         "envelopeVersion": "2021-01-01",
         "packages": [
             {
-                "name": "691462484548::edgemlsdk_longevity",
+                "name": "ACCOUNT_ID::edgemlsdk_longevity",
                 "version": "1.0"
             }
         ],
         "nodes": [
             {
                 "name": "longevity_node",
-                "interface": "691462484548::edgemlsdk_longevity.edgemlsdk_longevity_asset_interface",
+                "interface": "ACCOUNT_ID::edgemlsdk_longevity.edgemlsdk_longevity_asset_interface",
                 "overridable": false,
                 "launch": "onAppStart"
             },

--- a/src/edgemlsdk/src/utilities/machine_setup.sh
+++ b/src/edgemlsdk/src/utilities/machine_setup.sh
@@ -159,7 +159,7 @@ check_and_install_python_module boto3
 check_and_install_python_module awscrt
 
 # Install CBS-CLI and configure (Will give errors if already run, can be ignored)
-toolbox registry add s3://cbs-toolbox-498039791012-us-west-2/tools.json
+toolbox registry add s3://cbs-toolbox-ACCOUNT_ID-us-west-2/tools.json
 toolbox install cbs-cli
 cbs_configure
 conan profile detect

--- a/station_install/setup_station.sh
+++ b/station_install/setup_station.sh
@@ -241,7 +241,23 @@ java -jar ./GreengrassInstaller/lib/Greengrass.jar --version
 # Create IoT thing
 # Replace aws-region, thing-name, thing-group-name and etc with your desird value
 # If it fails with "The role with name GreengrassV2TokenExchangeRole cannot be found", rerun the command
-java -Droot="/aws_dda/greengrass/v2" -Dlog.store=FILE   -jar ./GreengrassInstaller/lib/Greengrass.jar   --aws-region ${aws_region}   --thing-name ${thing_name} --thing-group-name DDA_transition_EC2_Group   --thing-policy-name GreengrassV2IoTThingPolicy   --tes-role-name GreengrassV2TokenExchangeRole   --tes-role-alias-name GreengrassCoreTokenExchangeRoleAlias   --component-default-user ggc_user:ggc_group   --setup-system-service true --provision true
+# Export credentials for Java SDK (it cannot use SSO cache or IMDS in all contexts)
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    # Try to get credentials from the AWS CLI (works with SSO, instance roles, etc.)
+    eval $(aws configure export-credentials --format env 2>/dev/null) || true
+fi
+# Pass credentials as Java system properties to guarantee the SDK sees them
+JAVA_CRED_PROPS=""
+if [ -n "$AWS_ACCESS_KEY_ID" ]; then
+    JAVA_CRED_PROPS="-Daws.accessKeyId=$AWS_ACCESS_KEY_ID -Daws.secretAccessKey=$AWS_SECRET_ACCESS_KEY"
+    if [ -n "$AWS_SESSION_TOKEN" ]; then
+        JAVA_CRED_PROPS="$JAVA_CRED_PROPS -Daws.sessionToken=$AWS_SESSION_TOKEN"
+    fi
+fi
+echo "DEBUG: AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:0:10}..."
+echo "DEBUG: JAVA_CRED_PROPS set: $([ -n \"$JAVA_CRED_PROPS\" ] && echo 'yes' || echo 'NO - credentials missing!')"
+AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" \
+java -Droot="/aws_dda/greengrass/v2" -Dlog.store=FILE $JAVA_CRED_PROPS -jar ./GreengrassInstaller/lib/Greengrass.jar   --aws-region ${aws_region}   --thing-name ${thing_name} --thing-group-name DDA_transition_EC2_Group   --thing-policy-name GreengrassV2IoTThingPolicy   --tes-role-name GreengrassV2TokenExchangeRole   --tes-role-alias-name GreengrassCoreTokenExchangeRoleAlias   --component-default-user ggc_user:ggc_group   --setup-system-service true --provision true
 
 # Add ggc_user to a group that allows access to GPU and driver
 usermod -aG video ggc_user


### PR DESCRIPTION
## Summary

Merges the `jp5v2` branch into `main`, unifying the build system to support all three target platforms from a single branch.

Because `main` and `jp5v2` had unrelated git histories, this brings in jp5v2's file content as a single reviewable commit on top of `main` (no files removed; tree matches jp5v2 exactly).

## Changes

- **Unified build paths**: JP4.6 (Ubuntu 18.04, aarch64), JP5 (Ubuntu 20.04, aarch64), and x86_64 (Ubuntu 20.04) from one branch
- **Separate Dockerfiles**: `Dockerfile.jp5` for JetPack 5 (l4t-jetpack base), standard `Dockerfile` for x86/JP4.6
- **ECR deployment**: Large Docker images (>2GB Greengrass artifact limit) are pushed to ECR; the recipe uses `DockerApplicationManager` + `docker:` artifact URIs so Greengrass handles ECR auth via the Token Exchange Service
- **Region/bucket auto-detection** from AWS config (no hardcoded `us-east-1`)
- **Removed hardcoded AWS account IDs** from edgemlsdk sources
- **Build fixes**: buildx `--load` for docker-container driver, skip tegra profile on x86_64, `botocore[crt]` for SSO publish, fail-fast error handling
- **Updated IAM documentation** in README (ECR publish/pull policies, TES role)

## Testing

- JP5 (aarch64) build + ECR publish + cloud deployment verified working on Jetson edge device
- x86_64 and JP4.6 build fixes applied

## Notes

- 26 files changed, 5 new files, zero deletions
- See `README.md` for updated IAM role/policy requirements