### PR TITLE
fix: robust Aravis/USB3Vision camera handling + device-driven advanced image settings

### DIFF
--- a/recipe-amd64.yaml
+++ b/recipe-amd64.yaml
@@ -75,6 +75,7 @@ Manifests:
           bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64/host_scripts/setup_dda_users.sh ;
           bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64/host_scripts/get_nvidia_libs_versions.sh;
           bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64/host_scripts/setup_paths.sh;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64/host_scripts/configure_usb.sh;
           export $(grep -v '^#' /tmp/.dda.env | xargs) ;
           docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.amd64-x86_64/custom-build/aws.edgeml.dda.LocalServer.amd64/docker-compose.yaml up --no-build ;
       Shutdown:

--- a/recipe-arm64-jp5.yaml
+++ b/recipe-arm64-jp5.yaml
@@ -79,6 +79,7 @@ Manifests:
           bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/setup_dda_users.sh ;
           bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/get_nvidia_libs_versions.sh;
           bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/setup_paths.sh;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/configure_usb.sh;
           export $(grep -v '^#' /tmp/.dda.env | xargs) ;
           docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/docker-compose.yaml up --no-build ;
       Shutdown:

--- a/recipe-arm64-jp6.yaml
+++ b/recipe-arm64-jp6.yaml
@@ -79,6 +79,7 @@ Manifests:
           bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP6-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP6/host_scripts/setup_dda_users.sh ;
           bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP6-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP6/host_scripts/get_nvidia_libs_versions.sh;
           bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP6-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP6/host_scripts/setup_paths.sh;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP6-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP6/host_scripts/configure_usb.sh;
           export $(grep -v '^#' /tmp/.dda.env | xargs) ;
           docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP6-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP6/docker-compose.yaml up --no-build ;
       Shutdown:

--- a/recipe-arm64.yaml
+++ b/recipe-arm64.yaml
@@ -79,6 +79,7 @@ Manifests:
           bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/host_scripts/setup_dda_users.sh ;
           bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/host_scripts/get_nvidia_libs_versions.sh;
           bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/host_scripts/setup_paths.sh;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/host_scripts/configure_usb.sh;
           export $(grep -v '^#' /tmp/.dda.env | xargs) ;
           docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64/docker-compose.yaml up --no-build ;
       Shutdown:

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -9,6 +9,8 @@ ComponentDependencies:
     VersionRequirement: ">=2.4.0"
   aws.greengrass.ShadowManager:
     VersionRequirement: ">=2.2.0"
+  aws.greengrass.Cli:
+    VersionRequirement: ">=2.6.0"
 ComponentConfiguration:
   DefaultConfiguration:
     StreamShadowName: "streamConfigurationShadow"
@@ -63,30 +65,28 @@ Manifests:
       Install:
         RequiresPrivilege: true
         Script: |
-          docker images --quiet --filter=dangling=true | xargs --no-run-if-empty docker rmi -f ;
-          BACKEND_DIR="{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-backend-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5" ;
-          APP_DIR="{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5" ;
-          docker load -i $BACKEND_DIR/flask-app.tar ;
-          docker load -i $APP_DIR/react-webapp.tar.gz
+          docker images --quiet --filter=dangling=true | xargs --no-run-if-empty docker rmi -f || true; docker load -i {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/flask-app.tar && docker load -i {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/react-webapp.tar
+          chmod +x {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/*.sh
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/install_nvidia_csi_service.sh
       Run:
         RequiresPrivilege: true
         SetEnv:
           COMPONENT_WORK_PATH: "{work:path}"
           KERNEL_ROOT_PATH: "{kernel:rootPath}"
           INFERENCE_COMPONENT_DECOMPRESED_PATH: "{aws.edgeml.dda.InferenceApp:artifacts:decompressedPath}"
-          LOCAL_SERVER_COMPONENT_DECOMPRESSED_PATH: "{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64"
+          LOCAL_SERVER_COMPONENT_DECOMPRESSED_PATH: "{artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64"
         Script: |
-          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/setup_dda_users.sh ;
-          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/get_nvidia_libs_versions.sh;
-          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/setup_paths.sh;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/setup_dda_users.sh ;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/get_nvidia_libs_versions.sh;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/setup_paths.sh;
+          bash {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/host_scripts/configure_usb.sh;
           export $(grep -v '^#' /tmp/.dda.env | xargs) ;
-          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/docker-compose.yaml up --no-build ;
+          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/docker-compose.yaml up --no-build ;
       Shutdown:
         RequiresPrivilege: true
         Script: |
-          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/docker-compose.yaml down
+          systemctl stop nvidia-csi-capture || true
+          docker compose --profile $DOCKER_PROFILE -f {artifacts:decompressedPath}/aws.edgeml.dda.LocalServer.arm64JP5-aarch64/custom-build/aws.edgeml.dda.LocalServer.arm64JP5/docker-compose.yaml down
     Artifacts:
-      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/aws.edgeml.dda.LocalServer.arm64JP5-backend-aarch64.zip
-        Unarchive: ZIP
-      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/aws.edgeml.dda.LocalServer.arm64JP5-app-aarch64.zip
+      - URI: s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/aws.edgeml.dda.LocalServer.arm64JP5-aarch64.zip
         Unarchive: ZIP

--- a/src/backend/alembic/configuration_database/versions/b2f1a9c4d7e3_add_advanced_camera_settings.py
+++ b/src/backend/alembic/configuration_database/versions/b2f1a9c4d7e3_add_advanced_camera_settings.py
@@ -1,0 +1,58 @@
+#
+#  Copyright 2025 Amazon Web Services, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""add advanced camera settings
+
+Revision ID: b2f1a9c4d7e3
+Revises: c1ce33a752b2
+Create Date: 2026-06-12 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'b2f1a9c4d7e3'
+down_revision: Union[str, None] = 'c1ce33a752b2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('image_source_configuration', schema=None) as batch_op:
+        # Nullable JSON column holding the persisted advanced GenICam controls
+        # (reverseX, reverseY, balanceWhiteAuto). Nullable, so existing rows
+        # backfill to NULL and no data migration is required.
+        batch_op.add_column(sa.Column("advancedSettings", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('image_source_configuration', schema=None) as batch_op:
+        batch_op.drop_column('advancedSettings')

--- a/src/backend/dao/sqlite_db/models.py
+++ b/src/backend/dao/sqlite_db/models.py
@@ -48,6 +48,9 @@ class ImageSourceConfiguration(Base):
     imageCrop = Column(JSON)
     device = Column(String)
     deviceName = Column(String)
+    # Persisted advanced GenICam controls (safe set: reverseX, reverseY,
+    # balanceWhiteAuto). Stored as JSON so new controls don't need a migration.
+    advancedSettings = Column(JSON)
 
 
 class InputConfiguration(Base):

--- a/src/backend/data_models/common.py
+++ b/src/backend/data_models/common.py
@@ -54,6 +54,7 @@ class ImageSourceConfigurationsOutputModel(BaseModel):
     device: Optional[str] = None
     deviceName: Optional[str] = None
     imageSourceConfigId: str
+    advancedSettings: Optional[dict] = None
 
 
 class ImageSourceCropModel(BaseModel):
@@ -70,6 +71,7 @@ class ImageSourceConfigurationsInputModel(BaseModel):
     imageCrop: Optional[ImageSourceCropModel] = None
     device: Optional[str] = None
     deviceName: Optional[str] = None
+    advancedSettings: Optional[dict] = None
 
 
 class InputConfigurationsModel(BaseModel):

--- a/src/backend/edge_ml1_p_camera_management/aravis_functions.py
+++ b/src/backend/edge_ml1_p_camera_management/aravis_functions.py
@@ -53,6 +53,7 @@ import logging
 import logging.config
 
 from exceptions.api.aravis_camera_not_found import AravisCameraNotFound
+from exceptions.api.aravis_camera_open_error import AravisCameraOpenError
 
 # LOG LEVELS
 # CRITICAL 50
@@ -95,14 +96,48 @@ def getCameras():
 
 
 def getCamera(cameraId):
+    # Enable Fake camera
+    Aravis.enable_interface("Fake")
+    # Refresh camera list and discover new cameras, if any
+    Aravis.update_device_list()
+
+    # Capture the set of devices currently enumerated on the bus so we can tell
+    # apart two very different failure modes when Aravis.Camera.new() raises:
+    #   1. The camera is not enumerated at all -> genuinely "not found".
+    #   2. The camera is enumerated (it shows up when adding an image source)
+    #      but cannot be opened/bootstrapped -> "detected but unavailable".
+    # The second case is what users hit when a USB3/GenICam camera negotiates
+    # only a USB2 link (non-SuperSpeed cable, USB2 port/hub, low bus power) or
+    # the device is already held open by another process. Aravis reports it as
+    # "Failed to bootstrap USB device ... ", which previously surfaced to the
+    # user as a confusing "not found".
+    discovered_ids = [Aravis.get_device_id(i) for i in range(Aravis.get_n_devices())]
+
     try:
-        # Enable Fake camera
-        Aravis.enable_interface("Fake")
-        # Refresh camera list and discover new cameras, if any
-        Aravis.update_device_list()
         return Aravis.Camera.new(cameraId)
-    except GError:
-        raise AravisCameraNotFound("Error fetching camera details")
+    except GError as err:
+        error_detail = getattr(err, "message", None) or str(err)
+        if cameraId not in discovered_ids:
+            log.error(
+                "Camera '%s' was not found on the bus. Discovered devices: %s. Error: %s",
+                cameraId, discovered_ids, error_detail,
+            )
+            raise AravisCameraNotFound(
+                f"Camera '{cameraId}' was not detected. Make sure it is connected "
+                f"and not already in use by another device."
+            )
+        log.error(
+            "Camera '%s' was detected but could not be opened. Error: %s",
+            cameraId, error_detail,
+        )
+        raise AravisCameraOpenError(
+            f"Camera '{cameraId}' was detected but could not be opened. This often "
+            f"means a USB3 (GenICam) camera negotiated only a USB2 link, a faulty or "
+            f"non-SuperSpeed cable, a USB2 port/hub, insufficient bus power, or the "
+            f"camera is already in use by another process. Reconnect the camera "
+            f"directly to a USB3 (SuperSpeed) port using a certified USB3 cable and "
+            f"try again. Underlying error: {error_detail}"
+        )
 
 
 def get_input_file_from_pipeline(pipelinestr):

--- a/src/backend/edge_ml1_p_camera_management/aravis_functions.py
+++ b/src/backend/edge_ml1_p_camera_management/aravis_functions.py
@@ -47,6 +47,7 @@ import gi
 import numpy as np
 import os
 from string import Template
+import threading
 import time
 import traceback
 import logging
@@ -74,6 +75,11 @@ from model.Camera import Camera
 # Initialize Aravis
 log = logging.getLogger(__name__)
 
+# Serializes full bus rescans so a context teardown (Aravis.shutdown) can never
+# race with a concurrent enumeration in another request thread.
+_rescan_lock = threading.Lock()
+
+
 def getCameras():
     Aravis.enable_interface("Fake")
     Aravis.update_device_list()
@@ -93,6 +99,33 @@ def getCameras():
         camera = Camera(id, model, address, physical_id, protocol, serial, vendor)
         cameras.append(camera)
     return cameras
+
+
+def rescan_cameras():
+    """
+    Force a fresh enumeration of the camera bus and return the discovered
+    cameras.
+
+    The backend runs inside a container that does not receive host udev hotplug
+    events, and Aravis/libusb keeps a cached USB context for the life of the
+    process. Because of this, a camera connected after the server started may
+    not show up from a plain update_device_list(), and the only reliable way to
+    pick it up used to be restarting the container.
+
+    Aravis.shutdown() tears down the cached USB/GenICam context in this
+    enumeration process; the following update_device_list() rebuilds it and
+    reliably discovers devices that were hotplugged after startup. Camera
+    acquisition objects live in a separate manager process with their own
+    Aravis context (see utils.camera_manager), so resetting the context here
+    does not disturb active acquisitions/streams.
+    """
+    with _rescan_lock:
+        try:
+            Aravis.shutdown()
+        except Exception as err:
+            # A failed teardown is non-fatal; the re-init below still runs.
+            log.warning("Aravis.shutdown() during rescan failed, continuing: %s", err)
+        return getCameras()
 
 
 def getCamera(cameraId):

--- a/src/backend/endpoints/camera.py
+++ b/src/backend/endpoints/camera.py
@@ -28,13 +28,18 @@
 # limitations under the License.
 # Fastapi modules
 from fastapi import APIRouter, Depends
-from typing import List
-from pydantic import RootModel
+from typing import List, Optional
+from pydantic import RootModel, BaseModel
 
 # Custom Modules
 from edge_ml1_p_camera_management import aravis_functions
 from endpoints.route.access_log_router import get_api_router
-from utils.camera_manager import connect_camera, disconnect_camera, get_camera_feature_bounds
+from utils.camera_manager import (
+    connect_camera,
+    disconnect_camera,
+    get_camera_feature_bounds,
+    apply_camera_features,
+)
 
 # Schema and Validation models
 from model.Camera import CameraSchema
@@ -83,3 +88,21 @@ def disconnect_camera_endpoint(cameraId: str):
 @router.get("/cameras/{cameraId}/feature-bounds")
 def get_camera_feature_bounds_endpoint(cameraId: str):
     return get_camera_feature_bounds(cameraId)
+
+
+class ApplyCameraFeature(BaseModel):
+    feature: str
+    type: str
+    value: object
+
+
+class ApplyCameraFeaturesRequest(BaseModel):
+    features: List[ApplyCameraFeature] = []
+
+
+# Applies advanced GenICam feature values (white balance, flip, pixel format,
+# ROI, ...) to the live camera and returns the device-accepted values.
+@router.post("/cameras/{cameraId}/features")
+def apply_camera_features_endpoint(cameraId: str, request: ApplyCameraFeaturesRequest):
+    features = [f.dict() for f in request.features]
+    return apply_camera_features(cameraId, features)

--- a/src/backend/endpoints/camera.py
+++ b/src/backend/endpoints/camera.py
@@ -55,6 +55,17 @@ def getcameras() -> GetCamerasResponse:
     result = schema.dump(cameras)
     return result
 
+# Forces a fresh bus enumeration and returns the cameras.
+# Use this to pick up a camera that was connected after the server started,
+# without restarting the container (the container does not receive host udev
+# hotplug events, so a plain GET /cameras may not see it).
+@router.post("/cameras/rescan")
+def rescan_cameras_endpoint() -> GetCamerasResponse:
+    cameras = aravis_functions.rescan_cameras()
+    schema = CameraSchema(many=True)
+    result = schema.dump(cameras)
+    return result
+
 @router.get("/cameras/{cameraId}/connect")
 def connect_camera_endpoint(cameraId: str):
     # Check if the camera is online, 

--- a/src/backend/endpoints/camera.py
+++ b/src/backend/endpoints/camera.py
@@ -34,7 +34,7 @@ from pydantic import RootModel
 # Custom Modules
 from edge_ml1_p_camera_management import aravis_functions
 from endpoints.route.access_log_router import get_api_router
-from utils.camera_manager import connect_camera, disconnect_camera
+from utils.camera_manager import connect_camera, disconnect_camera, get_camera_feature_bounds
 
 # Schema and Validation models
 from model.Camera import CameraSchema
@@ -76,3 +76,10 @@ def connect_camera_endpoint(cameraId: str):
 @router.get("/cameras/{cameraId}/disconnect")
 def disconnect_camera_endpoint(cameraId: str):
     return disconnect_camera(cameraId)
+
+# Returns the adjustable feature ranges (gain, exposure, ...) for a camera,
+# read from the device's GenICam feature map, so the UI can present limits
+# that match the actual hardware instead of hard-coded defaults.
+@router.get("/cameras/{cameraId}/feature-bounds")
+def get_camera_feature_bounds_endpoint(cameraId: str):
+    return get_camera_feature_bounds(cameraId)

--- a/src/backend/exceptions/api/aravis_camera_open_error.py
+++ b/src/backend/exceptions/api/aravis_camera_open_error.py
@@ -1,0 +1,48 @@
+#
+#  Copyright 2025 Amazon Web Services, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from starlette import status
+
+from exceptions.api.aravis_camera_exception import AravisCameraException
+
+
+class AravisCameraOpenError(AravisCameraException):
+    """
+    Raised when a camera is discovered on the bus (it shows up in the device
+    list) but cannot be opened / bootstrapped.
+
+    This is distinct from AravisCameraNotFound, which means the device was not
+    enumerated at all. A common cause of an open failure is a GenICam/USB3
+    camera that negotiated only a USB2 link (bad or non-SuperSpeed cable, a
+    USB2 port/hub, or insufficient bus power), or the camera already being held
+    open by another process. Surfacing this separately lets the UI tell the
+    user the camera was detected but could not be accessed, instead of the
+    misleading "not found".
+    """
+
+    def __init__(self, message, status_code=status.HTTP_422_UNPROCESSABLE_ENTITY):
+        super().__init__(message, status_code)

--- a/src/backend/model/image_source_configuration.py
+++ b/src/backend/model/image_source_configuration.py
@@ -28,7 +28,8 @@
 from marshmallow import Schema, fields, post_load
 
 class ImageSourceConfiguration:
-    def __init__(self, imageSourceConfigId, gain, exposure, processingPipeline, creationTime, imageCrop=None, device=None, deviceName=None):
+    def __init__(self, imageSourceConfigId, gain, exposure, processingPipeline, creationTime, imageCrop=None, device=None, deviceName=None,
+                 reverseX=None, reverseY=None, balanceWhiteAuto=None, pixelFormat=None, width=None, height=None, offsetX=None, offsetY=None):
         self.imageSourceConfigId = imageSourceConfigId
         self.gain = gain
         self.exposure = exposure
@@ -37,6 +38,15 @@ class ImageSourceConfiguration:
         self.imageCrop = imageCrop
         self.device = device
         self.deviceName = deviceName
+        # Advanced GenICam controls (applied to the device at acquisition time).
+        self.reverseX = reverseX
+        self.reverseY = reverseY
+        self.balanceWhiteAuto = balanceWhiteAuto
+        self.pixelFormat = pixelFormat
+        self.width = width
+        self.height = height
+        self.offsetX = offsetX
+        self.offsetY = offsetY
 
     def get(self, attr_name, default=None):
         return getattr(self, attr_name, default)
@@ -59,6 +69,15 @@ class ImageSourceConfigurationSchema(Schema):
     imageCrop = fields.Nested(ImageCropConfigSchema(), required=False)
     device = fields.Str(required=False, allow_none=True)
     deviceName = fields.Str(required=False, allow_none=True)
+    # Advanced GenICam controls (optional; applied to the device at acquisition).
+    reverseX = fields.Bool(required=False, allow_none=True)
+    reverseY = fields.Bool(required=False, allow_none=True)
+    balanceWhiteAuto = fields.Str(required=False, allow_none=True)
+    pixelFormat = fields.Str(required=False, allow_none=True)
+    width = fields.Int(required=False, allow_none=True)
+    height = fields.Int(required=False, allow_none=True)
+    offsetX = fields.Int(required=False, allow_none=True)
+    offsetY = fields.Int(required=False, allow_none=True)
 
     @post_load
     def make_source(self, data, **kwargs):

--- a/src/backend/model/image_source_configuration.py
+++ b/src/backend/model/image_source_configuration.py
@@ -28,7 +28,7 @@
 from marshmallow import Schema, fields, post_load, EXCLUDE
 
 class ImageSourceConfiguration:
-    def __init__(self, imageSourceConfigId, gain, exposure, processingPipeline, creationTime, imageCrop=None, device=None, deviceName=None):
+    def __init__(self, imageSourceConfigId, gain, exposure, processingPipeline, creationTime, imageCrop=None, device=None, deviceName=None, advancedSettings=None):
         self.imageSourceConfigId = imageSourceConfigId
         self.gain = gain
         self.exposure = exposure
@@ -37,6 +37,9 @@ class ImageSourceConfiguration:
         self.imageCrop = imageCrop
         self.device = device
         self.deviceName = deviceName
+        # Persisted safe advanced GenICam controls (reverseX, reverseY,
+        # balanceWhiteAuto).
+        self.advancedSettings = advancedSettings
 
     def get(self, attr_name, default=None):
         return getattr(self, attr_name, default)
@@ -67,6 +70,7 @@ class ImageSourceConfigurationSchema(Schema):
     imageCrop = fields.Nested(ImageCropConfigSchema(), required=False)
     device = fields.Str(required=False, allow_none=True)
     deviceName = fields.Str(required=False, allow_none=True)
+    advancedSettings = fields.Dict(required=False, allow_none=True)
 
     @post_load
     def make_source(self, data, **kwargs):

--- a/src/backend/model/image_source_configuration.py
+++ b/src/backend/model/image_source_configuration.py
@@ -25,11 +25,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, EXCLUDE
 
 class ImageSourceConfiguration:
-    def __init__(self, imageSourceConfigId, gain, exposure, processingPipeline, creationTime, imageCrop=None, device=None, deviceName=None,
-                 reverseX=None, reverseY=None, balanceWhiteAuto=None, pixelFormat=None, width=None, height=None, offsetX=None, offsetY=None):
+    def __init__(self, imageSourceConfigId, gain, exposure, processingPipeline, creationTime, imageCrop=None, device=None, deviceName=None):
         self.imageSourceConfigId = imageSourceConfigId
         self.gain = gain
         self.exposure = exposure
@@ -38,15 +37,6 @@ class ImageSourceConfiguration:
         self.imageCrop = imageCrop
         self.device = device
         self.deviceName = deviceName
-        # Advanced GenICam controls (applied to the device at acquisition time).
-        self.reverseX = reverseX
-        self.reverseY = reverseY
-        self.balanceWhiteAuto = balanceWhiteAuto
-        self.pixelFormat = pixelFormat
-        self.width = width
-        self.height = height
-        self.offsetX = offsetX
-        self.offsetY = offsetY
 
     def get(self, attr_name, default=None):
         return getattr(self, attr_name, default)
@@ -61,6 +51,14 @@ class ImageCropConfigSchema(Schema):
     right = fields.Int(required=True)
 
 class ImageSourceConfigurationSchema(Schema):
+    # Advanced GenICam controls (reverseX, pixelFormat, width, ...) may be
+    # present in the preview override config; ignore them here rather than
+    # adding them as fields. Adding fields would make dump() emit them and break
+    # the persistence/ORM layer, which has no columns for them. They are still
+    # applied to the device from the raw override dict at acquisition time.
+    class Meta:
+        unknown = EXCLUDE
+
     imageSourceConfigId = fields.Str(required=True)
     gain = fields.Int(required=True)
     exposure = fields.Int(required=True)
@@ -69,15 +67,6 @@ class ImageSourceConfigurationSchema(Schema):
     imageCrop = fields.Nested(ImageCropConfigSchema(), required=False)
     device = fields.Str(required=False, allow_none=True)
     deviceName = fields.Str(required=False, allow_none=True)
-    # Advanced GenICam controls (optional; applied to the device at acquisition).
-    reverseX = fields.Bool(required=False, allow_none=True)
-    reverseY = fields.Bool(required=False, allow_none=True)
-    balanceWhiteAuto = fields.Str(required=False, allow_none=True)
-    pixelFormat = fields.Str(required=False, allow_none=True)
-    width = fields.Int(required=False, allow_none=True)
-    height = fields.Int(required=False, allow_none=True)
-    offsetX = fields.Int(required=False, allow_none=True)
-    offsetY = fields.Int(required=False, allow_none=True)
 
     @post_load
     def make_source(self, data, **kwargs):

--- a/src/backend/utils/camera_manager.py
+++ b/src/backend/utils/camera_manager.py
@@ -49,6 +49,24 @@ from threading import Lock
 
 get_frame_lock = Lock()
 
+# Tier 2 / Tier 3 GenICam controls surfaced under "Advanced settings".
+# (response_key, GenICam feature name, kind, unit). Each is included only when
+# the connected device actually implements it, so unsupported controls never
+# appear in the UI.
+ADVANCED_DEVICE_FEATURES = [
+    # Tier 2 — common, conditional
+    ("balanceWhiteAuto", "BalanceWhiteAuto", "enumeration", None),
+    ("reverseX", "ReverseX", "boolean", None),
+    ("reverseY", "ReverseY", "boolean", None),
+    # Tier 3 — supported but pipeline-affecting; the device locks these while
+    # streaming, so applying them rebuilds the stream.
+    ("pixelFormat", "PixelFormat", "enumeration", None),
+    ("width", "Width", "integer", "px"),
+    ("height", "Height", "integer", "px"),
+    ("offsetX", "OffsetX", "integer", "px"),
+    ("offsetY", "OffsetY", "integer", "px"),
+]
+
 class Camera():
     def __init__(self,camera_id):
         self.status = None
@@ -107,44 +125,173 @@ class Camera():
               "increment": <number|None>,
               "current": <value|None>,
               "unit": <str|None>,
-              "options": [<str>, ...]   # enumeration only
+              "options": [<str>, ...],   # enumeration only
+              "available": <bool>,       # supported by this device
+              "advanced": <bool>         # belongs in the "Advanced settings" UI
             }
-        Exposure time is reported in microseconds (Aravis' native unit and the
-        unit stored for USB3Vision cameras).
+        Features the device does not implement are omitted entirely, so the UI
+        can simply render whatever is returned. Exposure time is reported in
+        microseconds (Aravis' native unit and the unit stored for USB3Vision
+        cameras).
         """
         bounds = {}
         if not self.camera:
             return bounds
 
-        # (feature_name, kind, unit) for the controls that are common across
-        # most GenICam (USB3Vision / GigE Vision) devices. Unsupported features
-        # are skipped silently so this works across vendors/models.
-        float_features = [
+        # Primary controls (always shown when supported).
+        for key, feature, unit in [
             ("exposure", "ExposureTime", "us"),
             ("gain", "Gain", None),
-        ]
+        ]:
+            entry = self._read_float_bounds(key, feature, unit)
+            if entry:
+                entry["advanced"] = False
+                bounds[key] = entry
 
-        for key, _feature, unit in float_features:
-            try:
-                if key == "exposure":
-                    fmin, fmax = self.camera.get_exposure_time_bounds()
-                    current = self.camera.get_exposure_time()
-                else:  # gain
-                    fmin, fmax = self.camera.get_gain_bounds()
-                    current = self.camera.get_gain()
-                bounds[key] = {
-                    "type": "float",
-                    "min": fmin,
-                    "max": fmax,
-                    "increment": None,
-                    "current": current,
-                    "unit": unit,
-                    "options": [],
-                }
-            except Exception as e:
-                logger.warning(f"Camera ID {self.camera_id}: unable to read {key} bounds: {e}")
+        # Tier 2 / Tier 3 controls, surfaced under "Advanced settings". These
+        # are common across most GenICam devices but vary by model, so each is
+        # included only when the device actually implements it.
+        for key, feature, kind, unit in ADVANCED_DEVICE_FEATURES:
+            entry = self._read_feature_entry(feature, kind, unit)
+            if entry:
+                entry["advanced"] = True
+                bounds[key] = entry
 
         return bounds
+
+    def _read_float_bounds(self, key, feature, unit):
+        try:
+            if not self.camera.get_device().is_feature_available(feature):
+                return None
+            if key == "exposure":
+                fmin, fmax = self.camera.get_exposure_time_bounds()
+                current = self.camera.get_exposure_time()
+            else:
+                fmin, fmax = self.camera.get_gain_bounds()
+                current = self.camera.get_gain()
+            return {
+                "type": "float", "min": fmin, "max": fmax, "increment": None,
+                "current": current, "unit": unit, "options": [], "available": True,
+                "feature": feature,
+            }
+        except Exception as e:
+            logger.warning(f"Camera ID {self.camera_id}: unable to read {key} bounds: {e}")
+            return None
+
+    def _read_feature_entry(self, feature, kind, unit):
+        """Read a single GenICam feature generically. Returns None if the device
+        does not implement it (or it cannot be read)."""
+        try:
+            device = self.camera.get_device()
+            if not device.is_feature_available(feature):
+                return None
+
+            entry = {
+                "type": kind, "min": None, "max": None, "increment": None,
+                "current": None, "unit": unit, "options": [], "available": True,
+                "feature": feature,
+            }
+            if kind == "enumeration":
+                entry["current"] = device.get_string_feature_value(feature)
+                entry["options"] = list(
+                    device.dup_available_enumeration_feature_values_as_strings(feature) or []
+                )
+            elif kind == "boolean":
+                entry["current"] = device.get_boolean_feature_value(feature)
+            elif kind == "integer":
+                entry["current"] = device.get_integer_feature_value(feature)
+                try:
+                    imin, imax = device.get_integer_feature_bounds(feature)
+                    entry["min"], entry["max"] = imin, imax
+                except Exception:
+                    pass
+            elif kind == "float":
+                entry["current"] = device.get_float_feature_value(feature)
+                try:
+                    fmin, fmax = device.get_float_feature_bounds(feature)
+                    entry["min"], entry["max"] = fmin, fmax
+                except Exception:
+                    pass
+            return entry
+        except Exception as e:
+            logger.warning(f"Camera ID {self.camera_id}: unable to read feature {feature}: {e}")
+            return None
+
+    def apply_device_features(self, features):
+        """
+        Apply a batch of GenICam feature values to the live camera.
+
+        `features` is a list of {"feature": <GenICam name>, "type": <kind>,
+        "value": <value>}. Payload-affecting features (ROI / PixelFormat) cause
+        the stream to be rebuilt so subsequent captures stay consistent. Returns
+        the re-read current values so the UI can reflect what the device
+        actually accepted (values may be coerced/clamped by the device).
+        """
+        applied = {}
+        if not self.camera:
+            return applied
+
+        payload_affecting = {"Width", "Height", "OffsetX", "OffsetY", "PixelFormat"}
+        self._lock.acquire()
+        try:
+            device = self.camera.get_device()
+            # Stop acquisition before touching features that are locked while
+            # streaming (ROI, PixelFormat, etc.). Best-effort.
+            try:
+                self.camera.stop_acquisition()
+            except Exception:
+                pass
+
+            needs_stream_rebuild = False
+            for item in features:
+                feature = item.get("feature")
+                kind = item.get("type")
+                value = item.get("value")
+                if not feature:
+                    continue
+                try:
+                    if kind in ("enumeration", "string"):
+                        device.set_string_feature_value(feature, str(value))
+                    elif kind == "boolean":
+                        device.set_boolean_feature_value(feature, bool(value))
+                    elif kind == "integer":
+                        device.set_integer_feature_value(feature, int(value))
+                    elif kind == "float":
+                        device.set_float_feature_value(feature, float(value))
+                    else:
+                        logger.warning(f"Camera ID {self.camera_id}: unknown feature kind '{kind}' for {feature}")
+                        continue
+                    if feature in payload_affecting:
+                        needs_stream_rebuild = True
+                except Exception as e:
+                    logger.error(f"Camera ID {self.camera_id}: failed to set {feature}={value}: {e}")
+                    raise AravisCameraException(f"Failed to set {feature}: {e}")
+
+            if needs_stream_rebuild:
+                self.payload = self.camera.get_payload()
+                if hasattr(self, "stream"):
+                    del self.stream
+                self.stream = self.camera.create_stream(None, None)
+                self.set_buffer()
+
+            # Re-read so the caller sees the device-accepted values.
+            for item in features:
+                feature = item.get("feature")
+                kind = item.get("type")
+                try:
+                    if kind in ("enumeration", "string"):
+                        applied[feature] = device.get_string_feature_value(feature)
+                    elif kind == "boolean":
+                        applied[feature] = device.get_boolean_feature_value(feature)
+                    elif kind == "integer":
+                        applied[feature] = device.get_integer_feature_value(feature)
+                    elif kind == "float":
+                        applied[feature] = device.get_float_feature_value(feature)
+                except Exception:
+                    pass
+            return applied
+        finally:
+            self._lock.release()
 
     def connect_camera(self):
         logger.info(f"Camera ID {self.camera_id} : Connecting")
@@ -304,6 +451,29 @@ def get_camera_feature_bounds(camera_id):
         raise AravisCameraException(f"Unable to connect camera {camera_id}")
 
     return camera.get_feature_bounds()
+
+
+def apply_camera_features(camera_id, features):
+    """
+    Apply a batch of advanced GenICam feature values to a live camera and return
+    the device-accepted values. Connects on demand if the camera isn't already
+    connected.
+
+    `features` is a list of {"feature", "type", "value"}.
+    """
+    if not camera_id:
+        raise AravisCameraException("Camera ID is required")
+    if not features:
+        return {}
+
+    if camera_id not in camera_objects:
+        connect_camera(camera_id)
+
+    camera = camera_objects.get(camera_id)
+    if camera is None:
+        raise AravisCameraException(f"Unable to connect camera {camera_id}")
+
+    return camera.apply_device_features(features)
 
 def _disconnect_camera(camera_id):
     camera = camera_objects.get(camera_id)

--- a/src/backend/utils/camera_manager.py
+++ b/src/backend/utils/camera_manager.py
@@ -54,38 +54,28 @@ get_frame_lock = Lock()
 # blocking pop_buffer (and thus every preview) indefinitely.
 FRAME_POP_TIMEOUT_MARGIN_US = 5_000_000  # 5s beyond the exposure time
 
-# Tier 2 / Tier 3 GenICam controls surfaced under "Advanced settings".
-# (response_key, GenICam feature name, kind, unit). Each is included only when
-# the connected device actually implements it, so unsupported controls never
-# appear in the UI.
+# Tier 2 GenICam controls surfaced under "Advanced settings". Scoped to the
+# "safe" controls that are persisted and don't affect the stream payload /
+# pipeline. (Pixel format and ROI are intentionally excluded for now: they need
+# the GStreamer caps to track them, so they are a separate follow-up.)
+# (response_key, GenICam feature name, kind, unit).
 ADVANCED_DEVICE_FEATURES = [
-    # Tier 2 — common, conditional
     ("balanceWhiteAuto", "BalanceWhiteAuto", "enumeration", None),
     ("reverseX", "ReverseX", "boolean", None),
     ("reverseY", "ReverseY", "boolean", None),
-    # Tier 3 — supported but pipeline-affecting; the device locks these while
-    # streaming, so applying them rebuilds the stream.
-    ("pixelFormat", "PixelFormat", "enumeration", None),
-    ("width", "Width", "integer", "px"),
-    ("height", "Height", "integer", "px"),
-    ("offsetX", "OffsetX", "integer", "px"),
-    ("offsetY", "OffsetY", "integer", "px"),
 ]
 
-# Image-source-config key -> (GenICam feature, kind) for the advanced controls.
-# These are applied inside start_acquisition (acquisition stopped, immediately
-# before the grab) — the same path gain/exposure use — so they reliably affect
-# the captured frame instead of being written out-of-band.
+# Image-source-config advancedSettings key -> (GenICam feature, kind) for the
+# controls applied inside start_acquisition (the same path gain/exposure use),
+# so they reliably affect the captured frame and the persisted profile applies
+# in preview, capture and workflow alike.
 CONFIG_FEATURE_MAP = {
     "reverseX": ("ReverseX", "boolean"),
     "reverseY": ("ReverseY", "boolean"),
     "balanceWhiteAuto": ("BalanceWhiteAuto", "enumeration"),
-    "pixelFormat": ("PixelFormat", "enumeration"),
-    "width": ("Width", "integer"),
-    "height": ("Height", "integer"),
-    "offsetX": ("OffsetX", "integer"),
-    "offsetY": ("OffsetY", "integer"),
 }
+# None of the currently-supported safe controls change the payload; kept for
+# when pixel format / ROI are added back.
 PAYLOAD_AFFECTING_FEATURES = {"Width", "Height", "OffsetX", "OffsetY", "PixelFormat"}
 
 class Camera():
@@ -381,13 +371,15 @@ class Camera():
         self.stream.push_buffer(Aravis.Buffer.new_allocate(self.payload))
 
     def _apply_config_features(self, config):
-        """Apply advanced GenICam controls present in the image-source config to
-        the device. Returns True if a payload-affecting feature (ROI / pixel
-        format) changed, so the caller can rebuild the stream. Only writes a
-        feature when its value actually changes, so per-frame previews don't
-        rewrite (and rebuild the stream) every grab. Must be called with
-        self._lock held and acquisition stopped."""
+        """Apply advanced GenICam controls from config['advancedSettings'] to the
+        device. Returns True if a payload-affecting feature changed (so the
+        caller can rebuild the stream). Only writes a feature when its value
+        actually changes, so per-frame previews don't rewrite each grab. Must be
+        called with self._lock held and acquisition stopped."""
         if not self.camera or not config:
+            return False
+        advanced = config.get("advancedSettings") or {}
+        if not advanced:
             return False
         applied = getattr(self, "_applied_features", None)
         if applied is None:
@@ -396,9 +388,9 @@ class Camera():
         device = self.camera.get_device()
         payload_changed = False
         for key, (feature, kind) in CONFIG_FEATURE_MAP.items():
-            if key not in config or config.get(key) is None:
+            if key not in advanced or advanced.get(key) is None:
                 continue
-            value = config.get(key)
+            value = advanced.get(key)
             if applied.get(key) == value:
                 continue  # already applied; skip redundant write / stream rebuild
             try:

--- a/src/backend/utils/camera_manager.py
+++ b/src/backend/utils/camera_manager.py
@@ -49,6 +49,11 @@ from threading import Lock
 
 get_frame_lock = Lock()
 
+# Upper bound for how long to wait for a single frame before giving up, on top
+# of the configured exposure time. Prevents a stalled USB/GenICam transfer from
+# blocking pop_buffer (and thus every preview) indefinitely.
+FRAME_POP_TIMEOUT_MARGIN_US = 5_000_000  # 5s beyond the exposure time
+
 # Tier 2 / Tier 3 GenICam controls surfaced under "Advanced settings".
 # (response_key, GenICam feature name, kind, unit). Each is included only when
 # the connected device actually implements it, so unsupported controls never
@@ -379,7 +384,20 @@ class Camera():
         self._lock.acquire()
         with Timer(metric_name="CameraGetFrameTime"):
             self.camera.software_trigger()
-            arv_buffer = self.stream.pop_buffer()
+            # Bound the wait so a stalled transfer can't hang the request (and,
+            # via get_frame_lock, every subsequent preview) forever.
+            timeout_us = int((getattr(self, "exposure", 0) or 0) + FRAME_POP_TIMEOUT_MARGIN_US)
+            arv_buffer = self.stream.timeout_pop_buffer(timeout_us)
+            if arv_buffer is None:
+                logger.error(
+                    f"Camera ID {self.camera_id} : Timed out after {timeout_us} us waiting for a frame"
+                )
+                self.update_camera_status(
+                    CameraStatusEnum.DISCONNECTED,
+                    "Timed out waiting for a frame from the camera",
+                )
+                self._lock.release()
+                return pickle.dumps(None)
             self.set_buffer()
             if arv_buffer.get_status() != Aravis.BufferStatus.SUCCESS:
                 logger.error(f"Camera ID {self.camera_id} : Failed to get frame")

--- a/src/backend/utils/camera_manager.py
+++ b/src/backend/utils/camera_manager.py
@@ -534,20 +534,18 @@ def connect_camera(camera_id):
 def get_camera_feature_bounds(camera_id):
     """
     Return the adjustable feature ranges for a camera, read from its GenICam
-    feature map. Uses the existing connection if the camera is already
-    connected (e.g. while editing image settings); otherwise connects on demand
-    using the same path as preview/capture.
+    feature map. Reads only from an existing connection — it never opens/claims
+    the camera itself, because doing so makes a subsequent connect (which opens
+    the device to verify it) fail with LIBUSB_ERROR_BUSY. If the camera isn't
+    connected, returns an empty dict so the UI falls back to defaults /
+    read-only until the user connects.
     """
     if not camera_id:
         raise AravisCameraException("Camera ID is required")
 
-    if camera_id not in camera_objects:
-        # Raises AravisCameraException if the camera cannot be reached.
-        connect_camera(camera_id)
-
     camera = camera_objects.get(camera_id)
     if camera is None:
-        raise AravisCameraException(f"Unable to connect camera {camera_id}")
+        return {}
 
     return camera.get_feature_bounds()
 

--- a/src/backend/utils/camera_manager.py
+++ b/src/backend/utils/camera_manager.py
@@ -138,24 +138,32 @@ class Camera():
         if not self.camera:
             return bounds
 
-        # Primary controls (always shown when supported).
-        for key, feature, unit in [
-            ("exposure", "ExposureTime", "us"),
-            ("gain", "Gain", None),
-        ]:
-            entry = self._read_float_bounds(key, feature, unit)
-            if entry:
-                entry["advanced"] = False
-                bounds[key] = entry
+        # Serialize with acquisition (start/get_frame/stop all take this lock).
+        # Reading GenICam registers on the shared camera concurrently with a
+        # frame grab corrupts the libaravis/libusb channel and can wedge
+        # pop_buffer, so feature reads must not overlap acquisition.
+        self._lock.acquire()
+        try:
+            # Primary controls (always shown when supported).
+            for key, feature, unit in [
+                ("exposure", "ExposureTime", "us"),
+                ("gain", "Gain", None),
+            ]:
+                entry = self._read_float_bounds(key, feature, unit)
+                if entry:
+                    entry["advanced"] = False
+                    bounds[key] = entry
 
-        # Tier 2 / Tier 3 controls, surfaced under "Advanced settings". These
-        # are common across most GenICam devices but vary by model, so each is
-        # included only when the device actually implements it.
-        for key, feature, kind, unit in ADVANCED_DEVICE_FEATURES:
-            entry = self._read_feature_entry(feature, kind, unit)
-            if entry:
-                entry["advanced"] = True
-                bounds[key] = entry
+            # Tier 2 / Tier 3 controls, surfaced under "Advanced settings". These
+            # are common across most GenICam devices but vary by model, so each is
+            # included only when the device actually implements it.
+            for key, feature, kind, unit in ADVANCED_DEVICE_FEATURES:
+                entry = self._read_feature_entry(feature, kind, unit)
+                if entry:
+                    entry["advanced"] = True
+                    bounds[key] = entry
+        finally:
+            self._lock.release()
 
         return bounds
 

--- a/src/backend/utils/camera_manager.py
+++ b/src/backend/utils/camera_manager.py
@@ -92,7 +92,60 @@ class Camera():
 
     def get_camera_id(self):
         return self.camera_id
-        
+
+    def get_feature_bounds(self):
+        """
+        Read adjustable feature ranges directly from the camera's GenICam
+        feature map (the device "XML"), so the UI can present limits that match
+        the actual hardware instead of hard-coded defaults.
+
+        Returns a dict keyed by feature name. Each entry describes the feature
+        generically so new controls can be surfaced without changing the shape:
+            {
+              "type": "float" | "integer" | "enumeration" | "boolean",
+              "min": <number|None>, "max": <number|None>,
+              "increment": <number|None>,
+              "current": <value|None>,
+              "unit": <str|None>,
+              "options": [<str>, ...]   # enumeration only
+            }
+        Exposure time is reported in microseconds (Aravis' native unit and the
+        unit stored for USB3Vision cameras).
+        """
+        bounds = {}
+        if not self.camera:
+            return bounds
+
+        # (feature_name, kind, unit) for the controls that are common across
+        # most GenICam (USB3Vision / GigE Vision) devices. Unsupported features
+        # are skipped silently so this works across vendors/models.
+        float_features = [
+            ("exposure", "ExposureTime", "us"),
+            ("gain", "Gain", None),
+        ]
+
+        for key, _feature, unit in float_features:
+            try:
+                if key == "exposure":
+                    fmin, fmax = self.camera.get_exposure_time_bounds()
+                    current = self.camera.get_exposure_time()
+                else:  # gain
+                    fmin, fmax = self.camera.get_gain_bounds()
+                    current = self.camera.get_gain()
+                bounds[key] = {
+                    "type": "float",
+                    "min": fmin,
+                    "max": fmax,
+                    "increment": None,
+                    "current": current,
+                    "unit": unit,
+                    "options": [],
+                }
+            except Exception as e:
+                logger.warning(f"Camera ID {self.camera_id}: unable to read {key} bounds: {e}")
+
+        return bounds
+
     def connect_camera(self):
         logger.info(f"Camera ID {self.camera_id} : Connecting")
         try:
@@ -230,6 +283,27 @@ def connect_camera(camera_id):
     else: # Connection Failed
         disconnect_camera(camera_id)
         raise AravisCameraException(camera_status.error)
+
+
+def get_camera_feature_bounds(camera_id):
+    """
+    Return the adjustable feature ranges for a camera, read from its GenICam
+    feature map. Uses the existing connection if the camera is already
+    connected (e.g. while editing image settings); otherwise connects on demand
+    using the same path as preview/capture.
+    """
+    if not camera_id:
+        raise AravisCameraException("Camera ID is required")
+
+    if camera_id not in camera_objects:
+        # Raises AravisCameraException if the camera cannot be reached.
+        connect_camera(camera_id)
+
+    camera = camera_objects.get(camera_id)
+    if camera is None:
+        raise AravisCameraException(f"Unable to connect camera {camera_id}")
+
+    return camera.get_feature_bounds()
 
 def _disconnect_camera(camera_id):
     camera = camera_objects.get(camera_id)

--- a/src/backend/utils/camera_manager.py
+++ b/src/backend/utils/camera_manager.py
@@ -72,6 +72,22 @@ ADVANCED_DEVICE_FEATURES = [
     ("offsetY", "OffsetY", "integer", "px"),
 ]
 
+# Image-source-config key -> (GenICam feature, kind) for the advanced controls.
+# These are applied inside start_acquisition (acquisition stopped, immediately
+# before the grab) — the same path gain/exposure use — so they reliably affect
+# the captured frame instead of being written out-of-band.
+CONFIG_FEATURE_MAP = {
+    "reverseX": ("ReverseX", "boolean"),
+    "reverseY": ("ReverseY", "boolean"),
+    "balanceWhiteAuto": ("BalanceWhiteAuto", "enumeration"),
+    "pixelFormat": ("PixelFormat", "enumeration"),
+    "width": ("Width", "integer"),
+    "height": ("Height", "integer"),
+    "offsetX": ("OffsetX", "integer"),
+    "offsetY": ("OffsetY", "integer"),
+}
+PAYLOAD_AFFECTING_FEATURES = {"Width", "Height", "OffsetX", "OffsetY", "PixelFormat"}
+
 class Camera():
     def __init__(self,camera_id):
         self.status = None
@@ -322,6 +338,15 @@ class Camera():
             logger.info(f"Camera ID {self.camera_id} : Setup camera")
             device = self.camera.get_device()
 
+            # Write feature changes straight through to the device instead of
+            # only updating Aravis' register cache. Without this, writes such as
+            # ReverseX/ReverseY/PixelFormat can read back as "set" while the
+            # sensor never actually applied them.
+            try:
+                self.camera.set_register_cache_policy(Aravis.RegisterCachePolicy.DISABLE)
+            except Exception as e:
+                logger.warning(f"Camera ID {self.camera_id} : could not disable register cache: {e}")
+
             # TODO: This is ideal settings but didnt work with zebra cameras.
             # device.set_string_feature_value("TriggerMode", "On")
             # device.set_string_feature_value("TriggerSelector", "FrameStart")
@@ -355,6 +380,44 @@ class Camera():
     def set_buffer(self):
         self.stream.push_buffer(Aravis.Buffer.new_allocate(self.payload))
 
+    def _apply_config_features(self, config):
+        """Apply advanced GenICam controls present in the image-source config to
+        the device. Returns True if a payload-affecting feature (ROI / pixel
+        format) changed, so the caller can rebuild the stream. Only writes a
+        feature when its value actually changes, so per-frame previews don't
+        rewrite (and rebuild the stream) every grab. Must be called with
+        self._lock held and acquisition stopped."""
+        if not self.camera or not config:
+            return False
+        applied = getattr(self, "_applied_features", None)
+        if applied is None:
+            applied = {}
+            self._applied_features = applied
+        device = self.camera.get_device()
+        payload_changed = False
+        for key, (feature, kind) in CONFIG_FEATURE_MAP.items():
+            if key not in config or config.get(key) is None:
+                continue
+            value = config.get(key)
+            if applied.get(key) == value:
+                continue  # already applied; skip redundant write / stream rebuild
+            try:
+                if not device.is_feature_available(feature):
+                    continue
+                if kind in ("enumeration", "string"):
+                    device.set_string_feature_value(feature, str(value))
+                elif kind == "boolean":
+                    device.set_boolean_feature_value(feature, bool(value))
+                elif kind == "integer":
+                    device.set_integer_feature_value(feature, int(value))
+                applied[key] = value
+                logger.info(f"Camera ID {self.camera_id} : set {feature}={value}")
+                if feature in PAYLOAD_AFFECTING_FEATURES:
+                    payload_changed = True
+            except Exception as e:
+                logger.error(f"Camera ID {self.camera_id} : failed to set {feature}={value}: {e}")
+        return payload_changed
+
     def start_acquisition(self, image_source_config):
         # Made image_src_cfg optional for camera status check
         self._lock.acquire()
@@ -366,6 +429,16 @@ class Camera():
             self.camera.set_gain(self.gain)
             logger.info(f"setting exposure {self.exposure}")
             self.camera.set_exposure_time(self.exposure)
+            # Apply advanced GenICam controls (flip, white balance, pixel
+            # format, ROI) here, with acquisition stopped, so they actually take
+            # effect on the frame about to be grabbed. Rebuild the stream if a
+            # payload-affecting feature (ROI / pixel format) changed.
+            if self._apply_config_features(image_source_config):
+                self.payload = self.camera.get_payload()
+                if hasattr(self, "stream"):
+                    del self.stream
+                self.stream = self.camera.create_stream(None, None)
+                self.set_buffer()
             logger.info(f"Camera ID {self.camera_id} : camera setup done, start acquisition")
         with Timer(metric_name="CameraStartAcquisitionTime"):
             self.camera.start_acquisition()

--- a/src/frontend/src/api/CameraAPI.ts
+++ b/src/frontend/src/api/CameraAPI.ts
@@ -46,9 +46,14 @@ export interface CameraFeatureBound {
   min: number | null;
   max: number | null;
   increment: number | null;
-  current: number | null;
+  current: number | string | boolean | null;
   unit: string | null;
   options: string[];
+  available?: boolean;
+  // True for Tier 2/3 controls that belong under "Advanced settings".
+  advanced?: boolean;
+  // GenICam feature name, echoed back when applying a change.
+  feature?: string;
 }
 
 export interface CameraFeatureBounds {
@@ -65,5 +70,28 @@ export async function getCameraFeatureBounds(
     cameraId,
   );
   const { data } = await axios.get<CameraFeatureBounds>(endpoint);
+  return data;
+}
+
+export interface ApplyCameraFeature {
+  feature: string;
+  type: CameraFeatureBound["type"];
+  value: number | string | boolean;
+}
+
+/**
+ * Apply advanced GenICam feature values (white balance, flip, pixel format,
+ * ROI, ...) to the live camera. Returns the device-accepted values keyed by
+ * GenICam feature name (the device may clamp/coerce them).
+ */
+export async function applyCameraFeatures(
+  cameraId: string,
+  features: ApplyCameraFeature[],
+): Promise<Record<string, number | string | boolean>> {
+  const endpoint = APIList.cameraFeaturesAPI.replace("{camera_id}", cameraId);
+  const { data } = await axios.post<Record<string, number | string | boolean>>(
+    endpoint,
+    { features },
+  );
   return data;
 }

--- a/src/frontend/src/api/CameraAPI.ts
+++ b/src/frontend/src/api/CameraAPI.ts
@@ -35,3 +35,35 @@ export async function disconnectCamera(cameraId: string) {
   const endpoint = `${APIList.camerasAPI}/${cameraId}/disconnect`;
   await axios.get<Camera[]>(endpoint);
 }
+
+/**
+ * A single adjustable camera feature, described generically so new controls
+ * (read from the device's GenICam feature map) can be surfaced without
+ * changing the response shape. Exposure time is reported in microseconds.
+ */
+export interface CameraFeatureBound {
+  type: "float" | "integer" | "enumeration" | "boolean";
+  min: number | null;
+  max: number | null;
+  increment: number | null;
+  current: number | null;
+  unit: string | null;
+  options: string[];
+}
+
+export interface CameraFeatureBounds {
+  gain?: CameraFeatureBound;
+  exposure?: CameraFeatureBound;
+  [feature: string]: CameraFeatureBound | undefined;
+}
+
+export async function getCameraFeatureBounds(
+  cameraId: string,
+): Promise<CameraFeatureBounds> {
+  const endpoint = APIList.cameraFeatureBoundsAPI.replace(
+    "{camera_id}",
+    cameraId,
+  );
+  const { data } = await axios.get<CameraFeatureBounds>(endpoint);
+  return data;
+}

--- a/src/frontend/src/components/form/FormSliderInput.tsx
+++ b/src/frontend/src/components/form/FormSliderInput.tsx
@@ -79,6 +79,7 @@ export default function FormSliderInput({
           <Slider
             min={props.min}
             max={props.max}
+            disabled={props.disabled}
             value={sliderValue}
             onChange={(newValue) => {
               onValueChange(newValue as number);

--- a/src/frontend/src/components/image-settings/EditImageSettings.tsx
+++ b/src/frontend/src/components/image-settings/EditImageSettings.tsx
@@ -36,6 +36,7 @@ import { NoCrop } from "../image-source/roi/RoIAnnotationImage";
 import { isArvisCameraImageSource, setHashValuesInUrl } from "components/utils";
 import { DynamicRouterHashKey } from "components/layout/constants";
 import { DEFAULT_SETTINGS_BOUNDS, toSettingsBounds } from "./bounds";
+import { buildAdvancedSettings } from "./advancedFeatures";
 
 export default function EditImageSettings(): JSX.Element {
   const navigate = useNavigate();
@@ -109,16 +110,19 @@ export default function EditImageSettings(): JSX.Element {
 
   const editMutation = useMutation({
     mutationFn: (values: SchemaType) => {
-      // NOTE: advanced device controls (flip, white balance, pixel format, ROI)
-      // are applied live through the preview/capture config and are not yet
-      // persisted to the image-source profile (the DB has no columns for them;
-      // persistence is a follow-up requiring a migration). Sending them here
-      // would 500 in the persistence layer, so they are intentionally omitted.
+      // Advanced controls (flip, white balance) are persisted under
+      // advancedSettings and applied on the acquisition path (preview, capture
+      // and workflow). Pixel format / ROI remain out of scope.
+      const advancedSettings = buildAdvancedSettings(
+        boundsQuery.data,
+        form.getValues() as Record<string, any>,
+      );
       const imageSourceConfiguration: ImageSourceConfiguration = {
         gain: values.editGain,
         exposure: values.editExposure,
         processingPipeline: values.editGstreamerPipeline,
         imageCrop: cropSettings,
+        ...(advancedSettings ? { advancedSettings } : {}),
       };
 
       return editImageSource(imageSourceId, {
@@ -217,6 +221,7 @@ export default function EditImageSettings(): JSX.Element {
             formIsValid={form.formState.isValid}
             settingsBounds={settingsBounds}
             cameraFeatureBounds={boundsQuery.data}
+            savedAdvanced={getQuery.data?.imageSourceConfiguration?.advancedSettings}
           />
         </form>
       </FormProvider>

--- a/src/frontend/src/components/image-settings/EditImageSettings.tsx
+++ b/src/frontend/src/components/image-settings/EditImageSettings.tsx
@@ -205,6 +205,7 @@ export default function EditImageSettings(): JSX.Element {
             recheckCameraStatusFn={getQuery.refetch}
             formIsValid={form.formState.isValid}
             settingsBounds={settingsBounds}
+            cameraFeatureBounds={boundsQuery.data}
           />
         </form>
       </FormProvider>

--- a/src/frontend/src/components/image-settings/EditImageSettings.tsx
+++ b/src/frontend/src/components/image-settings/EditImageSettings.tsx
@@ -36,7 +36,6 @@ import { NoCrop } from "../image-source/roi/RoIAnnotationImage";
 import { isArvisCameraImageSource, setHashValuesInUrl } from "components/utils";
 import { DynamicRouterHashKey } from "components/layout/constants";
 import { DEFAULT_SETTINGS_BOUNDS, toSettingsBounds } from "./bounds";
-import { buildAdvancedConfig } from "./advancedFeatures";
 
 export default function EditImageSettings(): JSX.Element {
   const navigate = useNavigate();
@@ -110,12 +109,16 @@ export default function EditImageSettings(): JSX.Element {
 
   const editMutation = useMutation({
     mutationFn: (values: SchemaType) => {
+      // NOTE: advanced device controls (flip, white balance, pixel format, ROI)
+      // are applied live through the preview/capture config and are not yet
+      // persisted to the image-source profile (the DB has no columns for them;
+      // persistence is a follow-up requiring a migration). Sending them here
+      // would 500 in the persistence layer, so they are intentionally omitted.
       const imageSourceConfiguration: ImageSourceConfiguration = {
         gain: values.editGain,
         exposure: values.editExposure,
         processingPipeline: values.editGstreamerPipeline,
         imageCrop: cropSettings,
-        ...buildAdvancedConfig(boundsQuery.data, form.getValues() as Record<string, any>),
       };
 
       return editImageSource(imageSourceId, {

--- a/src/frontend/src/components/image-settings/EditImageSettings.tsx
+++ b/src/frontend/src/components/image-settings/EditImageSettings.tsx
@@ -19,11 +19,12 @@ import { FormProvider, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { Button, ContentLayout, Header } from "@cloudscape-design/components";
-import { schema, SchemaType } from "./edit/schema";
+import { makeSchema, SchemaType } from "./edit/schema";
 import * as React from "react";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { editImageSource, getImageSource } from "../../api/ImageSourceAPI";
+import { getCameraFeatureBounds } from "../../api/CameraAPI";
 import {
   ImageSourceConfiguration,
   RegionOfInterest,
@@ -33,6 +34,7 @@ import EditImageSettingsPage from "./EditImageSettingsPage";
 import { NoCrop } from "../image-source/roi/RoIAnnotationImage";
 import { isArvisCameraImageSource, setHashValuesInUrl } from "components/utils";
 import { DynamicRouterHashKey } from "components/layout/constants";
+import { DEFAULT_SETTINGS_BOUNDS, toSettingsBounds } from "./bounds";
 
 export default function EditImageSettings(): JSX.Element {
   const navigate = useNavigate();
@@ -48,6 +50,41 @@ export default function EditImageSettings(): JSX.Element {
   });
 
   const imgSrcName = getQuery.data?.name || "";
+
+  const isArvisCamera = isArvisCameraImageSource(getQuery.data?.type || "");
+  const cameraId = getQuery.data?.cameraId || "";
+
+  // Pull the gain/exposure ranges from the camera's GenICam feature map so the
+  // sliders and validation match the actual hardware. Only meaningful for
+  // Aravis (USB3Vision/GigE) cameras; other sources fall back to constants.
+  const boundsQuery = useQuery({
+    queryKey: ["cameraFeatureBounds", cameraId],
+    queryFn: () => getCameraFeatureBounds(cameraId),
+    enabled: isArvisCamera && !!cameraId,
+    retry: 1,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const settingsBounds = useMemo(
+    () =>
+      isArvisCamera
+        ? toSettingsBounds(boundsQuery.data)
+        : DEFAULT_SETTINGS_BOUNDS,
+    [isArvisCamera, boundsQuery.data],
+  );
+
+  const resolver = useMemo(
+    () =>
+      yupResolver(
+        makeSchema({
+          gainMin: settingsBounds.gainMin,
+          gainMax: settingsBounds.gainMax,
+          exposureMin: settingsBounds.exposureMin,
+          exposureMax: settingsBounds.exposureMax,
+        }),
+      ),
+    [settingsBounds],
+  );
 
   useEffect(() => {
     const nextHash = setHashValuesInUrl(hash.substring(1), {
@@ -117,7 +154,7 @@ export default function EditImageSettings(): JSX.Element {
   });
 
   const form = useForm({
-    resolver: yupResolver(schema),
+    resolver,
     mode: "onBlur",
     values: {
       editGain: getQuery.data?.imageSourceConfiguration.gain ?? 0,
@@ -126,6 +163,15 @@ export default function EditImageSettings(): JSX.Element {
         getQuery.data?.imageSourceConfiguration.processingPipeline ?? "",
     },
   });
+
+  // When the device bounds arrive after first render, re-run validation so the
+  // form validity reflects the camera's real limits (using the latest resolver).
+  useEffect(() => {
+    if (boundsQuery.data) {
+      form.trigger();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settingsBounds]);
   const [initialGstreamerPipeline, setInitialGstreamerPipeline] = useState("");
 
   useEffect(() => {
@@ -153,11 +199,12 @@ export default function EditImageSettings(): JSX.Element {
             cropSettings={cropSettings}
             initialPipelineString={initialGstreamerPipeline ?? ""}
             isLoading={getQuery.isLoading}
-            isArvisCamera={isArvisCameraImageSource(getQuery.data?.type || "")}
+            isArvisCamera={isArvisCamera}
             cameraStatus={getQuery.data?.cameraStatus?.status}
-            cameraId={getQuery.data?.cameraId || ""}
+            cameraId={cameraId}
             recheckCameraStatusFn={getQuery.refetch}
             formIsValid={form.formState.isValid}
+            settingsBounds={settingsBounds}
           />
         </form>
       </FormProvider>

--- a/src/frontend/src/components/image-settings/EditImageSettings.tsx
+++ b/src/frontend/src/components/image-settings/EditImageSettings.tsx
@@ -26,6 +26,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { editImageSource, getImageSource } from "../../api/ImageSourceAPI";
 import { getCameraFeatureBounds } from "../../api/CameraAPI";
 import {
+  CameraStatus,
   ImageSourceConfiguration,
   RegionOfInterest,
 } from "../image-source/types";
@@ -54,14 +55,19 @@ export default function EditImageSettings(): JSX.Element {
 
   const isArvisCamera = isArvisCameraImageSource(getQuery.data?.type || "");
   const cameraId = getQuery.data?.cameraId || "";
+  const cameraConnected =
+    getQuery.data?.cameraStatus?.status === CameraStatus.Connected;
 
   // Pull the gain/exposure ranges from the camera's GenICam feature map so the
   // sliders and validation match the actual hardware. Only meaningful for
-  // Aravis (USB3Vision/GigE) cameras; other sources fall back to constants.
+  // Aravis (USB3Vision/GigE) cameras, and only when the camera is already
+  // connected — reading bounds must not claim the camera (that would make a
+  // later connect fail with LIBUSB_ERROR_BUSY). Falls back to constants
+  // otherwise.
   const boundsQuery = useQuery({
     queryKey: ["cameraFeatureBounds", cameraId],
     queryFn: () => getCameraFeatureBounds(cameraId),
-    enabled: isArvisCamera && !!cameraId,
+    enabled: isArvisCamera && !!cameraId && cameraConnected,
     retry: 1,
     staleTime: 5 * 60 * 1000,
   });

--- a/src/frontend/src/components/image-settings/EditImageSettings.tsx
+++ b/src/frontend/src/components/image-settings/EditImageSettings.tsx
@@ -35,6 +35,7 @@ import { NoCrop } from "../image-source/roi/RoIAnnotationImage";
 import { isArvisCameraImageSource, setHashValuesInUrl } from "components/utils";
 import { DynamicRouterHashKey } from "components/layout/constants";
 import { DEFAULT_SETTINGS_BOUNDS, toSettingsBounds } from "./bounds";
+import { buildAdvancedConfig } from "./advancedFeatures";
 
 export default function EditImageSettings(): JSX.Element {
   const navigate = useNavigate();
@@ -108,6 +109,7 @@ export default function EditImageSettings(): JSX.Element {
         exposure: values.editExposure,
         processingPipeline: values.editGstreamerPipeline,
         imageCrop: cropSettings,
+        ...buildAdvancedConfig(boundsQuery.data, form.getValues() as Record<string, any>),
       };
 
       return editImageSource(imageSourceId, {

--- a/src/frontend/src/components/image-settings/EditImageSettingsPage.tsx
+++ b/src/frontend/src/components/image-settings/EditImageSettingsPage.tsx
@@ -18,6 +18,7 @@
 import { useWatch } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import {
+  Alert,
   Button,
   Container,
   Form,
@@ -77,6 +78,7 @@ export default function EditImageSettingsPage(
   // For non-Arvis cameras (like Nvidia CSI), only check form validity
   // For Arvis cameras, check both form validity and camera connection status
   const isSaveDisabled = !props.formIsValid || (props.isArvisCamera && props.cameraStatus !== CameraStatus.Connected);
+  const isReadOnly = props.isArvisCamera && props.cameraStatus !== CameraStatus.Connected;
   
   console.log('Save button disabled:', isSaveDisabled, 'Reason:', {
     formInvalid: !props.formIsValid,
@@ -197,15 +199,26 @@ export default function EditImageSettingsPage(
           }
         >
           <Grid gridDefinition={[{ colspan: 3 }, { colspan: 9 }]}>
-            <EditImageSettingsPane
-              initialPipelineString={initialPipelineValue}
-              setGstreamerPipelineToDownload={(newPipeline: string): void =>
-                setGstreamerPipelineToDownload(newPipeline)
-              }
-              settingsBounds={props.settingsBounds}
-              cameraId={props.isArvisCamera ? props.cameraId : undefined}
-              cameraFeatureBounds={props.cameraFeatureBounds}
-            />
+            <SpaceBetween size="m">
+              {isReadOnly ? (
+                <Alert type="info" header="Read-only">
+                  This camera isn't connected, so settings are read-only. It may
+                  be powered off, on a non-SuperSpeed link, or in use by another
+                  station or process. Connect to the camera to preview and save
+                  changes.
+                </Alert>
+              ) : null}
+              <EditImageSettingsPane
+                initialPipelineString={initialPipelineValue}
+                setGstreamerPipelineToDownload={(newPipeline: string): void =>
+                  setGstreamerPipelineToDownload(newPipeline)
+                }
+                settingsBounds={props.settingsBounds}
+                cameraId={props.isArvisCamera ? props.cameraId : undefined}
+                cameraFeatureBounds={props.cameraFeatureBounds}
+                readOnly={isReadOnly}
+              />
+            </SpaceBetween>
             <Container header={<Header variant={"h1"}>Image preview</Header>}>
               {editImageContent}
             </Container>

--- a/src/frontend/src/components/image-settings/EditImageSettingsPage.tsx
+++ b/src/frontend/src/components/image-settings/EditImageSettingsPage.tsx
@@ -43,6 +43,7 @@ import ImagePlaceholder from "components/common/ImagePlaceholder";
 import { CameraDisconnectedContent } from "components/common/ImagePlaceholder/PresetPlaceholderContents";
 import useCameraConnection from "components/hook/useCameraConnection";
 import { SettingsBounds } from "./bounds";
+import { CameraFeatureBounds } from "../../api/CameraAPI";
 
 type EditImageSettingsPageProps = {
   id: string;
@@ -55,6 +56,7 @@ type EditImageSettingsPageProps = {
   recheckCameraStatusFn: () => void;
   formIsValid: boolean;
   settingsBounds: SettingsBounds;
+  cameraFeatureBounds?: CameraFeatureBounds;
 };
 
 export default function EditImageSettingsPage(
@@ -195,6 +197,8 @@ export default function EditImageSettingsPage(
                 setGstreamerPipelineToDownload(newPipeline)
               }
               settingsBounds={props.settingsBounds}
+              cameraId={props.isArvisCamera ? props.cameraId : undefined}
+              cameraFeatureBounds={props.cameraFeatureBounds}
             />
             <Container header={<Header variant={"h1"}>Image preview</Header>}>
               {editImageContent}

--- a/src/frontend/src/components/image-settings/EditImageSettingsPage.tsx
+++ b/src/frontend/src/components/image-settings/EditImageSettingsPage.tsx
@@ -42,6 +42,7 @@ import { CameraStatus, RegionOfInterest } from "../image-source/types";
 import ImagePlaceholder from "components/common/ImagePlaceholder";
 import { CameraDisconnectedContent } from "components/common/ImagePlaceholder/PresetPlaceholderContents";
 import useCameraConnection from "components/hook/useCameraConnection";
+import { SettingsBounds } from "./bounds";
 
 type EditImageSettingsPageProps = {
   id: string;
@@ -53,6 +54,7 @@ type EditImageSettingsPageProps = {
   cameraId: string;
   recheckCameraStatusFn: () => void;
   formIsValid: boolean;
+  settingsBounds: SettingsBounds;
 };
 
 export default function EditImageSettingsPage(
@@ -192,6 +194,7 @@ export default function EditImageSettingsPage(
               setGstreamerPipelineToDownload={(newPipeline: string): void =>
                 setGstreamerPipelineToDownload(newPipeline)
               }
+              settingsBounds={props.settingsBounds}
             />
             <Container header={<Header variant={"h1"}>Image preview</Header>}>
               {editImageContent}

--- a/src/frontend/src/components/image-settings/EditImageSettingsPage.tsx
+++ b/src/frontend/src/components/image-settings/EditImageSettingsPage.tsx
@@ -45,7 +45,8 @@ import { CameraDisconnectedContent } from "components/common/ImagePlaceholder/Pr
 import useCameraConnection from "components/hook/useCameraConnection";
 import { SettingsBounds } from "./bounds";
 import { CameraFeatureBounds } from "../../api/CameraAPI";
-import { buildAdvancedConfig } from "./advancedFeatures";
+import { AdvancedCameraSettings } from "../image-source/types";
+import { buildAdvancedSettings } from "./advancedFeatures";
 
 type EditImageSettingsPageProps = {
   id: string;
@@ -59,6 +60,7 @@ type EditImageSettingsPageProps = {
   formIsValid: boolean;
   settingsBounds: SettingsBounds;
   cameraFeatureBounds?: CameraFeatureBounds;
+  savedAdvanced?: AdvancedCameraSettings;
 };
 
 export default function EditImageSettingsPage(
@@ -113,7 +115,7 @@ export default function EditImageSettingsPage(
         values.editExposure &&
         values.editGstreamerPipeline
       ) {
-        const advancedConfig = buildAdvancedConfig(
+        const advancedSettings = buildAdvancedSettings(
           props.cameraFeatureBounds,
           values as Record<string, any>,
         );
@@ -123,7 +125,7 @@ export default function EditImageSettingsPage(
             exposure: values.editExposure,
             processingPipeline: gstreamerPipelineToDownload,
             imageCrop: props.cropSettings,
-            ...advancedConfig,
+            ...(advancedSettings ? { advancedSettings } : {}),
           },
         });
       }
@@ -216,6 +218,7 @@ export default function EditImageSettingsPage(
                 settingsBounds={props.settingsBounds}
                 cameraId={props.isArvisCamera ? props.cameraId : undefined}
                 cameraFeatureBounds={props.cameraFeatureBounds}
+                savedAdvanced={props.savedAdvanced}
                 readOnly={isReadOnly}
               />
             </SpaceBetween>

--- a/src/frontend/src/components/image-settings/EditImageSettingsPage.tsx
+++ b/src/frontend/src/components/image-settings/EditImageSettingsPage.tsx
@@ -44,6 +44,7 @@ import { CameraDisconnectedContent } from "components/common/ImagePlaceholder/Pr
 import useCameraConnection from "components/hook/useCameraConnection";
 import { SettingsBounds } from "./bounds";
 import { CameraFeatureBounds } from "../../api/CameraAPI";
+import { buildAdvancedConfig } from "./advancedFeatures";
 
 type EditImageSettingsPageProps = {
   id: string;
@@ -110,12 +111,17 @@ export default function EditImageSettingsPage(
         values.editExposure &&
         values.editGstreamerPipeline
       ) {
+        const advancedConfig = buildAdvancedConfig(
+          props.cameraFeatureBounds,
+          values as Record<string, any>,
+        );
         return await getImagePreview(props.id, {
           imageSourceConfiguration: {
             gain: values.editGain,
             exposure: values.editExposure,
             processingPipeline: gstreamerPipelineToDownload,
             imageCrop: props.cropSettings,
+            ...advancedConfig,
           },
         });
       }

--- a/src/frontend/src/components/image-settings/EditImageSettingsPane.tsx
+++ b/src/frontend/src/components/image-settings/EditImageSettingsPane.tsx
@@ -27,6 +27,7 @@ type EditImageSettingsPaneProps = {
   settingsBounds: SettingsBounds;
   cameraId?: string;
   cameraFeatureBounds?: CameraFeatureBounds;
+  readOnly?: boolean;
 };
 export default function EditImageSettingsPane(
   props: EditImageSettingsPaneProps,
@@ -37,6 +38,7 @@ export default function EditImageSettingsPane(
         <EditImageSettingsInput
           namePrefix="edit"
           settingsBounds={props.settingsBounds}
+          readOnly={props.readOnly}
         />
         <EditImageAdvancedSettingsInput
           namePrefix="edit"
@@ -44,6 +46,7 @@ export default function EditImageSettingsPane(
           setGstreamerPipelineToDownload={props.setGstreamerPipelineToDownload}
           cameraId={props.cameraId}
           cameraFeatureBounds={props.cameraFeatureBounds}
+          readOnly={props.readOnly}
         />
       </SpaceBetween>
     </>

--- a/src/frontend/src/components/image-settings/EditImageSettingsPane.tsx
+++ b/src/frontend/src/components/image-settings/EditImageSettingsPane.tsx
@@ -18,10 +18,12 @@
 import { SpaceBetween } from "@cloudscape-design/components";
 import EditImageSettingsInput from "./details-input/EditImageSettingsInput";
 import EditImageAdvancedSettingsInput from "./details-input/EditImageAdvancedSettingsInput";
+import { SettingsBounds } from "./bounds";
 
 type EditImageSettingsPaneProps = {
   initialPipelineString: string;
   setGstreamerPipelineToDownload: (newPipeline: string) => void;
+  settingsBounds: SettingsBounds;
 };
 export default function EditImageSettingsPane(
   props: EditImageSettingsPaneProps,
@@ -29,7 +31,10 @@ export default function EditImageSettingsPane(
   return (
     <>
       <SpaceBetween direction="vertical" size="l">
-        <EditImageSettingsInput namePrefix="edit" />
+        <EditImageSettingsInput
+          namePrefix="edit"
+          settingsBounds={props.settingsBounds}
+        />
         <EditImageAdvancedSettingsInput
           namePrefix="edit"
           initialPipelineString={props.initialPipelineString}

--- a/src/frontend/src/components/image-settings/EditImageSettingsPane.tsx
+++ b/src/frontend/src/components/image-settings/EditImageSettingsPane.tsx
@@ -19,11 +19,14 @@ import { SpaceBetween } from "@cloudscape-design/components";
 import EditImageSettingsInput from "./details-input/EditImageSettingsInput";
 import EditImageAdvancedSettingsInput from "./details-input/EditImageAdvancedSettingsInput";
 import { SettingsBounds } from "./bounds";
+import { CameraFeatureBounds } from "../../api/CameraAPI";
 
 type EditImageSettingsPaneProps = {
   initialPipelineString: string;
   setGstreamerPipelineToDownload: (newPipeline: string) => void;
   settingsBounds: SettingsBounds;
+  cameraId?: string;
+  cameraFeatureBounds?: CameraFeatureBounds;
 };
 export default function EditImageSettingsPane(
   props: EditImageSettingsPaneProps,
@@ -39,6 +42,8 @@ export default function EditImageSettingsPane(
           namePrefix="edit"
           initialPipelineString={props.initialPipelineString}
           setGstreamerPipelineToDownload={props.setGstreamerPipelineToDownload}
+          cameraId={props.cameraId}
+          cameraFeatureBounds={props.cameraFeatureBounds}
         />
       </SpaceBetween>
     </>

--- a/src/frontend/src/components/image-settings/EditImageSettingsPane.tsx
+++ b/src/frontend/src/components/image-settings/EditImageSettingsPane.tsx
@@ -20,6 +20,7 @@ import EditImageSettingsInput from "./details-input/EditImageSettingsInput";
 import EditImageAdvancedSettingsInput from "./details-input/EditImageAdvancedSettingsInput";
 import { SettingsBounds } from "./bounds";
 import { CameraFeatureBounds } from "../../api/CameraAPI";
+import { AdvancedCameraSettings } from "../image-source/types";
 
 type EditImageSettingsPaneProps = {
   initialPipelineString: string;
@@ -27,6 +28,7 @@ type EditImageSettingsPaneProps = {
   settingsBounds: SettingsBounds;
   cameraId?: string;
   cameraFeatureBounds?: CameraFeatureBounds;
+  savedAdvanced?: AdvancedCameraSettings;
   readOnly?: boolean;
 };
 export default function EditImageSettingsPane(
@@ -46,6 +48,7 @@ export default function EditImageSettingsPane(
           setGstreamerPipelineToDownload={props.setGstreamerPipelineToDownload}
           cameraId={props.cameraId}
           cameraFeatureBounds={props.cameraFeatureBounds}
+          savedAdvanced={props.savedAdvanced}
           readOnly={props.readOnly}
         />
       </SpaceBetween>

--- a/src/frontend/src/components/image-settings/advancedFeatures.ts
+++ b/src/frontend/src/components/image-settings/advancedFeatures.ts
@@ -37,16 +37,6 @@ const ADVANCED_FEATURE_META: AdvancedFeatureMeta[] = [
   },
   { key: "reverseX", label: "Flip horizontal" },
   { key: "reverseY", label: "Flip vertical" },
-  {
-    key: "pixelFormat",
-    label: "Pixel format",
-    description:
-      "Changing the pixel format can affect the processing pipeline and model input.",
-  },
-  { key: "width", label: "Width (px)" },
-  { key: "height", label: "Height (px)" },
-  { key: "offsetX", label: "Offset X (px)" },
-  { key: "offsetY", label: "Offset Y (px)" },
 ];
 
 export interface AdvancedFeature extends AdvancedFeatureMeta {
@@ -84,19 +74,20 @@ export function advFieldName(key: string): string {
 type FeatureValue = string | number | boolean;
 
 /**
- * Build the advanced portion of an imageSourceConfiguration from current form
- * values, keyed by the config keys the backend expects (reverseX, pixelFormat,
- * width, ...). Only includes features the connected camera supports.
+ * Build the persisted `advancedSettings` object from current form values, keyed
+ * by the config keys the backend expects (reverseX, reverseY,
+ * balanceWhiteAuto). Only includes controls the connected camera supports.
+ * Returns undefined when there is nothing to send.
  */
-export function buildAdvancedConfig(
+export function buildAdvancedSettings(
   bounds: CameraFeatureBounds | undefined,
   formValues: Record<string, any> | undefined,
-): Record<string, FeatureValue> {
+): Record<string, FeatureValue> | undefined {
+  if (!bounds || !formValues) return undefined;
   const out: Record<string, FeatureValue> = {};
-  if (!bounds || !formValues) return out;
   for (const f of getSupportedAdvancedFeatures(bounds)) {
     const v = formValues[advFieldName(f.key)];
     if (v !== undefined && v !== null && v !== "") out[f.key] = v;
   }
-  return out;
+  return Object.keys(out).length ? out : undefined;
 }

--- a/src/frontend/src/components/image-settings/advancedFeatures.ts
+++ b/src/frontend/src/components/image-settings/advancedFeatures.ts
@@ -1,0 +1,73 @@
+/*
+ *
+ * Copyright 2025 Amazon Web Services, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { CameraFeatureBound, CameraFeatureBounds } from "../../api/CameraAPI";
+
+/**
+ * Display metadata for the advanced (Tier 2 / Tier 3) device controls. The
+ * order here is the order they render in. Only features the device actually
+ * reports (and that carry the `advanced` flag) are shown, so this list can
+ * safely describe more than any single camera supports.
+ */
+interface AdvancedFeatureMeta {
+  key: string;
+  label: string;
+  description?: string;
+}
+
+const ADVANCED_FEATURE_META: AdvancedFeatureMeta[] = [
+  {
+    key: "balanceWhiteAuto",
+    label: "Auto white balance",
+    description: "Automatic white balance mode (color cameras).",
+  },
+  { key: "reverseX", label: "Flip horizontal" },
+  { key: "reverseY", label: "Flip vertical" },
+  {
+    key: "pixelFormat",
+    label: "Pixel format",
+    description:
+      "Changing the pixel format can affect the processing pipeline and model input.",
+  },
+  { key: "width", label: "Width (px)" },
+  { key: "height", label: "Height (px)" },
+  { key: "offsetX", label: "Offset X (px)" },
+  { key: "offsetY", label: "Offset Y (px)" },
+];
+
+export interface AdvancedFeature extends AdvancedFeatureMeta {
+  bound: CameraFeatureBound;
+}
+
+/**
+ * Extract the advanced controls a given camera actually supports, in display
+ * order. Returns an empty array when the camera reports none (so the section
+ * can be hidden entirely).
+ */
+export function getSupportedAdvancedFeatures(
+  bounds?: CameraFeatureBounds,
+): AdvancedFeature[] {
+  if (!bounds) return [];
+  const supported: AdvancedFeature[] = [];
+  for (const meta of ADVANCED_FEATURE_META) {
+    const bound = bounds[meta.key];
+    if (bound && bound.advanced && bound.available !== false) {
+      supported.push({ ...meta, bound });
+    }
+  }
+  return supported;
+}

--- a/src/frontend/src/components/image-settings/advancedFeatures.ts
+++ b/src/frontend/src/components/image-settings/advancedFeatures.ts
@@ -71,3 +71,32 @@ export function getSupportedAdvancedFeatures(
   }
   return supported;
 }
+
+// Advanced controls live in the same react-hook-form as gain/exposure under
+// these field names, so the preview/save include them and apply them through
+// the acquisition path (rather than a separate live-apply call).
+export const ADV_FIELD_PREFIX = "adv_";
+
+export function advFieldName(key: string): string {
+  return `${ADV_FIELD_PREFIX}${key}`;
+}
+
+type FeatureValue = string | number | boolean;
+
+/**
+ * Build the advanced portion of an imageSourceConfiguration from current form
+ * values, keyed by the config keys the backend expects (reverseX, pixelFormat,
+ * width, ...). Only includes features the connected camera supports.
+ */
+export function buildAdvancedConfig(
+  bounds: CameraFeatureBounds | undefined,
+  formValues: Record<string, any> | undefined,
+): Record<string, FeatureValue> {
+  const out: Record<string, FeatureValue> = {};
+  if (!bounds || !formValues) return out;
+  for (const f of getSupportedAdvancedFeatures(bounds)) {
+    const v = formValues[advFieldName(f.key)];
+    if (v !== undefined && v !== null && v !== "") out[f.key] = v;
+  }
+  return out;
+}

--- a/src/frontend/src/components/image-settings/bounds.ts
+++ b/src/frontend/src/components/image-settings/bounds.ts
@@ -1,0 +1,69 @@
+/*
+ *
+ * Copyright 2025 Amazon Web Services, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { CameraFeatureBounds } from "../../api/CameraAPI";
+import { EXPOSURE_MAX, EXPOSURE_MIN, GAIN_MAX, GAIN_MIN } from "./constants";
+
+/**
+ * Normalized gain/exposure ranges used by the edit-settings form. Values come
+ * from the camera's GenICam feature map when available, and fall back to the
+ * static constants (used for Nvidia CSI / ICam or when the device cannot be
+ * queried) so behavior never regresses.
+ */
+export interface SettingsBounds {
+  gainMin: number;
+  gainMax: number;
+  exposureMin: number;
+  exposureMax: number;
+  // Human-readable unit for the exposure field label.
+  exposureUnit: string;
+}
+
+export const DEFAULT_SETTINGS_BOUNDS: SettingsBounds = {
+  gainMin: GAIN_MIN,
+  gainMax: GAIN_MAX,
+  exposureMin: EXPOSURE_MIN,
+  exposureMax: EXPOSURE_MAX,
+  // The legacy constants are expressed for the Nvidia CSI path (nanoseconds).
+  exposureUnit: "nanoseconds",
+};
+
+function unitLabel(unit: string | null | undefined): string {
+  if (unit === "us") return "microseconds";
+  if (unit === "ns") return "nanoseconds";
+  return DEFAULT_SETTINGS_BOUNDS.exposureUnit;
+}
+
+/**
+ * Convert the generic device feature-bounds response into the numeric ranges
+ * the form needs. Min is rounded up and max rounded down so the slider/input
+ * (which store integers) always stay within what the hardware accepts.
+ */
+export function toSettingsBounds(data?: CameraFeatureBounds): SettingsBounds {
+  if (!data) return DEFAULT_SETTINGS_BOUNDS;
+
+  const gain = data.gain;
+  const exposure = data.exposure;
+
+  return {
+    gainMin: gain?.min != null ? Math.ceil(gain.min) : GAIN_MIN,
+    gainMax: gain?.max != null ? Math.floor(gain.max) : GAIN_MAX,
+    exposureMin: exposure?.min != null ? Math.ceil(exposure.min) : EXPOSURE_MIN,
+    exposureMax: exposure?.max != null ? Math.floor(exposure.max) : EXPOSURE_MAX,
+    exposureUnit: unitLabel(exposure?.unit),
+  };
+}

--- a/src/frontend/src/components/image-settings/details-input/AdvancedDeviceControls.tsx
+++ b/src/frontend/src/components/image-settings/details-input/AdvancedDeviceControls.tsx
@@ -26,6 +26,7 @@ import {
 import { useEffect, useMemo, useRef } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { CameraFeatureBounds } from "../../../api/CameraAPI";
+import { AdvancedCameraSettings } from "../../image-source/types";
 import {
   AdvancedFeature,
   advFieldName,
@@ -34,6 +35,7 @@ import {
 
 interface AdvancedDeviceControlsProps {
   bounds?: CameraFeatureBounds;
+  savedAdvanced?: AdvancedCameraSettings;
   readOnly?: boolean;
 }
 
@@ -47,6 +49,7 @@ interface AdvancedDeviceControlsProps {
  */
 export default function AdvancedDeviceControls({
   bounds,
+  savedAdvanced,
   readOnly,
 }: AdvancedDeviceControlsProps) {
   const { setValue, control } = useFormContext();
@@ -55,19 +58,23 @@ export default function AdvancedDeviceControls({
     [bounds],
   );
 
-  // Seed the form fields from the device-reported current values once per
-  // bounds load, so the controls reflect "what the camera is reporting".
+  // Seed the form fields once per bounds load. Use the persisted value when
+  // present, otherwise the device-reported current value.
   const seededRef = useRef<string>("");
   useEffect(() => {
     const sig = features.map((f) => f.key).join(",");
     if (!features.length || seededRef.current === sig) return;
     for (const f of features) {
-      if (f.bound.current != null) {
-        setValue(advFieldName(f.key), f.bound.current as any);
+      const saved = savedAdvanced
+        ? (savedAdvanced as Record<string, any>)[f.key]
+        : undefined;
+      const initial = saved != null ? saved : f.bound.current;
+      if (initial != null) {
+        setValue(advFieldName(f.key), initial as any);
       }
     }
     seededRef.current = sig;
-  }, [features, setValue]);
+  }, [features, savedAdvanced, setValue]);
 
   if (features.length === 0) return null;
 

--- a/src/frontend/src/components/image-settings/details-input/AdvancedDeviceControls.tsx
+++ b/src/frontend/src/components/image-settings/details-input/AdvancedDeviceControls.tsx
@@ -1,0 +1,184 @@
+/*
+ *
+ * Copyright 2025 Amazon Web Services, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import {
+  Box,
+  Button,
+  FormField,
+  Input,
+  Select,
+  SpaceBetween,
+  Toggle,
+} from "@cloudscape-design/components";
+import { useContext, useEffect, useMemo, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import {
+  ApplyCameraFeature,
+  CameraFeatureBounds,
+  applyCameraFeatures,
+} from "../../../api/CameraAPI";
+import {
+  AdvancedFeature,
+  getSupportedAdvancedFeatures,
+} from "../advancedFeatures";
+import { AppLayoutContext } from "../../layout/AppLayoutContext";
+
+type FeatureValue = string | number | boolean;
+
+interface AdvancedDeviceControlsProps {
+  cameraId: string;
+  bounds?: CameraFeatureBounds;
+}
+
+function initialValues(features: AdvancedFeature[]): Record<string, FeatureValue> {
+  const values: Record<string, FeatureValue> = {};
+  for (const f of features) {
+    if (f.bound.current != null) {
+      values[f.key] = f.bound.current as FeatureValue;
+    }
+  }
+  return values;
+}
+
+/**
+ * Renders the advanced (Tier 2 / Tier 3) GenICam controls a camera supports.
+ * Values are initialized from what the device reports when the page loads, and
+ * changes are applied to the live camera. Renders nothing when the camera
+ * reports no advanced controls.
+ */
+export default function AdvancedDeviceControls({
+  cameraId,
+  bounds,
+}: AdvancedDeviceControlsProps) {
+  const { addSuccess, addError } = useContext(AppLayoutContext);
+  const features = useMemo(
+    () => getSupportedAdvancedFeatures(bounds),
+    [bounds],
+  );
+  const [values, setValues] = useState<Record<string, FeatureValue>>(() =>
+    initialValues(features),
+  );
+
+  // Re-seed from the device whenever the reported bounds change (initial load
+  // or refetch), so controls always reflect "what the camera is reporting".
+  useEffect(() => {
+    setValues(initialValues(features));
+  }, [features]);
+
+  const applyMutation = useMutation({
+    mutationFn: () => {
+      const changed: ApplyCameraFeature[] = features
+        .filter((f) => values[f.key] !== undefined && values[f.key] !== f.bound.current)
+        .map((f) => ({
+          feature: f.bound.feature ?? f.key,
+          type: f.bound.type,
+          value: values[f.key],
+        }));
+      return applyCameraFeatures(cameraId, changed);
+    },
+    onSuccess: (applied) => {
+      // Reflect the device-accepted values (it may clamp/coerce).
+      setValues((prev) => {
+        const next = { ...prev };
+        for (const f of features) {
+          const fname = f.bound.feature ?? f.key;
+          if (applied[fname] !== undefined) next[f.key] = applied[fname];
+        }
+        return next;
+      });
+      addSuccess({ content: <>Camera settings applied.</> });
+    },
+    onError: (error: any) => {
+      addError({
+        content: (
+          <>
+            Failed to apply camera settings.{" "}
+            {error?.response?.data?.message ?? error?.message ?? ""}
+          </>
+        ),
+      });
+    },
+  });
+
+  if (features.length === 0) return null;
+
+  const setValue = (key: string, value: FeatureValue): void =>
+    setValues((prev) => ({ ...prev, [key]: value }));
+
+  return (
+    <SpaceBetween size="m">
+      <Box variant="h4">Camera controls</Box>
+      {features.map((f) => (
+        <FormField key={f.key} label={f.label} description={f.description}>
+          {renderControl(f, values[f.key], (v) => setValue(f.key, v))}
+        </FormField>
+      ))}
+      <Button
+        formAction="none"
+        variant="normal"
+        loading={applyMutation.isLoading}
+        onClick={() => applyMutation.mutate()}
+      >
+        Apply camera settings
+      </Button>
+    </SpaceBetween>
+  );
+}
+
+function renderControl(
+  feature: AdvancedFeature,
+  value: FeatureValue | undefined,
+  onChange: (value: FeatureValue) => void,
+): JSX.Element {
+  const { bound } = feature;
+
+  if (bound.type === "boolean") {
+    return (
+      <Toggle
+        checked={Boolean(value)}
+        onChange={({ detail }) => onChange(detail.checked)}
+      />
+    );
+  }
+
+  if (bound.type === "enumeration") {
+    const options = (bound.options ?? []).map((o) => ({ label: o, value: o }));
+    const selectedOption =
+      value != null ? { label: String(value), value: String(value) } : null;
+    return (
+      <Select
+        selectedOption={selectedOption}
+        options={options}
+        onChange={({ detail }) =>
+          onChange(detail.selectedOption.value as string)
+        }
+      />
+    );
+  }
+
+  // integer / float
+  return (
+    <Input
+      type="number"
+      value={value != null ? `${value}` : ""}
+      onChange={({ detail }) => {
+        const parsed = Number(detail.value);
+        if (!Number.isNaN(parsed)) onChange(parsed);
+      }}
+    />
+  );
+}

--- a/src/frontend/src/components/image-settings/details-input/AdvancedDeviceControls.tsx
+++ b/src/frontend/src/components/image-settings/details-input/AdvancedDeviceControls.tsx
@@ -34,6 +34,7 @@ import {
 
 interface AdvancedDeviceControlsProps {
   bounds?: CameraFeatureBounds;
+  readOnly?: boolean;
 }
 
 /**
@@ -46,6 +47,7 @@ interface AdvancedDeviceControlsProps {
  */
 export default function AdvancedDeviceControls({
   bounds,
+  readOnly,
 }: AdvancedDeviceControlsProps) {
   const { setValue, control } = useFormContext();
   const features = useMemo(
@@ -74,7 +76,12 @@ export default function AdvancedDeviceControls({
       <Box variant="h4">Camera controls</Box>
       {features.map((f) => (
         <FormField key={f.key} label={f.label} description={f.description}>
-          <AdvancedControl feature={f} control={control} setValue={setValue} />
+          <AdvancedControl
+            feature={f}
+            control={control}
+            setValue={setValue}
+            disabled={readOnly}
+          />
         </FormField>
       ))}
     </SpaceBetween>
@@ -85,10 +92,12 @@ function AdvancedControl({
   feature,
   control,
   setValue,
+  disabled,
 }: {
   feature: AdvancedFeature;
   control: any;
   setValue: (name: string, value: any) => void;
+  disabled?: boolean;
 }): JSX.Element {
   const name = advFieldName(feature.key);
   const value = useWatch({ control, name });
@@ -98,6 +107,7 @@ function AdvancedControl({
     return (
       <Toggle
         checked={Boolean(value)}
+        disabled={disabled}
         onChange={({ detail }) => setValue(name, detail.checked)}
       />
     );
@@ -111,6 +121,7 @@ function AdvancedControl({
       <Select
         selectedOption={selectedOption}
         options={options}
+        disabled={disabled}
         onChange={({ detail }) => setValue(name, detail.selectedOption.value)}
       />
     );
@@ -121,6 +132,7 @@ function AdvancedControl({
     <Input
       type="number"
       value={value != null ? `${value}` : ""}
+      disabled={disabled}
       onChange={({ detail }) => {
         const parsed = Number(detail.value);
         if (!Number.isNaN(parsed)) setValue(name, parsed);

--- a/src/frontend/src/components/image-settings/details-input/AdvancedDeviceControls.tsx
+++ b/src/frontend/src/components/image-settings/details-input/AdvancedDeviceControls.tsx
@@ -17,140 +17,88 @@
  */
 import {
   Box,
-  Button,
   FormField,
   Input,
   Select,
   SpaceBetween,
   Toggle,
 } from "@cloudscape-design/components";
-import { useContext, useEffect, useMemo, useState } from "react";
-import { useMutation } from "@tanstack/react-query";
-import {
-  ApplyCameraFeature,
-  CameraFeatureBounds,
-  applyCameraFeatures,
-} from "../../../api/CameraAPI";
+import { useEffect, useMemo, useRef } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
+import { CameraFeatureBounds } from "../../../api/CameraAPI";
 import {
   AdvancedFeature,
+  advFieldName,
   getSupportedAdvancedFeatures,
 } from "../advancedFeatures";
-import { AppLayoutContext } from "../../layout/AppLayoutContext";
-
-type FeatureValue = string | number | boolean;
 
 interface AdvancedDeviceControlsProps {
-  cameraId: string;
   bounds?: CameraFeatureBounds;
 }
 
-function initialValues(features: AdvancedFeature[]): Record<string, FeatureValue> {
-  const values: Record<string, FeatureValue> = {};
-  for (const f of features) {
-    if (f.bound.current != null) {
-      values[f.key] = f.bound.current as FeatureValue;
-    }
-  }
-  return values;
-}
-
 /**
- * Renders the advanced (Tier 2 / Tier 3) GenICam controls a camera supports.
- * Values are initialized from what the device reports when the page loads, and
- * changes are applied to the live camera. Renders nothing when the camera
- * reports no advanced controls.
+ * Advanced (Tier 2 / Tier 3) GenICam controls a camera supports. The controls
+ * are bound to the same form as gain/exposure, so their values flow through the
+ * preview/capture config and are applied to the device on the acquisition path
+ * (the preview updates live as they change). Initialized from what the device
+ * reports on load. Renders nothing when the camera reports no advanced
+ * controls.
  */
 export default function AdvancedDeviceControls({
-  cameraId,
   bounds,
 }: AdvancedDeviceControlsProps) {
-  const { addSuccess, addError } = useContext(AppLayoutContext);
+  const { setValue, control } = useFormContext();
   const features = useMemo(
     () => getSupportedAdvancedFeatures(bounds),
     [bounds],
   );
-  const [values, setValues] = useState<Record<string, FeatureValue>>(() =>
-    initialValues(features),
-  );
 
-  // Re-seed from the device whenever the reported bounds change (initial load
-  // or refetch), so controls always reflect "what the camera is reporting".
+  // Seed the form fields from the device-reported current values once per
+  // bounds load, so the controls reflect "what the camera is reporting".
+  const seededRef = useRef<string>("");
   useEffect(() => {
-    setValues(initialValues(features));
-  }, [features]);
-
-  const applyMutation = useMutation({
-    mutationFn: () => {
-      const changed: ApplyCameraFeature[] = features
-        .filter((f) => values[f.key] !== undefined && values[f.key] !== f.bound.current)
-        .map((f) => ({
-          feature: f.bound.feature ?? f.key,
-          type: f.bound.type,
-          value: values[f.key],
-        }));
-      return applyCameraFeatures(cameraId, changed);
-    },
-    onSuccess: (applied) => {
-      // Reflect the device-accepted values (it may clamp/coerce).
-      setValues((prev) => {
-        const next = { ...prev };
-        for (const f of features) {
-          const fname = f.bound.feature ?? f.key;
-          if (applied[fname] !== undefined) next[f.key] = applied[fname];
-        }
-        return next;
-      });
-      addSuccess({ content: <>Camera settings applied.</> });
-    },
-    onError: (error: any) => {
-      addError({
-        content: (
-          <>
-            Failed to apply camera settings.{" "}
-            {error?.response?.data?.message ?? error?.message ?? ""}
-          </>
-        ),
-      });
-    },
-  });
+    const sig = features.map((f) => f.key).join(",");
+    if (!features.length || seededRef.current === sig) return;
+    for (const f of features) {
+      if (f.bound.current != null) {
+        setValue(advFieldName(f.key), f.bound.current as any);
+      }
+    }
+    seededRef.current = sig;
+  }, [features, setValue]);
 
   if (features.length === 0) return null;
-
-  const setValue = (key: string, value: FeatureValue): void =>
-    setValues((prev) => ({ ...prev, [key]: value }));
 
   return (
     <SpaceBetween size="m">
       <Box variant="h4">Camera controls</Box>
       {features.map((f) => (
         <FormField key={f.key} label={f.label} description={f.description}>
-          {renderControl(f, values[f.key], (v) => setValue(f.key, v))}
+          <AdvancedControl feature={f} control={control} setValue={setValue} />
         </FormField>
       ))}
-      <Button
-        formAction="none"
-        variant="normal"
-        loading={applyMutation.isLoading}
-        onClick={() => applyMutation.mutate()}
-      >
-        Apply camera settings
-      </Button>
     </SpaceBetween>
   );
 }
 
-function renderControl(
-  feature: AdvancedFeature,
-  value: FeatureValue | undefined,
-  onChange: (value: FeatureValue) => void,
-): JSX.Element {
+function AdvancedControl({
+  feature,
+  control,
+  setValue,
+}: {
+  feature: AdvancedFeature;
+  control: any;
+  setValue: (name: string, value: any) => void;
+}): JSX.Element {
+  const name = advFieldName(feature.key);
+  const value = useWatch({ control, name });
   const { bound } = feature;
 
   if (bound.type === "boolean") {
     return (
       <Toggle
         checked={Boolean(value)}
-        onChange={({ detail }) => onChange(detail.checked)}
+        onChange={({ detail }) => setValue(name, detail.checked)}
       />
     );
   }
@@ -163,9 +111,7 @@ function renderControl(
       <Select
         selectedOption={selectedOption}
         options={options}
-        onChange={({ detail }) =>
-          onChange(detail.selectedOption.value as string)
-        }
+        onChange={({ detail }) => setValue(name, detail.selectedOption.value)}
       />
     );
   }
@@ -177,7 +123,7 @@ function renderControl(
       value={value != null ? `${value}` : ""}
       onChange={({ detail }) => {
         const parsed = Number(detail.value);
-        if (!Number.isNaN(parsed)) onChange(parsed);
+        if (!Number.isNaN(parsed)) setValue(name, parsed);
       }}
     />
   );

--- a/src/frontend/src/components/image-settings/details-input/EditImageAdvancedSettingsInput.tsx
+++ b/src/frontend/src/components/image-settings/details-input/EditImageAdvancedSettingsInput.tsx
@@ -102,11 +102,8 @@ export default function EditImageAdvancedSettingsInput(
             Apply
           </Button>
         </Grid>
-        {props.cameraId ? (
-          <AdvancedDeviceControls
-            cameraId={props.cameraId}
-            bounds={props.cameraFeatureBounds}
-          />
+        {props.cameraFeatureBounds ? (
+          <AdvancedDeviceControls bounds={props.cameraFeatureBounds} />
         ) : null}
       </SpaceBetween>
     </ExpandableSection>

--- a/src/frontend/src/components/image-settings/details-input/EditImageAdvancedSettingsInput.tsx
+++ b/src/frontend/src/components/image-settings/details-input/EditImageAdvancedSettingsInput.tsx
@@ -26,6 +26,8 @@ import {
 import FormTextarea from "../../form/FormTextarea";
 import { PROCESSING_PIPELINE_MAX } from "../constants";
 import { useController, useWatch } from "react-hook-form";
+import { CameraFeatureBounds } from "../../../api/CameraAPI";
+import AdvancedDeviceControls from "./AdvancedDeviceControls";
 
 interface EditImageAdvancedSettingsInputProps {
   /**
@@ -42,6 +44,15 @@ interface EditImageAdvancedSettingsInputProps {
    * @param newPipeline - the new pipeline string
    */
   setGstreamerPipelineToDownload: (newPipeline: string) => void;
+  /**
+   * Connected camera id, used to apply advanced device controls.
+   */
+  cameraId?: string;
+  /**
+   * Device feature ranges/values read from the camera's GenICam feature map.
+   * Drives the optional advanced device controls.
+   */
+  cameraFeatureBounds?: CameraFeatureBounds;
 }
 
 export default function EditImageAdvancedSettingsInput(
@@ -91,6 +102,12 @@ export default function EditImageAdvancedSettingsInput(
             Apply
           </Button>
         </Grid>
+        {props.cameraId ? (
+          <AdvancedDeviceControls
+            cameraId={props.cameraId}
+            bounds={props.cameraFeatureBounds}
+          />
+        ) : null}
       </SpaceBetween>
     </ExpandableSection>
   );

--- a/src/frontend/src/components/image-settings/details-input/EditImageAdvancedSettingsInput.tsx
+++ b/src/frontend/src/components/image-settings/details-input/EditImageAdvancedSettingsInput.tsx
@@ -27,6 +27,7 @@ import FormTextarea from "../../form/FormTextarea";
 import { PROCESSING_PIPELINE_MAX } from "../constants";
 import { useController, useWatch } from "react-hook-form";
 import { CameraFeatureBounds } from "../../../api/CameraAPI";
+import { AdvancedCameraSettings } from "../../image-source/types";
 import AdvancedDeviceControls from "./AdvancedDeviceControls";
 
 interface EditImageAdvancedSettingsInputProps {
@@ -57,6 +58,11 @@ interface EditImageAdvancedSettingsInputProps {
    * When true the camera isn't connected, so device controls are read-only.
    */
   readOnly?: boolean;
+  /**
+   * Persisted advanced settings to initialize the controls from (falls back to
+   * the device-reported current values when a control isn't in here).
+   */
+  savedAdvanced?: AdvancedCameraSettings;
 }
 
 export default function EditImageAdvancedSettingsInput(
@@ -109,6 +115,7 @@ export default function EditImageAdvancedSettingsInput(
         {props.cameraFeatureBounds ? (
           <AdvancedDeviceControls
             bounds={props.cameraFeatureBounds}
+            savedAdvanced={props.savedAdvanced}
             readOnly={props.readOnly}
           />
         ) : null}

--- a/src/frontend/src/components/image-settings/details-input/EditImageAdvancedSettingsInput.tsx
+++ b/src/frontend/src/components/image-settings/details-input/EditImageAdvancedSettingsInput.tsx
@@ -53,6 +53,10 @@ interface EditImageAdvancedSettingsInputProps {
    * Drives the optional advanced device controls.
    */
   cameraFeatureBounds?: CameraFeatureBounds;
+  /**
+   * When true the camera isn't connected, so device controls are read-only.
+   */
+  readOnly?: boolean;
 }
 
 export default function EditImageAdvancedSettingsInput(
@@ -103,7 +107,10 @@ export default function EditImageAdvancedSettingsInput(
           </Button>
         </Grid>
         {props.cameraFeatureBounds ? (
-          <AdvancedDeviceControls bounds={props.cameraFeatureBounds} />
+          <AdvancedDeviceControls
+            bounds={props.cameraFeatureBounds}
+            readOnly={props.readOnly}
+          />
         ) : null}
       </SpaceBetween>
     </ExpandableSection>

--- a/src/frontend/src/components/image-settings/details-input/EditImageSettingsInput.tsx
+++ b/src/frontend/src/components/image-settings/details-input/EditImageSettingsInput.tsx
@@ -16,11 +16,12 @@
  *
  */
 import { Container, Header, SpaceBetween } from "@cloudscape-design/components";
-import { EXPOSURE_MAX, EXPOSURE_MIN, GAIN_MAX, GAIN_MIN } from "../constants";
 import FormSliderInput from "../../form/FormSliderInput";
+import { SettingsBounds } from "../bounds";
 
 interface EditImageSettingsInputProps {
   namePrefix: string;
+  settingsBounds: SettingsBounds;
 }
 
 /**
@@ -28,24 +29,28 @@ interface EditImageSettingsInputProps {
  */
 export default function EditImageSettingsInput({
   namePrefix,
+  settingsBounds,
 }: EditImageSettingsInputProps) {
+  const { gainMin, gainMax, exposureMin, exposureMax, exposureUnit } =
+    settingsBounds;
+
   return (
     <Container header={<Header variant="h1">Image settings</Header>}>
       <SpaceBetween direction="vertical" size="l">
         <FormSliderInput
           name={namePrefix + "Gain"}
-          min={GAIN_MIN}
-          max={GAIN_MAX}
+          min={gainMin}
+          max={gainMax}
           label="Gain (Primary Brightness Control)"
-          constraintText="Adjust gain (1.0 to 10.625) to control image brightness. Higher values = brighter images."
+          constraintText={`Adjust gain (${gainMin} to ${gainMax}) to control image brightness. Higher values = brighter images.`}
         />
 
         <FormSliderInput
           name={namePrefix + "Exposure"}
-          min={EXPOSURE_MIN}
-          max={EXPOSURE_MAX}
+          min={exposureMin}
+          max={exposureMax}
           label="Exposure (Secondary Control)"
-          constraintText="Exposure time in nanoseconds (1ms to 30ms). Use gain for primary brightness adjustment."
+          constraintText={`Exposure time in ${exposureUnit} (${exposureMin} to ${exposureMax}). Use gain for primary brightness adjustment.`}
         />
       </SpaceBetween>
     </Container>

--- a/src/frontend/src/components/image-settings/details-input/EditImageSettingsInput.tsx
+++ b/src/frontend/src/components/image-settings/details-input/EditImageSettingsInput.tsx
@@ -22,6 +22,7 @@ import { SettingsBounds } from "../bounds";
 interface EditImageSettingsInputProps {
   namePrefix: string;
   settingsBounds: SettingsBounds;
+  readOnly?: boolean;
 }
 
 /**
@@ -30,6 +31,7 @@ interface EditImageSettingsInputProps {
 export default function EditImageSettingsInput({
   namePrefix,
   settingsBounds,
+  readOnly,
 }: EditImageSettingsInputProps) {
   const { gainMin, gainMax, exposureMin, exposureMax, exposureUnit } =
     settingsBounds;
@@ -41,6 +43,7 @@ export default function EditImageSettingsInput({
           name={namePrefix + "Gain"}
           min={gainMin}
           max={gainMax}
+          disabled={readOnly}
           label="Gain (Primary Brightness Control)"
           constraintText={`Adjust gain (${gainMin} to ${gainMax}) to control image brightness. Higher values = brighter images.`}
         />
@@ -49,6 +52,7 @@ export default function EditImageSettingsInput({
           name={namePrefix + "Exposure"}
           min={exposureMin}
           max={exposureMax}
+          disabled={readOnly}
           label="Exposure (Secondary Control)"
           constraintText={`Exposure time in ${exposureUnit} (${exposureMin} to ${exposureMax}). Use gain for primary brightness adjustment.`}
         />

--- a/src/frontend/src/components/image-settings/edit/schema.ts
+++ b/src/frontend/src/components/image-settings/edit/schema.ts
@@ -24,38 +24,62 @@ import {
   PROCESSING_PIPELINE_MAX,
 } from "../constants";
 
-export const schema = yup.object({
-  editGain: yup
-    .number()
-    .typeError("A gain is required.")
-    .required("A gain is required.")
-    .min(
-      GAIN_MIN,
-      `Gain is invalid. A gain must be greater than or equal to ${GAIN_MIN}.`,
-    )
-    .max(
-      GAIN_MAX,
-      `Gain is invalid. A gain must be less than or equal to ${GAIN_MAX}.`,
-    ),
-  editExposure: yup
-    .number()
-    .typeError("An exposure is required.")
-    .required("An exposure is required.")
-    .min(
-      EXPOSURE_MIN,
-      `Exposure is invalid. An exposure must be greater than or equal to ${EXPOSURE_MIN}.`,
-    )
-    .max(
-      EXPOSURE_MAX,
-      `Exposure is invalid. An exposure must be less than or equal to ${EXPOSURE_MAX}.`,
-    ),
-  editGstreamerPipeline: yup
-    .string()
-    .required("A gstreamer pipeline is required.")
-    .defined("A gstreamer pipeline is required.")
-    .max(
-      PROCESSING_PIPELINE_MAX,
-      `Invalid gstreamer pipeline. A gstreamer pipeline must be no longer than ${PROCESSING_PIPELINE_MAX} characters`,
-    ),
-});
+export interface EditSettingsSchemaBounds {
+  gainMin: number;
+  gainMax: number;
+  exposureMin: number;
+  exposureMax: number;
+}
+
+const DEFAULT_SCHEMA_BOUNDS: EditSettingsSchemaBounds = {
+  gainMin: GAIN_MIN,
+  gainMax: GAIN_MAX,
+  exposureMin: EXPOSURE_MIN,
+  exposureMax: EXPOSURE_MAX,
+};
+
+/**
+ * Build the edit-settings validation schema. Gain/exposure limits are passed in
+ * so they can reflect the connected camera's actual GenICam ranges; they
+ * default to the static constants for non-Aravis sources or when the device
+ * cannot be queried.
+ */
+export function makeSchema(bounds: EditSettingsSchemaBounds = DEFAULT_SCHEMA_BOUNDS) {
+  return yup.object({
+    editGain: yup
+      .number()
+      .typeError("A gain is required.")
+      .required("A gain is required.")
+      .min(
+        bounds.gainMin,
+        `Gain is invalid. A gain must be greater than or equal to ${bounds.gainMin}.`,
+      )
+      .max(
+        bounds.gainMax,
+        `Gain is invalid. A gain must be less than or equal to ${bounds.gainMax}.`,
+      ),
+    editExposure: yup
+      .number()
+      .typeError("An exposure is required.")
+      .required("An exposure is required.")
+      .min(
+        bounds.exposureMin,
+        `Exposure is invalid. An exposure must be greater than or equal to ${bounds.exposureMin}.`,
+      )
+      .max(
+        bounds.exposureMax,
+        `Exposure is invalid. An exposure must be less than or equal to ${bounds.exposureMax}.`,
+      ),
+    editGstreamerPipeline: yup
+      .string()
+      .required("A gstreamer pipeline is required.")
+      .defined("A gstreamer pipeline is required.")
+      .max(
+        PROCESSING_PIPELINE_MAX,
+        `Invalid gstreamer pipeline. A gstreamer pipeline must be no longer than ${PROCESSING_PIPELINE_MAX} characters`,
+      ),
+  });
+}
+
+export const schema = makeSchema();
 export type SchemaType = yup.InferType<typeof schema>;

--- a/src/frontend/src/components/image-source/types.ts
+++ b/src/frontend/src/components/image-source/types.ts
@@ -79,6 +79,16 @@ export interface ImageSourceConfiguration {
   processingPipeline: string;
   imageCrop?: RegionOfInterest;
   creationTime?: number;
+  // Optional advanced GenICam controls, applied to the device on the
+  // acquisition path. Only sent for cameras that support them.
+  reverseX?: boolean;
+  reverseY?: boolean;
+  balanceWhiteAuto?: string;
+  pixelFormat?: string;
+  width?: number;
+  height?: number;
+  offsetX?: number;
+  offsetY?: number;
 }
 
 export type RegionOfInterest = {

--- a/src/frontend/src/components/image-source/types.ts
+++ b/src/frontend/src/components/image-source/types.ts
@@ -72,6 +72,12 @@ export interface CameraStatusModel {
   lastUpdatedTime?: number;
 }
 
+export interface AdvancedCameraSettings {
+  reverseX?: boolean;
+  reverseY?: boolean;
+  balanceWhiteAuto?: string;
+}
+
 export interface ImageSourceConfiguration {
   imageSourceConfigurationId?: string;
   gain: number;
@@ -79,16 +85,8 @@ export interface ImageSourceConfiguration {
   processingPipeline: string;
   imageCrop?: RegionOfInterest;
   creationTime?: number;
-  // Optional advanced GenICam controls, applied to the device on the
-  // acquisition path. Only sent for cameras that support them.
-  reverseX?: boolean;
-  reverseY?: boolean;
-  balanceWhiteAuto?: string;
-  pixelFormat?: string;
-  width?: number;
-  height?: number;
-  offsetX?: number;
-  offsetY?: number;
+  // Persisted safe advanced GenICam controls (flip, white balance).
+  advancedSettings?: AdvancedCameraSettings;
 }
 
 export type RegionOfInterest = {

--- a/src/frontend/src/config/Interface.tsx
+++ b/src/frontend/src/config/Interface.tsx
@@ -59,6 +59,7 @@ export const Connection = {
 export const APIList = {
   camerasAPI: `${Connection.ENDPOINT}/cameras`,
   cameraFeatureBoundsAPI: `${Connection.ENDPOINT}/cameras/{camera_id}/feature-bounds`,
+  cameraFeaturesAPI: `${Connection.ENDPOINT}/cameras/{camera_id}/features`,
   previewImageAPI: `${Connection.ENDPOINT}/cameras/{camera_id}/preview`,
   executePipelineAPI: `${Connection.ENDPOINT}/cameras/{camera_id}/execute-pipeline`,
   listStreamsAPI: `${Connection.ENDPOINT}/streams`,

--- a/src/frontend/src/config/Interface.tsx
+++ b/src/frontend/src/config/Interface.tsx
@@ -58,6 +58,7 @@ export const Connection = {
 
 export const APIList = {
   camerasAPI: `${Connection.ENDPOINT}/cameras`,
+  cameraFeatureBoundsAPI: `${Connection.ENDPOINT}/cameras/{camera_id}/feature-bounds`,
   previewImageAPI: `${Connection.ENDPOINT}/cameras/{camera_id}/preview`,
   executePipelineAPI: `${Connection.ENDPOINT}/cameras/{camera_id}/execute-pipeline`,
   listStreamsAPI: `${Connection.ENDPOINT}/streams`,

--- a/src/host_scripts/configure_usb.sh
+++ b/src/host_scripts/configure_usb.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+#
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Raises the usbfs memory limit used by libusb for USB transfers.
+#
+# USB3Vision / GenICam cameras (e.g. Basler ace USB 3.0) stream large frames
+# through usbfs. The kernel default of 16 MB is too small for high-resolution
+# cameras and leads to failed buffer allocations ("No space left on device" /
+# bootstrap and streaming failures) even when the camera is detected.
+#
+# This sets /sys/module/usbcore/parameters/usbfs_memory_mb to USBFS_MEMORY_MB
+# (default 1000). It only ever raises the value, never lowers it, so it is safe
+# to run repeatedly and will not override a larger value set elsewhere. The
+# setting is applied at runtime; because the LocalServer component Run lifecycle
+# executes on every component start (including boot), it is re-applied
+# automatically and does not require a kernel boot parameter.
+
+set -u
+
+USBFS_PARAM_PATH="/sys/module/usbcore/parameters/usbfs_memory_mb"
+DESIRED_USBFS_MEMORY_MB="${USBFS_MEMORY_MB:-1000}"
+
+if [ ! -w "${USBFS_PARAM_PATH}" ]; then
+    echo "configure_usb: ${USBFS_PARAM_PATH} not present or not writable; skipping usbfs tuning."
+    exit 0
+fi
+
+current_value="$(cat "${USBFS_PARAM_PATH}" 2>/dev/null || echo 0)"
+
+# Only raise the limit; never reduce a value that is already higher.
+if [ "${current_value}" -ge "${DESIRED_USBFS_MEMORY_MB}" ]; then
+    echo "configure_usb: usbfs_memory_mb already ${current_value} MB (>= ${DESIRED_USBFS_MEMORY_MB} MB); leaving unchanged."
+    exit 0
+fi
+
+if echo "${DESIRED_USBFS_MEMORY_MB}" > "${USBFS_PARAM_PATH}" 2>/dev/null; then
+    echo "configure_usb: raised usbfs_memory_mb from ${current_value} MB to ${DESIRED_USBFS_MEMORY_MB} MB."
+else
+    # Non-fatal: USB3 cameras may still work for smaller frames. Do not block startup.
+    echo "configure_usb: WARNING failed to set usbfs_memory_mb to ${DESIRED_USBFS_MEMORY_MB} MB (current ${current_value} MB)."
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
This branch hardens USB3Vision/GenICam (Aravis) camera support on the edge and replaces hard-coded image-setting limits with values read directly from the camera. It also adds a device-driven "Advanced settings" section (flip, auto white balance) that is now persisted, and fixes several reliability bugs (preview hangs, indefinite frame-grab blocking, `LIBUSB_ERROR_BUSY` on the edit page, and a save-time 500).

## Motivation
On real hardware (e.g. Basler ace USB3 cameras) the existing flow had several problems:
- Hard-coded gain/exposure limits were tuned for the NVIDIA CSI path (nanoseconds); applied to USB3Vision cameras (microseconds via Aravis) they produced a ~1s exposure floor.
- Cameras hot-plugged after container startup weren't detected without a restart.
- Concurrent GenICam reads + frame grabs could wedge the preview indefinitely.
- Opening the edit page could claim the USB interface and break a subsequent connect with `LIBUSB_ERROR_BUSY`.

## Changes

### Camera reliability (backend)
- **Distinguish "detected but can't open" from "not found"**: new `AravisCameraOpenError` (HTTP 422) explaining likely USB3 link/cable/port causes, instead of a generic "not found".
- **Hotplug rescan**: `POST /cameras/rescan` tears down the cached Aravis context and re-enumerates so newly connected cameras appear without a container restart (active streams unaffected; serialized with a lock).
- **usbfs memory limit**: `host_scripts/configure_usb.sh` raises `usbfs_memory_mb` to 1000 MB (override via `USBFS_MEMORY_MB`), wired into the privileged Run lifecycle of all four LocalServer recipes (arm64 JP5/JP6, arm64, amd64).
- **No indefinite blocking on frame grab**: `get_frame()` uses `timeout_pop_buffer()` (configured exposure + 5s margin); on timeout, marks the camera disconnected and fails fast instead of wedging every preview.
- **Serialize feature reads with acquisition**: `get_feature_bounds()` now holds the camera lock so GenICam register reads never overlap a frame grab (previous cause of preview hangs).

### Device-driven image settings
- **Real gain/exposure ranges**: `Camera.get_feature_bounds()` reads ranges/current values from the GenICam feature map in a generic, extensible shape; exposed via `GET /cameras/{cameraId}/feature-bounds`. Frontend normalizes these (`bounds.ts`) with fallback to existing constants, and the validation schema becomes `makeSchema(bounds)` so limits match the hardware (correct microsecond unit for USB3Vision).
- **Advanced settings (flip, auto white balance)**: device-introspected controls surfaced only when the connected device implements them. Applied through the acquisition path (same as gain/exposure) with the Aravis register cache disabled so writes actually reach the sensor.
- **Persistence**: new nullable `advancedSettings` JSON column on `image_source_configuration` (Alembic revision `b2f1a9c4d7e3`), threaded through ORM, marshmallow, and pydantic models. Settings now survive reload and apply in preview, capture, and workflow.

### Recipe / host scripts
- `recipe.yaml` wires in `configure_usb.sh` (usbfs limit) and `install_nvidia_csi_service.sh` into the privileged Install/Run lifecycle, adds the `aws.greengrass.Cli >= 2.6.0` dependency, stops `nvidia-csi-capture` on Shutdown, and consolidates the split `-app`/`-backend` build artifacts into a single `-aarch64` artifact path.

### Bug fixes folded in
- **`LIBUSB_ERROR_BUSY` on edit page**: `get_camera_feature_bounds()` no longer auto-connects; it reads only from an existing connection and returns `{}` when disconnected (frontend then shows a read-only fallback).
- **Save 500 (`height is an invalid keyword argument`)**: advanced fields no longer leak into the ORM persistence layer; schema uses `unknown=EXCLUDE` for preview overrides.

## Scope notes
- Pixel format and ROI are intentionally **out of scope** for persistence (they require GStreamer caps to track them — a separate follow-up).
- `ReverseY` is advertised by some sensors (e.g. acA4600-10uc) but not physically applied — a sensor quirk, not a code issue.

## Testing
Verified on a Basler USB3 camera: device-accurate gain/exposure ranges, `ReverseX`/`BalanceWhiteAuto` apply to captured frames, advanced settings persist and reload, feature-bounds returns `{}` while disconnected (no BUSY on subsequent connect), clean save returns 200, and the Alembic migration applies cleanly (`c1ce33a752b2` → `b2f1a9c4d7e3`).

## Files changed
~27 files across backend (camera manager, endpoints, models, migration), frontend (image-settings components, schema, API), host scripts, and the four component recipes.
