### PR TITLE
Concurrent camera stream viewing (multi-viewer live preview)

### DIFF
--- a/.kiro/specs/concurrent-camera-stream-viewing/.config.kiro
+++ b/.kiro/specs/concurrent-camera-stream-viewing/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "b4b904e3-cf37-4065-a121-966005904c7c", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/concurrent-camera-stream-viewing/design.md
+++ b/.kiro/specs/concurrent-camera-stream-viewing/design.md
@@ -1,0 +1,593 @@
+# Design Document
+
+## Overview
+
+Today the backend serves a live preview to only one viewer at a time. Each preview frame
+in `camera_manager.py` runs through a module-level `get_frame_lock` plus a per-request
+`start_acquisition()` / `get_frame()` / `stop_acquisition()` cycle on a `multiprocessing`-hosted
+`Camera` proxy. Two browser tabs polling the same camera serialize on that one lock, so the
+second viewer stalls behind the first, and every grab pays the full start/stop cost.
+
+This feature replaces the per-request grab model with a **broadcast model**: a single long-lived
+acquisition session per physical camera (the `Stream_Broadcaster`) reads frames once and fans the
+most recent frame out to every subscribed viewer. Viewers no longer claim the device — they
+**subscribe** to a stream, send periodic **heartbeats**, and **unsubscribe** when done. The session
+starts on the first subscriber and stops on the last, releasing the device claim.
+
+The design must hold one device claim per camera across two acquisition backends:
+
+- **GenICam / USB3Vision** via Aravis (the current `Camera` / `get_camera_frame()` path).
+- **NVIDIA CSI / ICAM** via GStreamer pipelines (the current `gst_pipeline_executor` path, which
+  today does not go through `get_camera_frame()`).
+
+It must also keep two existing consumers working against the *same* single claim:
+
+- **Edit_Settings_Preview** — applying gain / exposure / advanced GenICam features to the live
+  session, plus per-request config-override previews.
+- **Inference_Pipeline / capture** — `digital_input_process_manager`,
+  `digital_input_thread_manager`, `workflow`, and capture endpoints, which must reuse the active
+  session's claim rather than opening a second one.
+
+### Goals
+
+- One `Device_Claim` per `Physical_Camera` while ≥ 1 viewer is subscribed; zero when none are.
+- Acquire each frame once; fan it out identically to all viewers (≥ 8 concurrent) without
+  per-viewer blocking.
+- Automatic start-on-first-viewer / stop-on-last-viewer lifecycle keyed off explicit subscription
+  and heartbeat tracking, so abandoned tabs cannot pin the device.
+- Bounded freshness/latency (serve latest frame < 500 ms, no frame older than 2 s without a
+  staleness signal) regardless of viewer count.
+- Backend-agnostic behavior across Aravis and GStreamer cameras.
+- Edit-settings and inference/capture continue to function through the shared claim.
+
+### Non-Goals
+
+- Changing the on-the-wire image encoding or the GStreamer processing pipeline definitions.
+- Pixel-format / ROI live control (still out of scope, as in the current code).
+- Multi-host / clustered broadcasting; this is a single-backend-process design.
+
+## Architecture
+
+The `Stream_Broadcaster` is introduced as a backend-process-wide registry of per-camera
+**stream sessions**. Each session owns exactly one acquisition worker bound to one device claim,
+a single-slot **latest-frame buffer**, and a **viewer registry**. HTTP endpoints become thin
+clients over the broadcaster: subscribe / heartbeat / unsubscribe / get-frame / viewer-count.
+
+```mermaid
+graph TD
+    subgraph Clients
+        V1[Viewer tab A]
+        V2[Viewer tab B]
+        VN[Viewer tab N]
+    end
+
+    subgraph Backend Process
+        API[Stream API endpoints<br/>subscribe / heartbeat / frame / unsubscribe]
+        SB[StreamBroadcaster<br/>registry of sessions]
+        subgraph Session per camera
+            VR[Viewer Registry<br/>+ heartbeat clock]
+            LFB[Latest_Frame buffer<br/>single slot + seq + timestamp]
+            AW[Acquisition Worker<br/>one loop]
+        end
+        CM[Camera_Manager<br/>backend adapters]
+        INF[Inference / Capture<br/>get_camera_frame]
+        EDIT[Edit_Settings apply]
+    end
+
+    subgraph Devices
+        ARV[(Aravis camera)]
+        CSI[(NVIDIA CSI camera)]
+    end
+
+    V1 & V2 & VN -->|HTTP poll| API
+    API --> SB
+    SB --> VR
+    SB --> LFB
+    SB --> AW
+    AW --> CM
+    INF --> SB
+    EDIT --> SB
+    CM -->|one Device_Claim| ARV
+    CM -->|one pipeline claim| CSI
+    LFB -->|fan-out copy| API
+```
+
+### Concurrency / fan-out model
+
+The core problem with the current code is that the *reader* (device grab) and the *consumers*
+(viewer requests) share one lock, so consumers serialize behind the grab. The new model decouples
+them:
+
+- **One producer** per session: the acquisition worker is the *only* code that touches the device
+  handle. It loops: grab → write latest-frame slot → repeat. Aravis cameras switch from
+  per-request software-trigger to continuous acquisition driven by the worker; CSI cameras run a
+  persistent GStreamer `appsink` pull loop instead of a one-shot pipeline.
+- **Single-writer / many-reader latest-frame slot.** The worker publishes each frame into a single
+  shared slot guarded by a short-held lock (or an atomic pointer swap). Each frame carries a
+  monotonic **sequence number** and an **acquired-at timestamp**. Readers copy the current
+  reference out under the lock and release immediately — they never hold the lock across I/O and
+  never touch the device.
+- **Readers never block each other or the producer.** A viewer's get-frame is a slot read plus a
+  freshness check; its latency is independent of any other viewer's in-flight request (Req 1.5,
+  4.5). This satisfies "serve each viewer independently."
+- **Backpressure = drop-to-latest.** There is no per-viewer queue. Slow viewers simply read
+  whatever the latest frame is on their next poll; the producer never waits on a consumer. This
+  bounds memory and guarantees producer cadence is independent of viewer count (Req 4.5).
+
+```mermaid
+sequenceDiagram
+    participant W as Acquisition Worker
+    participant S as Latest_Frame slot
+    participant A as Viewer A
+    participant B as Viewer B
+    loop continuous
+        W->>W: grab frame from device
+        W->>S: publish(frame, seq+1, now)  (writer lock, brief)
+    end
+    A->>S: read() -> (frame seq=k, t)
+    B->>S: read() -> (frame seq=k, t)
+    Note over A,B: Same seq within one interval => identical bytes (Req 2.5)
+```
+
+### Single-claim sharing with inference / capture
+
+To honor Req 6, the device claim moves *into the session*, and both viewers and the inference
+path go through the broadcaster:
+
+- **Session active:** `get_camera_frame()` (inference/capture) is redirected to the broadcaster.
+  For inference it returns the session's latest frame (fresh grab fan-out) instead of opening a
+  second claim (Req 6.1). For capture with a per-capture config, the worker briefly applies the
+  override on the live session (see Edit-Settings interaction) and returns the next frame.
+- **No session:** `get_camera_frame()` falls back to the legacy dedicated-claim path
+  (open → grab → close), giving inference its frame within the 2 s bound (Req 6.3). This keeps
+  inference working when nobody is watching.
+
+The broadcaster therefore mediates *all* device access; the invariant "at most one open claim per
+camera" is enforced in one place.
+
+### Transport choice
+
+The current frontend polls a preview endpoint via `img src` / a 500 ms `refetchInterval` React
+Query. To minimize frontend churn while adding lifecycle, the design keeps a **poll-based
+transport** and layers an explicit subscription/heartbeat protocol on top of it:
+
+- The poll request for a frame **doubles as the heartbeat** (each frame GET refreshes the viewer's
+  last-active timestamp), so a viewer that keeps polling stays alive automatically. An explicit
+  heartbeat endpoint is also provided for clients that render via MJPEG/`img` and need to keep the
+  subscription alive without a JSON round-trip.
+- A separate **subscribe** call establishes the viewer id (start-on-first-viewer) and an
+  **unsubscribe** call (or `navigator.sendBeacon` on tab close) provides prompt teardown; the 30 s
+  stale-viewer sweep is the backstop for abandoned tabs.
+
+Polling (vs. websockets/MJPEG push) is chosen because it (a) reuses the existing frontend image
+flow and error handling, (b) makes the freshness/staleness contract a simple per-request check,
+and (c) keeps each viewer's request independent, which is exactly the property Req 1.5 / 4.5
+require. MJPEG remains available as an optional rendering transport over the same subscription.
+
+## Components and Interfaces
+
+### StreamBroadcaster (new)
+
+Process-wide singleton holding `{camera_id -> StreamSession}`. Thread-safe registry operations.
+
+```python
+class StreamBroadcaster:
+    MAX_VIEWERS_PER_CAMERA = 8
+    HEARTBEAT_INTERVAL_S = 10
+    STALE_TIMEOUT_S = 30
+    FIRST_FRAME_TIMEOUT_S = 10
+
+    def subscribe(self, camera_id: str, config: dict | None) -> SubscribeResult:
+        """Register a new viewer; start the session if this is the first viewer.
+        Raises ViewerLimitReached (Req 1.6) or CameraUnavailable (Req 1.7, 3.2)."""
+
+    def heartbeat(self, camera_id: str, viewer_id: str) -> bool:
+        """Refresh the viewer's last-active timestamp. Returns False if unknown/expired."""
+
+    def get_frame(self, camera_id: str, viewer_id: str) -> FrameResult:
+        """Return the latest frame (also refreshes heartbeat). Encodes NO_FRAME /
+        STALE / DISCONNECTED states (Req 2.6, 4.7, 7.5)."""
+
+    def unsubscribe(self, camera_id: str, viewer_id: str) -> None:
+        """Deregister a viewer; stop the session if it was the last (Req 3.3, 8.8)."""
+
+    def viewer_count(self, camera_id: str) -> int:
+        """Active viewer count (Req 8.4)."""
+
+    def get_inference_frame(self, camera_id: str, config: dict | None) -> dict | None:
+        """Reuse the active session's claim for inference/capture; fall back to a
+        dedicated claim when no session exists (Req 6.1, 6.3)."""
+
+    def apply_settings(self, camera_id: str, features: dict) -> ApplyResult:
+        """Apply gain/exposure/advanced features to the live session (Req 5)."""
+
+    def sweep_stale_viewers(self, now: float) -> None:
+        """Deregister viewers past STALE_TIMEOUT_S; stop emptied sessions (Req 3.8/3.9, 8.6/8.7)."""
+```
+
+### StreamSession (new)
+
+Owns one camera's acquisition worker, latest-frame slot, viewer registry, and lifecycle state.
+
+```python
+class StreamSession:
+    state: SessionState                 # STARTING | RUNNING | STOPPING | STOPPED | ERROR
+    camera_id: str
+    backend: CameraBackend              # AravisBackend | GStreamerBackend
+    viewers: dict[str, Viewer]
+    latest: LatestFrame | None
+    def add_viewer(self, viewer: Viewer) -> None: ...
+    def remove_viewer(self, viewer_id: str) -> bool: ...   # returns True if now empty
+    def publish(self, frame_bytes, width, height, now) -> None: ...  # writer side
+    def read_latest(self, now) -> FrameResult: ...                   # reader side
+    def is_empty(self) -> bool: ...
+```
+
+### CameraBackend adapters (new abstraction over existing code)
+
+A common interface so the broadcaster treats both camera families identically (Req 2.8).
+
+```python
+class CameraBackend(Protocol):
+    def open(self) -> None: ...          # acquire the single Device_Claim (≤3 attempts, Req 7.6)
+    def start_stream(self) -> None: ...  # continuous acquisition / appsink pull
+    def grab(self, timeout_ms: int) -> RawFrame | None: ...  # one frame, bounded wait
+    def apply_features(self, features: dict) -> dict: ...     # gain/exposure/advanced
+    def stop_stream(self) -> None: ...
+    def close(self) -> None: ...         # release the Device_Claim
+```
+
+- **AravisBackend** wraps the existing `Camera` class. Acquisition moves from per-request
+  software-trigger to a worker-driven continuous loop; `apply_features` reuses
+  `apply_device_features` / `_apply_config_features` with acquisition coordination.
+- **GStreamerBackend** wraps a persistent pipeline ending in an `appsink`, replacing the one-shot
+  `execute_image_source_pipeline` for the live-view path. Capture/inference still build their own
+  full processing pipelines but pull the source frame from the session.
+
+### Acquisition worker (new)
+
+One thread (or process) per session. Loop: `grab(timeout)` → on success `session.publish(...)`;
+on `None`/timeout mark disconnected (Req 7.1) and transition session to ERROR → stop. Sleeps to
+cap rate at the configured ceiling but never below device cadence (Req 4.3, 4.4).
+
+### Stream API endpoints (new / refactored `endpoints/streams.py`)
+
+| Method & path | Purpose | Requirements |
+|---|---|---|
+| `POST /streams/{camera_id}/subscribe` | Register viewer, start session if first. Returns `viewerId`. | 1.2, 3.1, 8.1 |
+| `GET  /streams/{camera_id}/frame?viewerId=` | Latest frame + state; refreshes heartbeat. | 2.3, 4.1, 4.6 |
+| `POST /streams/{camera_id}/heartbeat` | Explicit keep-alive. | 8.2, 8.3 |
+| `POST /streams/{camera_id}/unsubscribe` | Deregister viewer, stop session if last. | 3.6, 8.8 |
+| `GET  /streams/{camera_id}/viewers` | Active viewer count. | 8.4 |
+| `POST /streams/{camera_id}/settings` | Apply gain/exposure/advanced to live session. | 5.1, 5.2 |
+
+Existing `POST /image-sources/{id}/preview` with a config override is preserved and routed to a
+**single-frame override path** that does not mutate the live session (Req 5.4).
+
+### Camera_Manager (`camera_manager.py`, refactored)
+
+`get_camera_frame(camera_id, config)` is rewired to call `broadcaster.get_inference_frame(...)`,
+preserving its signature so `digital_input_*`, `workflow`, and capture endpoints are unchanged.
+The legacy dedicated-claim grab becomes the `no active session` fallback inside the broadcaster.
+
+## Data Models
+
+```python
+@dataclass(frozen=True)
+class LatestFrame:
+    data: bytes            # raw image payload (same shape as today's get_frame dict)
+    width: int
+    height: int
+    seq: int               # monotonic per session; identifies an acquisition interval
+    acquired_at: float     # epoch seconds when grabbed
+
+@dataclass
+class Viewer:
+    viewer_id: str         # server-issued uuid; duplicate subscribes => distinct ids (Req 8.5)
+    camera_id: str
+    subscribed_at: float
+    last_active: float     # updated on heartbeat/frame GET (Req 8.3)
+
+class SessionState(Enum):
+    STARTING = "starting"
+    RUNNING = "running"
+    STOPPING = "stopping"
+    STOPPED = "stopped"
+    ERROR = "error"
+
+class FrameStatus(Enum):
+    OK = "ok"
+    NO_FRAME = "no_frame"        # session up, no frame yet (Req 2.6, 4.2)
+    STALE = "stale"             # latest older than 2s (Req 4.7)
+    DISCONNECTED = "disconnected"  # camera dropped (Req 7.5)
+
+@dataclass
+class FrameResult:
+    status: FrameStatus
+    frame: LatestFrame | None
+    error: str | None = None
+
+@dataclass
+class SubscribeResult:
+    viewer_id: str | None
+    accepted: bool
+    reason: str | None        # "viewer_limit" | "camera_unavailable" | None
+    viewer_count: int
+
+# Configurable bounds (Req 7.1, 7.6)
+@dataclass
+class StreamConfig:
+    frame_timeout_ms: int = 5000      # clamp [500, 30000]
+    open_timeout_ms: int = 5000       # clamp [500, 30000]
+    max_open_attempts: int = 3
+    max_viewers: int = 8
+    heartbeat_interval_s: int = 10
+    stale_timeout_s: int = 30
+    first_frame_timeout_s: int = 10
+    stale_after_s: float = 2.0        # freshness ceiling for served frames (Req 4.6)
+    min_refresh_fps: float = 5.0      # Req 4.3
+```
+
+The viewer registry is keyed `camera_id -> {viewer_id -> Viewer}`; `viewer_count` is `len(...)`.
+The latest-frame slot is one `LatestFrame` reference per session, replaced wholesale on publish so
+readers always observe a complete, consistent frame (Req 2.2, 2.5).
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of
+a system — essentially, a formal statement about what the system should do. Properties serve as
+the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+These properties test the `StreamBroadcaster` / `StreamSession` logic against a **mock
+`CameraBackend`** (counting opens/closes/grabs and simulating failures) and an **injected clock**,
+so they exercise our fan-out, lifecycle, and freshness logic deterministically without real
+hardware. Each property is parametrized over both a mock `AravisBackend` and a mock
+`GStreamerBackend` to satisfy backend parity (Req 2.8). Wall-clock timing bounds (e.g. "within
+500 ms", "within 5 s", frame-rate floors) and real-device behavior (first-frame arrival, applied
+setting visible within N frames, inter-frame gaps) are verified by integration/perf tests in the
+Testing Strategy, not by these properties.
+
+### Property 1: Single device-claim invariant
+
+*For any* sequence of subscribe / unsubscribe / stale-sweep / disconnect operations across one or
+more cameras, the number of open `Device_Claim`s for each camera equals 1 when that camera has at
+least one active viewer and 0 when it has none, never exceeds 1 at any point, and a new claim is
+never opened before a prior claim for the same camera has been released (no overlapping claims).
+
+**Validates: Requirements 1.2, 2.1, 3.4, 7.7**
+
+### Property 2: Session lifecycle (start on first, stop and release on last)
+
+*For any* viewer operation sequence, the first viewer to subscribe to a camera with no session
+causes exactly one session to be created, and whenever the active viewer count for a camera
+returns to 0 the session is stopped and its backend `close()` (claim release) is invoked.
+
+**Validates: Requirements 3.1, 3.3, 3.7, 8.7**
+
+### Property 3: Fan-out delivers the identical latest frame to every viewer
+
+*For any* set of 1 to `max_viewers` subscribed viewers and any sequence of published frames, every
+viewer that reads after a publish (and before the next) receives a byte-identical frame with the
+same sequence number as every other viewer reading in that interval, and that frame is the most
+recently published one.
+
+**Validates: Requirements 1.1, 1.4, 2.2, 2.5**
+
+### Property 4: Reads are independent of other viewers and do not re-grab
+
+*For any* viewer and *any* number of other viewers in any read state, a viewer's `get_frame`
+returns the current latest frame as a pure function of the latest-frame slot — independent of the
+presence, count, or pending reads of other viewers — and repeated reads with no intervening
+publish return the same frame without invoking a device grab.
+
+**Validates: Requirements 1.5, 2.4**
+
+### Property 5: Producer cadence is independent of viewer count
+
+*For any* fixed sequence of frames produced by the backend, the sequence of frames published into
+the latest-frame slot is identical whether 1 or `max_viewers` viewers are reading arbitrarily, and
+no viewer read prevents or delays a publish (drop-to-latest, no backpressure).
+
+**Validates: Requirements 4.5**
+
+### Property 6: Viewer-limit enforcement
+
+*For any* operation sequence that brings a camera to `max_viewers` active viewers, the next
+subscribe is rejected with reason `viewer_limit`, the active viewer count remains `max_viewers`,
+and all existing viewers remain registered and able to read frames.
+
+**Validates: Requirements 1.6, 1.3**
+
+### Property 7: Open-failure handling
+
+*For any* camera whose backend `open()` fails, a subscribe attempt makes at most
+`max_open_attempts` (3) attempts, then is rejected with reason `camera_unavailable`, leaves no
+session and zero claims for that camera, while subscriptions to any other healthy camera still
+succeed.
+
+**Validates: Requirements 1.7, 3.2, 7.6**
+
+### Property 8: Viewer-count correctness and duplicate subscriptions
+
+*For any* operation sequence, the reported active viewer count for a camera is always a
+non-negative integer equal to the number of distinct registered viewers, and subscribing K times
+to the same camera yields K distinct viewer ids that each count toward the total.
+
+**Validates: Requirements 8.1, 8.4, 8.5, 8.8**
+
+### Property 9: Heartbeat update and staleness predicate
+
+*For any* viewer and *any* receipt time t, processing a heartbeat sets that viewer's last-active
+timestamp to t, and *for any* last-active time and current time `now`, the viewer is classified as
+stale exactly when `now - last_active > stale_timeout_s`.
+
+**Validates: Requirements 3.9, 8.3**
+
+### Property 10: Stale sweep deregisters, heartbeats keep alive
+
+*For any* set of viewers with arbitrary last-active timestamps, a stale-sweep at time `now`
+removes exactly those viewers with `now - last_active > stale_timeout_s` (decrementing the count
+accordingly and treating them as unsubscribed), while any viewer that has sent a heartbeat within
+`stale_timeout_s` of `now` is retained.
+
+**Validates: Requirements 3.8, 8.2, 8.6**
+
+### Property 11: Frame freshness predicate
+
+*For any* latest frame with acquired-at time and *any* request time `now`, a read returns status
+`OK` with the frame when `now - acquired_at <= stale_after_s` (2 s) and status `STALE` otherwise.
+
+**Validates: Requirements 4.6, 4.7**
+
+### Property 12: No-frame-yet handling
+
+*For any* session that has started but published no frame, a read returns status `NO_FRAME` and
+the session remains active (not stopped).
+
+**Validates: Requirements 2.6, 4.2**
+
+### Property 13: Acquisition failure preserves the last good frame
+
+*For any* published latest frame followed by a failed grab, the latest-frame slot still equals the
+last successfully published frame (the failed grab does not overwrite it) and an acquisition-failure
+indication is produced.
+
+**Validates: Requirements 2.7**
+
+### Property 14: Disconnection cascade
+
+*For any* session with any set of subscribed viewers, when a grab times out or fails such that the
+camera is marked disconnected, the session is stopped with its backend `close()` (claim release)
+invoked before stop completion is reported, and every subscribed viewer's subsequent `get_frame`
+returns status `DISCONNECTED` with no frame payload (never a previously cached frame).
+
+**Validates: Requirements 7.1, 7.2, 7.3, 7.4, 7.5, 3.5, 3.11**
+
+### Property 15: Timeout/configuration clamping
+
+*For any* configured frame-timeout or open-timeout value, the effective timeout used equals that
+value clamped to the range [500, 30000] ms.
+
+**Validates: Requirements 7.1**
+
+### Property 16: Inference reuses the session claim, falls back when none
+
+*For any* camera, a frame request from the inference/capture path returns a frame without opening
+a second claim when a session is active (claim count stays 1), and when no session exists it opens
+exactly one dedicated claim, returns a frame, and releases that claim (count returns to 0).
+
+**Validates: Requirements 6.1, 6.3, 6.4**
+
+### Property 17: Inference failure leaves the session intact
+
+*For any* active session, if an inference frame request fails or the camera becomes unavailable
+for that request, an error indication is returned to the caller while the session remains running
+and its `Device_Claim` is retained.
+
+**Validates: Requirements 6.6**
+
+### Property 18: Live settings apply preserves the session
+
+*For any* set of valid camera control values applied to a running session, the backend reflects
+the requested values, the session remains in the RUNNING state, the subscribed viewer set is
+unchanged, and the latest frame remains readable throughout.
+
+**Validates: Requirements 5.1, 5.2, 5.3**
+
+### Property 19: Settings-apply failure retains prior values
+
+*For any* apply request in which at least one control fails, the operation returns an error
+identifying the failed control, the control values in effect before the request are retained
+unchanged, and the session remains active.
+
+**Validates: Requirements 5.5**
+
+### Property 20: Override preview isolation
+
+*For any* per-request configuration override preview against a running session, the session's
+applied control values and the shared latest frame delivered to other viewers are unchanged by the
+override request.
+
+**Validates: Requirements 5.4**
+
+### Property 21: Out-of-range capture configuration is rejected
+
+*For any* per-capture image-source configuration containing at least one parameter value outside
+its accepted range, the request is rejected with an error identifying an offending parameter and
+the previously active image-source configuration is preserved unchanged.
+
+**Validates: Requirements 6.5**
+
+## Error Handling
+
+| Condition | Detection | Response | Requirements |
+|---|---|---|---|
+| Device open fails on subscribe | `backend.open()` raises across ≤3 attempts within `open_timeout_ms` | Reject subscribe, reason `camera_unavailable`, no session, other cameras unaffected | 1.7, 3.2, 7.6 |
+| Viewer limit reached | registry size == `max_viewers` on subscribe | Reject, reason `viewer_limit`, existing viewers untouched | 1.6 |
+| No frame yet | session RUNNING, slot empty | `FrameResult(NO_FRAME)`, session retained | 2.6, 4.2 |
+| First-frame timeout | no publish within `first_frame_timeout_s` | Stream error to viewers, stop session | 3.11 |
+| Single-grab timeout / failure | `grab()` returns `None` / non-success | Mark camera disconnected, retain last good slot until disconnect, surface failure | 2.7, 7.1 |
+| Camera disconnected | timeout/failure marks disconnect | All viewers get `DISCONNECTED` (no cached frame); stop session; release claim before completion | 7.2, 7.3, 7.4, 7.5 |
+| Stop failure | `stop_stream()` raises | Force claim release, mark STOPPED, surface error | 3.5 |
+| Stale viewer | sweep finds `now - last_active > 30s` | Deregister, decrement count, stop session if empty | 3.8, 8.6, 8.7 |
+| Apply control failure | `apply_features` raises for a control | Error names the control, retain prior values, keep session RUNNING | 5.5 |
+| Out-of-range capture config | validation against feature bounds | Reject, identify invalid parameter, preserve active config | 6.5 |
+| Inference grab failure (session active) | grab error during `get_inference_frame` | Error to inference caller, session + claim left intact | 6.6 |
+
+Errors are surfaced to viewers through the `FrameResult.status` enum (`NO_FRAME`, `STALE`,
+`DISCONNECTED`) and to subscribe callers through `SubscribeResult.reason`. The broadcaster logs at
+ERROR for device failures and at INFO for lifecycle transitions, reusing the existing `Timer`
+metrics (`CameraConnectTime`, `CameraGetFrameTime`, etc.) plus new metrics for session start/stop
+and viewer counts.
+
+## Testing Strategy
+
+### Property-based tests
+
+Property-based testing **is appropriate** for this feature: the `StreamBroadcaster` /
+`StreamSession` are pure-logic state machines (subscription registry, viewer counting, staleness
+and freshness predicates, single-slot fan-out, lifecycle transitions, single-claim invariant) whose
+behavior varies meaningfully with inputs (number of viewers, operation interleavings, heartbeat /
+acquisition timings, frame sequences). Exercising 100+ generated input sequences finds ordering and
+boundary bugs that a handful of examples would miss.
+
+- Library: **Hypothesis** (Python), matching the existing pytest suite under `test/backend-test`.
+- Each property test runs a **minimum of 100 iterations**.
+- Each test is tagged with a comment referencing its design property, format:
+  **Feature: concurrent-camera-stream-viewing, Property {number}: {property_text}**
+- Each correctness property (1–21) is implemented by a **single** property-based test.
+- Tests use a **mock `CameraBackend`** (records open/close/grab calls, can simulate open failure,
+  grab timeout/failure, and stop failure) and an **injected clock** so timing-dependent logic
+  (staleness, freshness, first-frame timeout) is deterministic.
+- Stateful/interleaving properties (1, 2, 6, 8) use Hypothesis `RuleBasedStateMachine` to generate
+  random subscribe / unsubscribe / heartbeat / sweep sequences and assert invariants after each step.
+- Backend-parity properties are parametrized over both a mock `AravisBackend` and a mock
+  `GStreamerBackend` (Req 2.8).
+
+### Unit / example tests
+
+Focus on concrete behaviors and boundaries not covered by universal properties:
+
+- Subscribe → frame → unsubscribe happy path for each backend.
+- The exact `max_viewers = 8` boundary (8th accepted, 9th rejected) — Req 1.3/1.6 edge.
+- `FrameResult` / `SubscribeResult` serialization on the API endpoints (status codes for
+  `NO_FRAME`, `STALE`, `DISCONNECTED`, `viewer_limit`, `camera_unavailable`).
+- `get_camera_frame` signature compatibility so `digital_input_*`, `workflow`, and capture
+  endpoints keep working unchanged (regression against existing tests in
+  `test/backend-test/api-endpoints`).
+
+### Integration / performance tests (timing & real-device bounds — NOT property tests)
+
+These verify the wall-clock and hardware-dependent acceptance criteria that property tests
+intentionally exclude:
+
+- First frame available within 10 s of session start (Req 3.10); latest-frame read < 100 ms /
+  500 ms (Req 2.3, 4.1, 4.2); stale response < 500 ms (Req 4.7 timing).
+- Refresh ≥ 5 fps for a ≥ 5 fps source and tracks device rate below that (Req 4.3, 4.4); refresh
+  rate independent of viewer count up to 8 (Req 4.5 wall-clock side).
+- New subscriber starts receiving within 2000 ms with no disruption to existing viewers (Req 1.4).
+- Applied setting visible in the live stream within 5 frames (Req 5.2).
+- Inference grab during active session keeps viewer inter-frame gaps ≤ 500 ms and ≥ 90% rate
+  (Req 6.2); inference dedicated-claim grab returns within 2000 ms (Req 6.3 timing).
+- End-to-end against a Fake Aravis camera (`Aravis.enable_interface("Fake")`, already used in the
+  codebase) and a simulated GStreamer source, run with 1–3 representative examples each.

--- a/.kiro/specs/concurrent-camera-stream-viewing/requirements.md
+++ b/.kiro/specs/concurrent-camera-stream-viewing/requirements.md
@@ -1,0 +1,140 @@
+# Requirements Document
+
+## Introduction
+
+Today the DefectDetectionApplication backend can serve a live camera preview to only one viewer at a time. Every preview frame grab in `camera_manager.py` runs through a global `get_frame_lock` and a per-request `start_acquisition()` / `get_frame()` / `stop_acquisition()` cycle. When two browser tabs or clients poll the same camera, they contend on this single lock, so effectively only one page can view the stream while the others stall or fail.
+
+This feature introduces a shared, broadcast-style frame source: a single acquisition loop per physical camera that fans out the most recent frame to every connected viewer. Viewers subscribe to a stream rather than each claiming the device. The shared acquisition starts when the first viewer connects and stops when the last viewer disconnects. The feature must cover concurrent viewing, frame fan-out, stream lifecycle, performance bounds, and correct interaction with the existing edit-settings / preview flow and the inference / capture pipeline, across both GenICam/USB3Vision (Aravis) cameras and NVIDIA CSI (GStreamer) cameras.
+
+This document defines what the system must do. Implementation choices (threading vs. multiprocessing, queue vs. shared memory, transport protocol) are deferred to design.
+
+## Glossary
+
+- **Camera_Manager**: The backend module responsible for opening, configuring, and reading frames from physical cameras (currently `src/backend/utils/camera_manager.py`).
+- **Physical_Camera**: A single hardware camera device addressed by a camera identifier, accessed via Aravis (GenICam/USB3Vision) or a GStreamer pipeline (NVIDIA CSI / ICAM).
+- **Stream_Broadcaster**: The component that owns exactly one acquisition session per Physical_Camera and distributes the most recent frame to all subscribed Viewers.
+- **Viewer**: A single client subscription to a camera stream, corresponding to one browser tab or client polling/receiving preview frames. A Physical_Camera may have multiple concurrent Viewers.
+- **Latest_Frame**: The most recently acquired frame held by the Stream_Broadcaster for a given Physical_Camera, available for fan-out to Viewers.
+- **Stream_Session**: The lifecycle of a Stream_Broadcaster's acquisition for one Physical_Camera, from the first Viewer subscribing to the last Viewer unsubscribing.
+- **Viewer_Heartbeat**: A periodic signal (poll request or keep-alive) from a Viewer that indicates the Viewer is still active. Viewers are expected to send a Viewer_Heartbeat at intervals of no more than 10 seconds.
+- **Edit_Settings_Preview**: The existing flow where a user adjusts camera controls (gain, exposure, advanced GenICam features) and previews the result, supplying a per-request image-source configuration override.
+- **Inference_Pipeline**: The capture and inference paths that grab full frames for workflows (`digital_input_process_manager`, `digital_input_thread_manager`, `workflow`, capture endpoints) via the Camera_Manager.
+- **Device_Claim**: An open, acquiring handle on a Physical_Camera. A USB3Vision/GenICam device that is already claimed returns a busy error to a second open attempt.
+- **Stale_Viewer**: A registered Viewer from which no Viewer_Heartbeat has been received within 30 seconds of its last-active timestamp (three consecutive missed heartbeats at the 10-second expected interval).
+
+## Requirements
+
+### Requirement 1: Concurrent Viewing of a Single Camera
+
+**User Story:** As an operator, I want to open the same camera's live preview in multiple browser tabs or on multiple clients at once, so that several people can watch the same camera without one viewer blocking the others.
+
+#### Acceptance Criteria
+
+1. WHEN two or more Viewers are subscribed to the same Physical_Camera, THE Stream_Broadcaster SHALL deliver each captured live preview frame to every subscribed Viewer, such that each Viewer receives frames at a rate no lower than 90 percent of the Physical_Camera's configured capture frame rate.
+2. WHILE one or more Viewers are subscribed to the same Physical_Camera, THE Camera_Manager SHALL hold exactly one Device_Claim for that Physical_Camera, and SHALL hold zero Device_Claims when no Viewers are subscribed.
+3. THE Stream_Broadcaster SHALL support a minimum of 8 concurrent Viewers per Physical_Camera while meeting the frame delivery rate defined in criterion 1.
+4. WHEN an additional Viewer subscribes to a Physical_Camera that already has between 1 and 7 active Viewers, THE Stream_Broadcaster SHALL begin delivering frames to the new Viewer within 2000 milliseconds, while continuing to deliver frames to each existing Viewer at the rate defined in criterion 1 with no dropped frames attributable to the new subscription.
+5. WHILE multiple Viewers are subscribed to the same Physical_Camera, THE Stream_Broadcaster SHALL serve each Viewer's frame requests independently, such that the time for any Viewer to receive a requested frame does not depend on, and is not blocked by, the pending or in-progress frame request of any other Viewer.
+6. IF a Viewer attempts to subscribe to a Physical_Camera that already has 8 active Viewers, THEN THE Stream_Broadcaster SHALL reject the subscription, return a response to the requesting Viewer indicating the per-camera Viewer limit has been reached, and continue delivering frames to the 8 existing Viewers without interruption.
+7. IF the Camera_Manager cannot establish or maintain the Device_Claim for a Physical_Camera when a Viewer subscribes, THEN THE Stream_Broadcaster SHALL reject the subscription and return a response to the requesting Viewer indicating the Physical_Camera is unavailable, without affecting frame delivery to any other Physical_Camera.
+
+### Requirement 2: Shared Frame Acquisition and Fan-Out
+
+**User Story:** As a developer, I want a single acquisition loop per camera that shares the most recent frame with all viewers, so that the device is read once and the result is reused instead of being re-grabbed per request.
+
+#### Acceptance Criteria
+
+1. WHILE one or more Viewers are subscribed to a Physical_Camera, THE Stream_Broadcaster SHALL maintain exactly one active acquisition session that reads frames from that Physical_Camera, regardless of the number of subscribed Viewers.
+2. WHEN the Stream_Broadcaster acquires a new frame from a Physical_Camera, THE Stream_Broadcaster SHALL replace the Latest_Frame for that Physical_Camera with the newly acquired frame.
+3. WHEN a Viewer requests the current preview frame, THE Stream_Broadcaster SHALL return the Latest_Frame for that Physical_Camera within 100 milliseconds of receiving the request.
+4. WHERE no new frame has been acquired since a Viewer's previous request, THE Stream_Broadcaster SHALL return the most recent Latest_Frame for that Physical_Camera to that Viewer without re-grabbing from the Physical_Camera.
+5. WHEN two or more Viewers request the current preview frame for the same Physical_Camera within the same acquisition interval, THE Stream_Broadcaster SHALL return the identical Latest_Frame to each requesting Viewer.
+6. IF no Latest_Frame is available for a Physical_Camera when a Viewer requests the current preview frame, THEN THE Stream_Broadcaster SHALL return a response to the Viewer indicating that no frame is currently available, while retaining the active acquisition session.
+7. IF frame acquisition from a Physical_Camera fails, THEN THE Stream_Broadcaster SHALL retain the existing Latest_Frame unchanged and return an indication of the acquisition failure to subscribed Viewers.
+8. THE Stream_Broadcaster SHALL provide the same frame-sharing behavior defined in criteria 1 through 7 for GenICam/USB3Vision (Aravis) cameras and for NVIDIA CSI (GStreamer) cameras.
+
+### Requirement 3: Stream Session Lifecycle
+
+**User Story:** As an operator, I want the camera stream to start automatically when the first viewer opens it and stop when the last viewer leaves, so that the device is only acquiring while someone is actually watching.
+
+#### Acceptance Criteria
+
+1. WHEN the first Viewer subscribes to a Physical_Camera that has no active Stream_Session, THE Stream_Broadcaster SHALL start a Stream_Session for that Physical_Camera within 5 seconds.
+2. IF the Device_Claim for a Physical_Camera cannot be acquired when starting a Stream_Session, THEN THE Stream_Broadcaster SHALL not start the Stream_Session and SHALL return an error indication to the subscribing Viewer identifying the Physical_Camera.
+3. WHEN the last active Viewer unsubscribes from a Physical_Camera, THE Stream_Broadcaster SHALL stop the Stream_Session for that Physical_Camera within 5 seconds.
+4. WHEN the Stream_Broadcaster stops a Stream_Session, THE Stream_Broadcaster SHALL release the Device_Claim for that Physical_Camera.
+5. IF stopping a Stream_Session fails, THEN THE Stream_Broadcaster SHALL release the Device_Claim for that Physical_Camera, mark the Stream_Session as stopped, and return an error indication identifying the failure.
+6. WHEN a Viewer explicitly unsubscribes from a Physical_Camera, THE Stream_Broadcaster SHALL stop delivering frames to that Viewer within 1 second.
+7. WHEN a Stream_Session stops, THE Stream_Broadcaster SHALL stop delivering frames to all Viewers that were subscribed to that Stream_Session within 1 second.
+8. IF a Stale_Viewer is detected, THEN THE Stream_Broadcaster SHALL treat the Stale_Viewer as unsubscribed.
+9. THE Stream_Broadcaster SHALL detect a Stale_Viewer when no Viewer_Heartbeat has been received from that Viewer within 30 seconds of its last-active timestamp.
+10. WHEN a new Stream_Session starts for a Physical_Camera, THE Stream_Broadcaster SHALL make the first Latest_Frame available to Viewers within 10 seconds.
+11. IF no frame is acquired within 10 seconds of a new Stream_Session starting, THEN THE Stream_Broadcaster SHALL report a stream error to the subscribed Viewers identifying the Physical_Camera.
+
+### Requirement 4: Performance and Freshness
+
+**User Story:** As an operator, I want the shared live preview to stay responsive and current, so that multiple viewers see a near-real-time view rather than stale or stuttering images.
+
+#### Acceptance Criteria
+
+1. WHEN a Viewer requests the current preview frame while a Latest_Frame is available, THE Stream_Broadcaster SHALL return that frame within 500 milliseconds of receiving the request.
+2. IF a Viewer requests the current preview frame while no Latest_Frame is available, THEN THE Stream_Broadcaster SHALL return a response indicating no frame is currently available within 500 milliseconds of receiving the request.
+3. WHILE the Physical_Camera is delivering frames at a rate of 5 frames per second or greater, THE Stream_Broadcaster SHALL refresh the Latest_Frame at a rate of at least 5 frames per second.
+4. WHILE the Physical_Camera is delivering frames at a rate below 5 frames per second, THE Stream_Broadcaster SHALL refresh the Latest_Frame at the rate the Physical_Camera is delivering frames.
+5. WHILE the number of Viewers subscribed to a Physical_Camera is between 1 and the supported Viewer count defined in Requirement 1, THE Stream_Broadcaster SHALL maintain the Latest_Frame refresh rate specified in criteria 3 and 4 for that Physical_Camera independent of the number of subscribed Viewers.
+6. WHEN serving the Latest_Frame to a Viewer, THE Stream_Broadcaster SHALL return a frame that was acquired no more than 2 seconds before the time the request was received.
+7. IF the most recently acquired Latest_Frame was acquired more than 2 seconds before the request was received, THEN THE Stream_Broadcaster SHALL return a response indicating the frame is stale within 500 milliseconds of receiving the request.
+
+### Requirement 5: Interaction with Edit-Settings Preview
+
+**User Story:** As an operator adjusting camera settings, I want my gain, exposure, and advanced feature changes to apply to the live shared preview, so that I can verify settings while others may also be viewing the same camera.
+
+#### Acceptance Criteria
+
+1. WHEN a user applies camera control values (gain, exposure, or advanced GenICam features) through the Edit_Settings_Preview flow, THE Camera_Manager SHALL apply those values to the active Stream_Session for that Physical_Camera within 2 seconds of the apply request.
+2. WHEN camera control values are applied to an active Stream_Session, THE Stream_Broadcaster SHALL reflect the applied values in the Latest_Frame delivered to all subscribed Viewers within 5 frames following completion of the apply operation.
+3. WHILE camera control values are being applied to a Physical_Camera, THE Stream_Broadcaster SHALL continue delivering the most recent available frame to subscribed Viewers without terminating the Stream_Session and without dropping any subscribed Viewer.
+4. WHEN a user requests an Edit_Settings_Preview with a per-request configuration override, THE Camera_Manager SHALL return a single preview frame that reflects the override configuration without modifying the camera control values applied to the active Stream_Session or the Latest_Frame delivered to other subscribed Viewers.
+5. IF applying a camera control value fails, THEN THE Camera_Manager SHALL return a descriptive error identifying the failed control, SHALL retain the camera control values that were in effect before the failed apply request, and SHALL keep the Stream_Session active.
+
+### Requirement 6: Interaction with the Inference and Capture Pipeline
+
+**User Story:** As an operator running inference, I want capture and workflow frame grabs to keep working while people are viewing the live preview, so that monitoring and inspection can happen at the same time without conflicting over the device.
+
+#### Acceptance Criteria
+
+1. WHEN the Inference_Pipeline requests a frame from a Physical_Camera that has an active Stream_Session, THE Camera_Manager SHALL return the frame using the existing Device_Claim within 500 milliseconds and SHALL NOT open a second Device_Claim for that Physical_Camera.
+2. WHILE the Inference_Pipeline is acquiring a frame from a Physical_Camera that has an active Stream_Session, THE Stream_Broadcaster SHALL continue delivering preview frames to each subscribed Viewer at a rate no lower than 90 percent of the Stream_Session configured frame rate, with no single inter-frame gap exceeding 500 milliseconds.
+3. WHEN the Inference_Pipeline requests a frame from a Physical_Camera that has no active Stream_Session, THE Camera_Manager SHALL open a dedicated Device_Claim, acquire the frame, and return it within 2000 milliseconds.
+4. WHEN the Inference_Pipeline applies a per-capture image-source configuration whose parameter values are within their accepted ranges, THE Camera_Manager SHALL return a frame that reflects that configuration.
+5. IF the Inference_Pipeline applies a per-capture image-source configuration containing one or more parameter values outside their accepted ranges, THEN THE Camera_Manager SHALL reject the request, return an error indication identifying the invalid parameter, and preserve the previously active image-source configuration unchanged.
+6. IF the Camera_Manager cannot return a requested frame within the applicable time bound or the Physical_Camera becomes unavailable, THEN THE Camera_Manager SHALL return an error indication to the Inference_Pipeline identifying the failure and SHALL leave any active Stream_Session and its Device_Claim intact.
+
+### Requirement 7: Error Handling and Camera Disconnection
+
+**User Story:** As an operator, I want clear feedback when a shared camera stream fails, so that all viewers understand the camera is unavailable instead of seeing a frozen image indefinitely.
+
+#### Acceptance Criteria
+
+1. IF the Stream_Broadcaster fails to acquire a frame within the configured frame timeout (configurable from 500 to 30,000 milliseconds, default 5,000 milliseconds), THEN THE Camera_Manager SHALL mark the Physical_Camera as disconnected within 1,000 milliseconds of the timeout expiring.
+2. WHEN the Camera_Manager marks a Physical_Camera as disconnected, THE Stream_Broadcaster SHALL report a stream error identifying the Physical_Camera to every subscribed Viewer within 1,000 milliseconds, where each error indicates the camera is disconnected.
+3. WHEN a Physical_Camera becomes disconnected during a Stream_Session, THE Stream_Broadcaster SHALL stop the Stream_Session within 2,000 milliseconds.
+4. WHEN the Stream_Broadcaster stops a Stream_Session due to disconnection, THE Stream_Broadcaster SHALL release the Device_Claim before reporting completion.
+5. IF a Viewer requests a frame while the Physical_Camera is disconnected, THEN THE Stream_Broadcaster SHALL return a stream error indicating the camera is disconnected and SHALL NOT return any previously acquired frame.
+6. WHEN a Viewer subscribes to a Physical_Camera that cannot be opened within the configured open timeout (configurable from 500 to 30,000 milliseconds, default 5,000 milliseconds) after a maximum of 3 open attempts, THE Stream_Broadcaster SHALL return an error identifying the Physical_Camera and SHALL NOT start a Stream_Session.
+7. IF the last Viewer unsubscribes while a frame acquisition is in progress, THEN THE Stream_Broadcaster SHALL complete the release of the Device_Claim before allowing a new Stream_Session for that Physical_Camera to start.
+
+### Requirement 8: Viewer Subscription Management
+
+**User Story:** As a developer, I want viewers to be tracked explicitly so the system knows when to start and stop streams, so that abandoned tabs do not keep the device claimed forever.
+
+#### Acceptance Criteria
+
+1. WHEN a Viewer subscribes to a Physical_Camera, THE Stream_Broadcaster SHALL register the Viewer as an active Viewer for that Physical_Camera within 1 second of receiving the subscription request.
+2. WHILE a Viewer is registered as active, THE Stream_Broadcaster SHALL accept Viewer_Heartbeats from that Viewer that are received at intervals of no more than 10 seconds to keep the subscription active.
+3. WHEN a Viewer_Heartbeat is received from a registered Viewer, THE Stream_Broadcaster SHALL update the last-active timestamp for that Viewer to the receipt time.
+4. WHEN the current count of active Viewers for a Physical_Camera is requested, THE Stream_Broadcaster SHALL return a non-negative integer count within 1 second of the request.
+5. IF a Viewer subscribes more than once to the same Physical_Camera, THEN THE Stream_Broadcaster SHALL track each subscription as a distinct active Viewer, counting each toward the active Viewer count.
+6. IF no Viewer_Heartbeat is received from a registered Viewer within 30 seconds of that Viewer's last-active timestamp, THEN THE Stream_Broadcaster SHALL deregister that Viewer from the Physical_Camera and decrement the active Viewer count for that Physical_Camera.
+7. WHEN the count of active Viewers for a Physical_Camera reaches 0, THE Stream_Broadcaster SHALL stop the Stream_Session and release the Device_Claim on that Physical_Camera within 5 seconds.
+8. WHEN a Viewer explicitly unsubscribes from a Physical_Camera, THE Stream_Broadcaster SHALL deregister that Viewer and decrement the active Viewer count for that Physical_Camera within 1 second.

--- a/.kiro/specs/concurrent-camera-stream-viewing/tasks.md
+++ b/.kiro/specs/concurrent-camera-stream-viewing/tasks.md
@@ -1,0 +1,313 @@
+# Implementation Plan: Concurrent Camera Stream Viewing
+
+## Overview
+
+This plan converts the broadcast-model design into incremental coding steps. It builds the shared
+stream stack bottom-up: data models and configuration, the `CameraBackend` abstraction, the
+single-slot `StreamSession`, the acquisition worker, then the process-wide `StreamBroadcaster`
+registry. From there it rewires inference/capture and edit-settings onto the single shared claim,
+exposes the new `/streams/...` API endpoints, updates the polling frontend preview, and closes with
+real-device integration/performance tests.
+
+Implementation language is **Python** (per the design's code), with **Hypothesis** property-based
+tests added to the existing pytest suite under `test/backend-test`. New backend code lives under
+`src/backend/utils/streaming/`. Each correctness property (1–21) maps to exactly one property-based
+test placed close to the code it validates; stateful/interleaving properties (1, 2, 6, 8) use
+Hypothesis `RuleBasedStateMachine`. All property tests run a minimum of 100 iterations against a
+mock `CameraBackend` with an injected clock, parametrized over mock Aravis and GStreamer backends
+where backend parity matters.
+
+## Tasks
+
+- [x] 1. Stream data models and configuration
+  - [x] 1.1 Implement core stream data models
+    - In `src/backend/utils/streaming/models.py`, define `LatestFrame` (frozen: data, width, height, seq, acquired_at), `Viewer` (viewer_id, camera_id, subscribed_at, last_active), `SessionState`, `FrameStatus`, `FrameResult`, and `SubscribeResult` dataclasses/enums
+    - Add `src/backend/utils/streaming/__init__.py`
+    - _Requirements: 2.2, 8.5_
+
+  - [x] 1.2 Implement `StreamConfig` with timeout clamping
+    - Add `StreamConfig` to `models.py` with frame_timeout_ms, open_timeout_ms, max_open_attempts, max_viewers, heartbeat/stale/first-frame timeouts, stale_after_s, min_refresh_fps
+    - Clamp `frame_timeout_ms` and `open_timeout_ms` to [500, 30000] on construction
+    - _Requirements: 7.1, 7.6_
+
+  - [x]* 1.3 Write property test for timeout clamping
+    - **Property 15: Timeout/configuration clamping** — effective timeout equals the configured value clamped to [500, 30000] ms
+    - **Validates: Requirements 7.1**
+    - Place in `test/backend-test/utils/streaming/test_stream_models.py`
+
+- [x] 2. CameraBackend abstraction and adapters
+  - [x] 2.1 Define the `CameraBackend` protocol and `RawFrame`
+    - In `src/backend/utils/streaming/backends.py`, define the `CameraBackend` Protocol (open, start_stream, grab, apply_features, stop_stream, close) and the `RawFrame` type
+    - _Requirements: 2.8_
+
+  - [x] 2.2 Implement `AravisBackend` adapter
+    - Wrap the existing `Camera` class / `get_camera_frame()` Aravis path; drive continuous acquisition from a worker loop instead of per-request software-trigger; route `apply_features` through `apply_device_features` / `_apply_config_features`
+    - Enforce open with ≤ 3 attempts within open timeout
+    - _Requirements: 2.8, 7.6_
+
+  - [x] 2.3 Implement `GStreamerBackend` adapter
+    - Wrap a persistent pipeline ending in an `appsink` pull loop (replacing one-shot `execute_image_source_pipeline` for live view); implement open/start_stream/grab/stop_stream/close
+    - _Requirements: 2.8_
+
+  - [x]* 2.4 Implement mock `CameraBackend` test double
+    - In `test/backend-test/utils/streaming/mock_camera_backend.py`, record open/close/grab counts, simulate open failure, grab timeout/failure, and stop failure; provide mock Aravis and GStreamer variants and an injectable clock helper
+    - _Requirements: 2.8_
+
+  - [x]* 2.5 Write unit tests for backend adapters
+    - Subscribe→grab→close happy path for each adapter against fakes
+    - _Requirements: 2.8_
+
+- [x] 3. StreamSession: latest-frame slot, viewer registry, freshness
+  - [x] 3.1 Implement `StreamSession`
+    - In `src/backend/utils/streaming/session.py`, implement single-writer/many-reader latest-frame slot (`publish`/`read_latest` under a brief writer lock), viewer registry (`add_viewer`/`remove_viewer`/`is_empty`), monotonic seq + acquired_at, and freshness/staleness + no-frame classification in `read_latest`
+    - _Requirements: 2.2, 2.4, 2.5, 2.6, 4.6, 4.7_
+
+  - [x]* 3.2 Write property test for fan-out
+    - **Property 3: Fan-out delivers the identical latest frame to every viewer** — every viewer reading in an interval gets the byte-identical, same-seq, most-recent frame
+    - **Validates: Requirements 1.1, 1.4, 2.2, 2.5**
+    - `test/backend-test/utils/streaming/test_session_fanout.py`
+
+  - [x]* 3.3 Write property test for independent, no-re-grab reads
+    - **Property 4: Reads are independent of other viewers and do not re-grab** — get_frame is a pure function of the slot; repeated reads with no publish return the same frame and trigger no device grab
+    - **Validates: Requirements 1.5, 2.4**
+    - `test/backend-test/utils/streaming/test_session_reads.py`
+
+  - [x]* 3.4 Write property test for frame freshness predicate
+    - **Property 11: Frame freshness predicate** — read returns OK when `now - acquired_at <= stale_after_s`, STALE otherwise
+    - **Validates: Requirements 4.6, 4.7**
+    - `test/backend-test/utils/streaming/test_session_freshness.py`
+
+  - [x]* 3.5 Write property test for no-frame-yet handling
+    - **Property 12: No-frame-yet handling** — started session with no publish returns NO_FRAME and stays active
+    - **Validates: Requirements 2.6, 4.2**
+    - `test/backend-test/utils/streaming/test_session_noframe.py`
+
+  - [x]* 3.6 Write property test for heartbeat/staleness predicate
+    - **Property 9: Heartbeat update and staleness predicate** — heartbeat sets last_active to t; viewer is stale exactly when `now - last_active > stale_timeout_s`
+    - **Validates: Requirements 3.9, 8.3**
+    - `test/backend-test/utils/streaming/test_session_heartbeat.py`
+
+- [x] 4. Acquisition worker
+  - [x] 4.1 Implement the acquisition worker loop
+    - In `src/backend/utils/streaming/worker.py`, implement one worker per session: grab→publish loop, rate ceiling cap that never drops below device cadence, first-frame timeout, and disconnect detection on grab timeout/failure (mark disconnected, transition session to ERROR→stop); retain last good slot on a failed grab
+    - _Requirements: 2.7, 3.10, 3.11, 4.3, 4.4, 7.1_
+
+  - [x]* 4.2 Write property test for producer cadence independence
+    - **Property 5: Producer cadence is independent of viewer count** — published frame sequence is identical for 1 vs max_viewers readers; no read delays/prevents a publish (drop-to-latest)
+    - **Validates: Requirements 4.5**
+    - `test/backend-test/utils/streaming/test_worker_cadence.py`
+
+  - [x]* 4.3 Write property test for acquisition-failure frame retention
+    - **Property 13: Acquisition failure preserves the last good frame** — a failed grab does not overwrite the slot and an acquisition-failure indication is produced
+    - **Validates: Requirements 2.7**
+    - `test/backend-test/utils/streaming/test_worker_failure.py`
+
+- [x] 5. StreamBroadcaster registry and lifecycle
+  - [x] 5.1 Implement broadcaster registry, subscribe/unsubscribe, and session start/stop
+    - In `src/backend/utils/streaming/broadcaster.py`, implement the process-wide `{camera_id -> StreamSession}` singleton with thread-safe subscribe (start-on-first), unsubscribe (stop-on-last with backend `close()`), `viewer_count`, and the single-device-claim invariant
+    - _Requirements: 1.2, 2.1, 3.1, 3.3, 3.4, 3.7, 8.1, 8.4, 8.7, 8.8_
+
+  - [x] 5.2 Implement viewer-limit and open-failure handling
+    - Reject subscribe with reason `viewer_limit` at max_viewers (existing viewers untouched); on `open()` failure retry ≤ 3 attempts then reject with reason `camera_unavailable`, leaving no session/claim and not affecting other cameras
+    - _Requirements: 1.3, 1.6, 1.7, 3.2, 7.6_
+
+  - [x] 5.3 Implement heartbeat refresh and stale-viewer sweep
+    - Implement `heartbeat` (refresh last_active), and `sweep_stale_viewers(now)` that deregisters viewers past stale_timeout_s, decrements counts, and stops emptied sessions
+    - _Requirements: 3.8, 8.2, 8.3, 8.6, 8.7_
+
+  - [x] 5.4 Implement `get_frame` state encoding and disconnection cascade
+    - Encode NO_FRAME/STALE/DISCONNECTED in `get_frame` (refreshing heartbeat); on disconnect stop the session, release the claim before reporting completion, and return DISCONNECTED with no cached payload to all viewers
+    - _Requirements: 2.6, 3.5, 3.11, 4.7, 7.2, 7.3, 7.4, 7.5_
+
+  - [x]* 5.5 Write stateful property test for the single-claim invariant
+    - **Property 1: Single device-claim invariant** — `RuleBasedStateMachine` over subscribe/unsubscribe/sweep/disconnect: claim count is 1 with ≥1 viewer, 0 with none, never > 1, never overlapping
+    - **Validates: Requirements 1.2, 2.1, 3.4, 7.7**
+    - `test/backend-test/utils/streaming/test_broadcaster_claim.py`
+
+  - [x]* 5.6 Write stateful property test for session lifecycle
+    - **Property 2: Session lifecycle (start on first, stop and release on last)** — `RuleBasedStateMachine`: first subscriber creates exactly one session; count returning to 0 stops it and invokes `close()`
+    - **Validates: Requirements 3.1, 3.3, 3.7, 8.7**
+    - `test/backend-test/utils/streaming/test_broadcaster_lifecycle.py`
+
+  - [x]* 5.7 Write stateful property test for viewer-limit enforcement
+    - **Property 6: Viewer-limit enforcement** — `RuleBasedStateMachine`: subscribe past max_viewers rejected with `viewer_limit`, count stays max, existing viewers still read
+    - **Validates: Requirements 1.3, 1.6**
+    - `test/backend-test/utils/streaming/test_broadcaster_viewerlimit.py`
+
+  - [x]* 5.8 Write stateful property test for viewer-count and duplicate subscriptions
+    - **Property 8: Viewer-count correctness and duplicate subscriptions** — `RuleBasedStateMachine`: reported count is a non-negative integer equal to distinct viewers; K subscribes yield K distinct ids each counted
+    - **Validates: Requirements 8.1, 8.4, 8.5, 8.8**
+    - `test/backend-test/utils/streaming/test_broadcaster_viewercount.py`
+
+  - [x]* 5.9 Write property test for open-failure handling
+    - **Property 7: Open-failure handling** — ≤ 3 open attempts then reject with `camera_unavailable`, no session/zero claims, other healthy cameras still subscribe
+    - **Validates: Requirements 1.7, 3.2, 7.6**
+    - `test/backend-test/utils/streaming/test_broadcaster_openfail.py`
+
+  - [x]* 5.10 Write property test for stale sweep
+    - **Property 10: Stale sweep deregisters, heartbeats keep alive** — sweep removes exactly viewers with `now - last_active > stale_timeout_s`; recently-heartbeated viewers retained
+    - **Validates: Requirements 3.8, 8.2, 8.6**
+    - `test/backend-test/utils/streaming/test_broadcaster_sweep.py`
+
+  - [x]* 5.11 Write property test for the disconnection cascade
+    - **Property 14: Disconnection cascade** — on grab timeout/failure marking disconnect, session stops with `close()` before completion and every viewer's subsequent get_frame returns DISCONNECTED with no payload
+    - **Validates: Requirements 3.5, 3.11, 7.1, 7.2, 7.3, 7.4, 7.5**
+    - `test/backend-test/utils/streaming/test_broadcaster_disconnect.py`
+
+- [x] 6. Checkpoint - broadcaster core
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 7. Inference/capture single-claim sharing
+  - [x] 7.1 Implement `get_inference_frame` reuse with dedicated-claim fallback
+    - Add `get_inference_frame(camera_id, config)` to `broadcaster.py`: when a session is active return the session frame without opening a second claim; when none exists open exactly one dedicated claim, grab, and release it. On failure with an active session, return an error and leave the session + claim intact
+    - _Requirements: 6.1, 6.3, 6.4, 6.6_
+
+  - [x] 7.2 Rewire `get_camera_frame()` onto the broadcaster
+    - In `src/backend/utils/camera_manager.py`, route `get_camera_frame(camera_id, config)` through `broadcaster.get_inference_frame(...)`, preserving the signature so `digital_input_*`, `workflow`, and capture endpoints are unchanged
+    - _Requirements: 6.1, 6.3_
+
+  - [x] 7.3 Implement out-of-range capture configuration validation
+    - Validate per-capture image-source config against feature bounds in `backends.py`; reject out-of-range values with an error identifying the offending parameter and preserve the active config
+    - _Requirements: 6.5_
+
+  - [x]* 7.4 Write property test for inference claim reuse/fallback
+    - **Property 16: Inference reuses the session claim, falls back when none** — claim count stays 1 with an active session; with none, opens exactly one dedicated claim and releases it (count returns to 0)
+    - **Validates: Requirements 6.1, 6.3, 6.4**
+    - `test/backend-test/utils/streaming/test_inference_reuse.py`
+
+  - [x]* 7.5 Write property test for inference-failure session integrity
+    - **Property 17: Inference failure leaves the session intact** — failed/unavailable inference request returns an error while the session stays RUNNING with its claim retained
+    - **Validates: Requirements 6.6**
+    - `test/backend-test/utils/streaming/test_inference_failure.py`
+
+  - [x]* 7.6 Write property test for out-of-range capture rejection
+    - **Property 21: Out-of-range capture configuration is rejected** — request rejected identifying an offending parameter, previously active config preserved
+    - **Validates: Requirements 6.5**
+    - `test/backend-test/utils/streaming/test_capture_validation.py`
+
+  - [x]* 7.7 Write regression tests for `get_camera_frame` compatibility
+    - Confirm `digital_input_*`, `workflow`, and capture callers keep working; extend `test/backend-test/utils/test_camera_manager.py`
+    - _Requirements: 6.1, 6.3_
+
+- [x] 8. Edit-settings interaction
+  - [x] 8.1 Implement live `apply_settings` on a running session
+    - Add `apply_settings(camera_id, features)` to `broadcaster.py`: apply gain/exposure/advanced features to the live session via the backend, keep session RUNNING and the viewer set unchanged, and keep the latest frame readable throughout
+    - _Requirements: 5.1, 5.2, 5.3_
+
+  - [x] 8.2 Implement settings-apply failure rollback
+    - On any control failure, return an error naming the failed control, retain prior in-effect values, and keep the session active
+    - _Requirements: 5.5_
+
+  - [x] 8.3 Implement isolated single-frame override preview path
+    - Add a single-frame override path (used by `POST /image-sources/{id}/preview`) that returns a preview reflecting the override without mutating the live session's applied values or the shared latest frame
+    - _Requirements: 5.4_
+
+  - [x]* 8.4 Write property test for live settings apply preserving the session
+    - **Property 18: Live settings apply preserves the session** — backend reflects valid values, session stays RUNNING, viewer set unchanged, latest frame readable throughout
+    - **Validates: Requirements 5.1, 5.2, 5.3**
+    - `test/backend-test/utils/streaming/test_settings_apply.py`
+
+  - [x]* 8.5 Write property test for settings-apply failure retention
+    - **Property 19: Settings-apply failure retains prior values** — error identifies the failed control, prior values retained, session active
+    - **Validates: Requirements 5.5**
+    - `test/backend-test/utils/streaming/test_settings_failure.py`
+
+  - [x]* 8.6 Write property test for override preview isolation
+    - **Property 20: Override preview isolation** — override preview leaves the session's applied values and the shared latest frame unchanged
+    - **Validates: Requirements 5.4**
+    - `test/backend-test/utils/streaming/test_override_isolation.py`
+
+- [x] 9. Stream API endpoints
+  - [x] 9.1 Implement the `/streams/...` endpoints and register the router
+    - Create `src/backend/endpoints/streams.py` with `POST /streams/{camera_id}/subscribe`, `GET /streams/{camera_id}/frame`, `POST /streams/{camera_id}/heartbeat`, `POST /streams/{camera_id}/unsubscribe`, `GET /streams/{camera_id}/viewers`, and `POST /streams/{camera_id}/settings` as thin clients over the broadcaster; register the router in `app.py`
+    - _Requirements: 1.2, 2.3, 3.1, 3.6, 4.1, 4.6, 5.1, 5.2, 8.1, 8.2, 8.3, 8.4, 8.8_
+
+  - [x] 9.2 Route the override preview endpoint to the isolated path
+    - Wire `POST /image-sources/{id}/preview` (in `src/backend/endpoints/image_source.py`) to the single-frame override path from task 8.3
+    - _Requirements: 5.4_
+
+  - [x]* 9.3 Write endpoint serialization/status-code tests
+    - Assert HTTP status mapping for OK / NO_FRAME / STALE / DISCONNECTED and subscribe reasons `viewer_limit` / `camera_unavailable`; cover the 8th-accepted / 9th-rejected boundary
+    - Place in `test/backend-test/api-endpoints/test_streams_api.py`
+    - _Requirements: 1.3, 1.6, 1.7, 2.6, 4.7, 7.5_
+
+- [x] 10. Checkpoint - API and sharing complete
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 11. Frontend polling preview lifecycle
+  - [x] 11.1 Wire the preview to subscribe/heartbeat/unsubscribe
+    - Update the camera preview component to call subscribe on mount (store viewerId), poll the frame endpoint (doubling as heartbeat), and unsubscribe on unmount including `navigator.sendBeacon` on tab close
+    - _Requirements: 3.6, 8.1, 8.2, 8.8_
+
+  - [x] 11.2 Render frame-state and subscribe-rejection feedback
+    - Handle NO_FRAME / STALE / DISCONNECTED frame states and `viewer_limit` / `camera_unavailable` subscribe rejections with clear user feedback instead of a frozen image
+    - _Requirements: 1.6, 1.7, 2.6, 4.7, 7.5_
+
+- [x] 12. Integration and performance tests (timing / real-device)
+  - [x]* 12.1 First-frame and latency-bound integration tests
+    - First frame within 10 s of session start; latest-frame read < 100 ms / < 500 ms; stale response < 500 ms
+    - _Requirements: 2.3, 3.10, 4.1, 4.2, 4.7_
+    - `test/backend-test/utils/streaming/integration/test_latency_bounds.py`
+
+  - [x]* 12.2 Refresh-rate and viewer-independence performance tests
+    - Refresh ≥ 5 fps for a ≥ 5 fps source, tracks device rate below that; refresh rate independent of viewer count up to 8
+    - _Requirements: 4.3, 4.4, 4.5_
+    - `test/backend-test/utils/streaming/integration/test_refresh_rate.py`
+
+  - [x]* 12.3 New-subscriber and applied-setting timing tests
+    - New subscriber starts receiving within 2000 ms with no disruption to existing viewers; applied setting visible within 5 frames
+    - _Requirements: 1.4, 5.2_
+    - `test/backend-test/utils/streaming/integration/test_subscriber_and_settings_timing.py`
+
+  - [x]* 12.4 Inference-during-session timing tests
+    - Inference grab during active session keeps viewer inter-frame gaps ≤ 500 ms and ≥ 90% rate; dedicated-claim grab returns within 2000 ms
+    - _Requirements: 6.2, 6.3_
+    - `test/backend-test/utils/streaming/integration/test_inference_timing.py`
+
+  - [x]* 12.5 End-to-end fake-device tests for both backends
+    - Run against a Fake Aravis camera (`Aravis.enable_interface("Fake")`) and a simulated GStreamer source with 1–3 examples each
+    - _Requirements: 2.8_
+    - `test/backend-test/utils/streaming/integration/test_end_to_end_backends.py`
+
+- [x] 13. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional test sub-tasks and can be skipped for a faster MVP; core
+  implementation tasks are never optional.
+- Each task references granular requirement clauses for traceability; each property test names the
+  design property number and the requirements it validates.
+- Property tests use a mock `CameraBackend` + injected clock, run ≥ 100 iterations, and are
+  parametrized over mock Aravis and GStreamer backends for parity (Req 2.8). Stateful properties
+  (1, 2, 6, 8) use `RuleBasedStateMachine`.
+- Wall-clock and real-device acceptance criteria are covered by the integration/performance tests
+  in section 12, not by the property tests.
+- Checkpoints provide incremental validation at natural boundaries.
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1", "2.1"] },
+    { "id": 1, "tasks": ["1.2", "2.2"] },
+    { "id": 2, "tasks": ["1.3", "2.3", "2.4"] },
+    { "id": 3, "tasks": ["2.5", "3.1"] },
+    { "id": 4, "tasks": ["3.2", "3.3", "3.4", "3.5", "3.6", "4.1"] },
+    { "id": 5, "tasks": ["4.2", "4.3", "5.1"] },
+    { "id": 6, "tasks": ["5.2"] },
+    { "id": 7, "tasks": ["5.3"] },
+    { "id": 8, "tasks": ["5.4"] },
+    { "id": 9, "tasks": ["7.1", "5.5", "5.6", "5.7", "5.8", "5.9", "5.10", "5.11"] },
+    { "id": 10, "tasks": ["8.1", "7.2", "7.3"] },
+    { "id": 11, "tasks": ["8.2"] },
+    { "id": 12, "tasks": ["8.3"] },
+    { "id": 13, "tasks": ["9.1", "7.4", "7.5", "7.6", "7.7", "8.4", "8.5", "8.6"] },
+    { "id": 14, "tasks": ["9.2", "9.3"] },
+    { "id": 15, "tasks": ["11.1"] },
+    { "id": 16, "tasks": ["11.2"] },
+    { "id": 17, "tasks": ["12.1", "12.2", "12.3", "12.4", "12.5"] }
+  ]
+}
+```

--- a/README.md
+++ b/README.md
@@ -282,6 +282,14 @@ version, and compile models for the matching compilation target (Jetson JetPack
 
 **Debugging:** `VERBOSE=1 ./gdk-component-build-and-publish.sh`
 
+**Publishing without rebuilding (`publish-ecr-only.sh`).** `gdk-component-build-and-publish.sh` always does a clean rebuild before publishing. If you have already built the images (e.g. the build succeeded but the publish failed because an auth/login session expired), use `publish-ecr-only.sh` to publish the **already-built** images without spending ~15-20 minutes on another build:
+
+```bash
+./publish-ecr-only.sh        # aarch64 JetPack 5 (aws.edgeml.dda.LocalServer.arm64JP5)
+```
+
+It reuses the locally-built `flask-app:latest` / `react-webapp:latest` images and the existing `custom-build/` staging directory, and runs only the ECR + S3 publish path used for >2 GB artifacts: bump to the next patch version, push the images to ECR, upload the small scripts/compose zip to S3, rewrite the recipe to reference the `docker:` + S3 artifacts, register the new component version, and tag it for portal discovery. It fails fast if AWS credentials are invalid or the built images/staging dir are missing (run a build first). It currently targets the arm64 JetPack 5 component; edit `COMPONENT_NAME`/`ARCH` near the top for other targets.
+
 > **Notice**: Stop the EC2 build server after building to avoid unnecessary costs.
 
 <details>
@@ -937,6 +945,7 @@ defect-detection-application/
 ├── datasets/                    # Sample datasets
 ├── build-custom.sh              # Custom build logic
 ├── gdk-component-build-and-publish.sh
+├── publish-ecr-only.sh          # Publish already-built images (no rebuild)
 └── setup-build-server.sh
 ```
 

--- a/publish-ecr-only.sh
+++ b/publish-ecr-only.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+set -e
+set -o pipefail
+# Publish-only (ECR + S3) for an already-built LocalServer component, WITHOUT
+# rebuilding. Mirrors the >2GB ECR path in gdk-component-build-and-publish.sh,
+# reusing the locally-built flask-app:latest / react-webapp:latest images and the
+# existing custom-build staging dir. For aarch64 JetPack 5.
+
+ARCH="aarch64"
+COMPONENT_NAME="aws.edgeml.dda.LocalServer.arm64JP5"
+
+echo "Checking AWS credentials..."
+aws sts get-caller-identity >/dev/null || { echo "ERROR: AWS credentials invalid/expired"; exit 1; }
+
+PUB_REGION=$(aws configure get region 2>/dev/null || true)
+[ -z "$PUB_REGION" ] && PUB_REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+PUB_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+if [ -z "$PUB_REGION" ] || [ -z "$PUB_ACCOUNT_ID" ] || [ "$PUB_ACCOUNT_ID" = "None" ]; then
+    echo "ERROR: cannot resolve region/account (region='$PUB_REGION' account='$PUB_ACCOUNT_ID')"; exit 1
+fi
+
+ECR_REGISTRY="${PUB_ACCOUNT_ID}.dkr.ecr.${PUB_REGION}.amazonaws.com"
+ECR_REPO_BACKEND="${ECR_REGISTRY}/dda/flask-app"
+ECR_REPO_FRONTEND="${ECR_REGISTRY}/dda/react-webapp"
+S3_BUCKET="dda-component-${PUB_REGION}-${PUB_ACCOUNT_ID}"
+
+# Pre-flight: the images and staging dir must already exist (built, not rebuilt here).
+docker image inspect flask-app:latest >/dev/null 2>&1 || { echo "ERROR: flask-app:latest not found"; exit 1; }
+docker image inspect react-webapp:latest >/dev/null 2>&1 || { echo "ERROR: react-webapp:latest not found"; exit 1; }
+STAGE_DIR="custom-build/${COMPONENT_NAME}"
+[ -d "$STAGE_DIR" ] || { echo "ERROR: staging dir $STAGE_DIR not found"; exit 1; }
+
+# Next version = bump patch of the latest registered version (start at 1.0.0).
+LATEST_VERSION=$(aws greengrassv2 list-component-versions \
+    --arn "arn:aws:greengrass:${PUB_REGION}:${PUB_ACCOUNT_ID}:components:${COMPONENT_NAME}" \
+    --query 'componentVersions[0].componentVersion' --output text 2>/dev/null || echo "None")
+if [ "$LATEST_VERSION" = "None" ] || [ -z "$LATEST_VERSION" ]; then
+    COMPONENT_VERSION="1.0.0"
+else
+    V_MAJOR=$(echo "$LATEST_VERSION" | cut -d. -f1)
+    V_MINOR=$(echo "$LATEST_VERSION" | cut -d. -f2)
+    V_PATCH=$(echo "$LATEST_VERSION" | cut -d. -f3)
+    COMPONENT_VERSION="${V_MAJOR}.${V_MINOR}.$((V_PATCH + 1))"
+fi
+echo "Latest registered: ${LATEST_VERSION}; publishing version: $COMPONENT_VERSION"
+
+# Authenticate to ECR and ensure repos exist.
+aws ecr get-login-password --region "$PUB_REGION" | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+aws ecr describe-repositories --repository-names dda/flask-app --region "$PUB_REGION" >/dev/null 2>&1 || \
+    aws ecr create-repository --repository-name dda/flask-app --region "$PUB_REGION" >/dev/null
+aws ecr describe-repositories --repository-names dda/react-webapp --region "$PUB_REGION" >/dev/null 2>&1 || \
+    aws ecr create-repository --repository-name dda/react-webapp --region "$PUB_REGION" >/dev/null
+
+echo "Pushing flask-app to ECR (${ECR_REPO_BACKEND}:${COMPONENT_VERSION})..."
+docker tag flask-app:latest "${ECR_REPO_BACKEND}:${COMPONENT_VERSION}"
+docker push "${ECR_REPO_BACKEND}:${COMPONENT_VERSION}"
+echo "Pushing react-webapp to ECR (${ECR_REPO_FRONTEND}:${COMPONENT_VERSION})..."
+docker tag react-webapp:latest "${ECR_REPO_FRONTEND}:${COMPONENT_VERSION}"
+docker push "${ECR_REPO_FRONTEND}:${COMPONENT_VERSION}"
+
+# Repackage a scripts-only zip (same name/layout as the full zip, minus the image tars).
+rm -f "${STAGE_DIR}/flask-app.tar" "${STAGE_DIR}/react-webapp.tar" "${STAGE_DIR}"/.tmp-* 2>/dev/null || true
+APP_ZIP="custom-build/${COMPONENT_NAME}-${ARCH}.zip"
+rm -f "$APP_ZIP"
+zip -r -X "$APP_ZIP" "custom-build/${COMPONENT_NAME}" -x '*/.tmp-*'
+
+S3_KEY="${COMPONENT_NAME}/${COMPONENT_VERSION}/${COMPONENT_NAME}-${ARCH}.zip"
+S3_URI="s3://${S3_BUCKET}/${S3_KEY}"
+echo "Uploading scripts artifact to ${S3_URI} ($(numfmt --to=iec "$(stat --format=%s "$APP_ZIP")" 2>/dev/null || echo "?"))..."
+aws s3 cp "$APP_ZIP" "$S3_URI" --region "$PUB_REGION"
+
+# Rewrite the recipe: docker image artifacts + S3 scripts artifact, add Docker/TES
+# deps, and swap the in-Install `docker load -i ...tar` for `docker tag <ecr> ...:latest`.
+python3 -c "import yaml" 2>/dev/null || pip3 install --user pyyaml >/dev/null 2>&1 || true
+ECR_RECIPE="greengrass-build/recipes/recipe-ecr.yaml"
+mkdir -p greengrass-build/recipes
+python3 - "recipe.yaml" "$ECR_RECIPE" "$ECR_REPO_BACKEND" "$ECR_REPO_FRONTEND" "$COMPONENT_VERSION" "$S3_URI" <<'PYEOF'
+import re, sys, yaml
+
+src, out, ecr_backend, ecr_frontend, version, s3_uri = sys.argv[1:7]
+
+with open(src) as f:
+    recipe = yaml.safe_load(f)
+
+recipe['ComponentVersion'] = version
+
+deps = recipe.setdefault('ComponentDependencies', {})
+deps['aws.greengrass.DockerApplicationManager'] = {'VersionRequirement': '~2.0.0'}
+deps['aws.greengrass.TokenExchangeService'] = {'VersionRequirement': '~2.0.0'}
+
+def rewrite_install(script: str) -> str:
+    script = re.sub(r'docker load -i \S*flask-app\.tar',
+                    f'docker tag {ecr_backend}:{version} flask-app:latest', script)
+    script = re.sub(r'docker load -i \S*react-webapp\.tar(?:\.gz)?',
+                    f'docker tag {ecr_frontend}:{version} react-webapp:latest', script)
+    return script
+
+changed = False
+for manifest in recipe.get('Manifests', []):
+    lifecycle = manifest.get('Lifecycle', {})
+    install = lifecycle.get('Install')
+    if isinstance(install, dict) and 'Script' in install:
+        new_script = rewrite_install(install['Script'])
+        if new_script != install['Script']:
+            changed = True
+        install['Script'] = new_script
+    manifest['Artifacts'] = [
+        {'URI': f'docker:{ecr_backend}:{version}'},
+        {'URI': f'docker:{ecr_frontend}:{version}'},
+        {'URI': s3_uri, 'Unarchive': 'ZIP'},
+    ]
+
+if not changed:
+    sys.stderr.write('ERROR: did not find docker load commands to rewrite in Install; recipe format may have changed.\n')
+    sys.exit(2)
+
+with open(out, 'w') as f:
+    yaml.dump(recipe, f, default_flow_style=False, sort_keys=False)
+print(f'Wrote ECR recipe: {out}')
+PYEOF
+
+echo "Creating component version via API..."
+aws greengrassv2 create-component-version --inline-recipe fileb://"$ECR_RECIPE" --region "$PUB_REGION"
+
+echo "Tagging component for portal discovery..."
+COMPONENT_ARN=$(aws greengrassv2 list-components --scope PRIVATE --region "$PUB_REGION" \
+    --query "components[?componentName=='${COMPONENT_NAME}'].arn | [0]" --output text 2>/dev/null || true)
+if [ -n "$COMPONENT_ARN" ] && [ "$COMPONENT_ARN" != "None" ]; then
+    aws greengrassv2 tag-resource --resource-arn "$COMPONENT_ARN" \
+        --tags "dda-portal:managed=true" --region "$PUB_REGION" 2>/dev/null \
+        && echo "Tagged $COMPONENT_ARN" || echo "WARN: tagging failed (non-critical)"
+else
+    echo "WARN: could not resolve component ARN for tagging (non-critical)"
+fi
+
+echo "DONE: published ${COMPONENT_NAME} v${COMPONENT_VERSION} (ECR + S3)"

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -108,7 +108,8 @@ from endpoints import (
     image_source,
     auth_info,
     download_file,
-    inference_result
+    inference_result,
+    streams
 )
 
 import dao.sqlite_db.models as models
@@ -147,6 +148,7 @@ app.include_router(workflow.router)
 app.include_router(auth_info.router)
 app.include_router(download_file.unauthenticated_router)
 app.include_router(inference_result.router)
+app.include_router(streams.router)
 
 
 def cleanup_workflow_digital_inputs():

--- a/src/backend/endpoints/image_source.py
+++ b/src/backend/endpoints/image_source.py
@@ -118,6 +118,41 @@ def get_frame(image_source_dict, image_source_config_override=None):
     camera_id = image_source_dict.get('cameraId')
     return get_camera_frame(camera_id, camera_config)
 
+
+def get_preview_frame(image_source_dict, image_source_config_override=None):
+    # Isolated single-frame override preview path for Aravis (CAMERA) image sources.
+    #
+    # Unlike get_frame (used by the capture path, which goes through
+    # camera_manager.get_camera_frame -> broadcaster.get_inference_frame), the preview
+    # routes through broadcaster.preview_with_override so the per-request override is
+    # isolated from any live preview session (Req 5.4): with an active session it returns
+    # the session's current frame WITHOUT disturbing it (override not applied), and with
+    # no session it opens a dedicated claim and actually applies the override so the
+    # preview reflects it.
+    if image_source_dict.get('type') in [ImageSourceType.ICAM, ImageSourceType.NVIDIA_CSI, ImageSourceType.FOLDER]:
+        raise HTTPException(
+                status_code=HTTP_400_BAD_REQUEST,
+                detail=f"The server cannot get frame for {image_source_dict.get('type')} using AravisSDK method.",
+            )
+
+    camera_config = {}
+    if image_source_config_override:
+        camera_config = image_source_config_override
+    else:
+        camera_config = utils.convert_sqlalchemy_object_to_dict(image_source_dict.get("imageSourceConfiguration"))
+    camera_id = image_source_dict.get('cameraId')
+
+    # Lazy import to avoid an import cycle (broadcaster -> backends -> camera_manager),
+    # consistent with camera_manager.get_camera_frame.
+    from utils.streaming.broadcaster import get_broadcaster
+
+    frame_data = get_broadcaster().preview_with_override(camera_id, camera_config)
+    if frame_data is None:
+        # Preserve the legacy error behavior: a missing frame raises so the endpoint
+        # surfaces its HTTP error (the same way get_camera_frame did).
+        raise Exception(f"Unable to get camera frame for camera id: {camera_id}")
+    return frame_data
+
 @router.post("/image-sources/{imageSourceId}/preview")
 def preview_image(imageSourceId, request: GetPreviewImageRequest = GetPreviewImageRequest(), db: Session = Depends(get_db)) -> GetPreviewImageResponse:
     try:
@@ -153,7 +188,7 @@ def preview_image(imageSourceId, request: GetPreviewImageRequest = GetPreviewIma
                 ImageSource(**image_source_dict),
                 image_source_config_override=image_source_config_override,
                 is_preview=True,
-                frame_data=get_frame(image_source_dict, image_source_config_override)
+                frame_data=get_preview_frame(image_source_dict, image_source_config_override)
             )
     except Exception as err:
         raise HTTPException(

--- a/src/backend/endpoints/image_source.py
+++ b/src/backend/endpoints/image_source.py
@@ -119,40 +119,6 @@ def get_frame(image_source_dict, image_source_config_override=None):
     return get_camera_frame(camera_id, camera_config)
 
 
-def get_preview_frame(image_source_dict, image_source_config_override=None):
-    # Isolated single-frame override preview path for Aravis (CAMERA) image sources.
-    #
-    # Unlike get_frame (used by the capture path, which goes through
-    # camera_manager.get_camera_frame -> broadcaster.get_inference_frame), the preview
-    # routes through broadcaster.preview_with_override so the per-request override is
-    # isolated from any live preview session (Req 5.4): with an active session it returns
-    # the session's current frame WITHOUT disturbing it (override not applied), and with
-    # no session it opens a dedicated claim and actually applies the override so the
-    # preview reflects it.
-    if image_source_dict.get('type') in [ImageSourceType.ICAM, ImageSourceType.NVIDIA_CSI, ImageSourceType.FOLDER]:
-        raise HTTPException(
-                status_code=HTTP_400_BAD_REQUEST,
-                detail=f"The server cannot get frame for {image_source_dict.get('type')} using AravisSDK method.",
-            )
-
-    camera_config = {}
-    if image_source_config_override:
-        camera_config = image_source_config_override
-    else:
-        camera_config = utils.convert_sqlalchemy_object_to_dict(image_source_dict.get("imageSourceConfiguration"))
-    camera_id = image_source_dict.get('cameraId')
-
-    # Lazy import to avoid an import cycle (broadcaster -> backends -> camera_manager),
-    # consistent with camera_manager.get_camera_frame.
-    from utils.streaming.broadcaster import get_broadcaster
-
-    frame_data = get_broadcaster().preview_with_override(camera_id, camera_config)
-    if frame_data is None:
-        # Preserve the legacy error behavior: a missing frame raises so the endpoint
-        # surfaces its HTTP error (the same way get_camera_frame did).
-        raise Exception(f"Unable to get camera frame for camera id: {camera_id}")
-    return frame_data
-
 @router.post("/image-sources/{imageSourceId}/preview")
 def preview_image(imageSourceId, request: GetPreviewImageRequest = GetPreviewImageRequest(), db: Session = Depends(get_db)) -> GetPreviewImageResponse:
     try:
@@ -188,7 +154,7 @@ def preview_image(imageSourceId, request: GetPreviewImageRequest = GetPreviewIma
                 ImageSource(**image_source_dict),
                 image_source_config_override=image_source_config_override,
                 is_preview=True,
-                frame_data=get_preview_frame(image_source_dict, image_source_config_override)
+                frame_data=get_frame(image_source_dict, image_source_config_override)
             )
     except Exception as err:
         raise HTTPException(

--- a/src/backend/endpoints/streams.py
+++ b/src/backend/endpoints/streams.py
@@ -1,0 +1,305 @@
+#
+#  Copyright 2025 Amazon Web Services, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Broadcast-model live-preview stream API endpoints.
+
+These endpoints are **thin clients** over the process-wide
+:class:`~utils.streaming.broadcaster.StreamBroadcaster` singleton
+(:func:`~utils.streaming.broadcaster.get_broadcaster`). They translate the
+broadcaster's domain results (:class:`SubscribeResult`, :class:`FrameResult`, the
+device-accepted settings dict, and the broadcaster's ``NoActiveSessionError`` /
+``SettingsApplyError``) into HTTP responses and status codes. All device access and
+the single-claim / lifecycle invariants live in the broadcaster; this layer adds no
+acquisition logic of its own.
+
+Routes (registered under the same auth / access-log router as the other endpoints):
+
+* ``POST /streams/{camera_id}/subscribe``   — start-on-first-viewer; returns the
+  server-issued ``viewerId`` and current ``viewerCount`` (Req 1.2, 3.1, 8.1).
+  Rejections map ``viewer_limit`` -> 429 and ``camera_unavailable`` -> 503.
+* ``GET  /streams/{camera_id}/frame``        — latest frame for a viewer; doubles as a
+  heartbeat (Req 2.3, 4.1, 4.6). ``OK`` / ``STALE`` return the frame bytes (200, with a
+  ``X-Frame-Status`` header flagging staleness), ``NO_FRAME`` returns 204, and
+  ``DISCONNECTED`` returns 503.
+* ``POST /streams/{camera_id}/heartbeat``    — explicit keep-alive; 200 when refreshed,
+  404 when the viewer / session is unknown (Req 8.2, 8.3).
+* ``POST /streams/{camera_id}/unsubscribe``  — stop-on-last-viewer; always 200 (Req 3.6,
+  8.8).
+* ``GET  /streams/{camera_id}/viewers``      — active viewer count (Req 8.4).
+* ``POST /streams/{camera_id}/settings``     — apply gain/exposure/advanced controls to
+  the live session (Req 5.1, 5.2); ``NoActiveSessionError`` -> 409, ``SettingsApplyError``
+  -> 422 naming the failed control.
+
+Frame transport: the broadcaster's :class:`~utils.streaming.models.LatestFrame` carries
+the raw image payload bytes (the same shape as the legacy ``get_camera_frame`` payload).
+To stay a thin pass-through (and avoid re-grabbing / re-encoding through the heavy
+GStreamer preview pipeline, which would defeat the broadcast model), the frame endpoint
+returns those bytes directly as the response body with the frame metadata
+(``seq`` / ``width`` / ``height`` / ``acquired_at`` / freshness) carried in
+``X-Frame-*`` headers. See the module-level note in the task report for this decision.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import Body, Query, HTTPException, Response
+from pydantic import BaseModel
+from starlette.status import (
+    HTTP_204_NO_CONTENT,
+    HTTP_404_NOT_FOUND,
+    HTTP_409_CONFLICT,
+    HTTP_422_UNPROCESSABLE_ENTITY,
+    HTTP_429_TOO_MANY_REQUESTS,
+    HTTP_503_SERVICE_UNAVAILABLE,
+)
+
+from endpoints.route.access_log_router import get_api_router
+from utils.streaming.broadcaster import (
+    NoActiveSessionError,
+    SettingsApplyError,
+    get_broadcaster,
+)
+from utils.streaming.models import FrameStatus
+
+logger = logging.getLogger(__name__)
+
+router = get_api_router()
+
+
+# --- request / response models -------------------------------------------
+
+
+class SubscribeRequest(BaseModel):
+    """Optional body for subscribe; carries the image-source/stream config.
+
+    The ``config`` dict is forwarded verbatim to the broadcaster, which uses it (its
+    ``type`` / ``imageSourceConfiguration``) to build the backend when starting a new
+    session. It is ignored when a session already exists (the existing claim is reused).
+    """
+
+    config: Optional[dict] = None
+
+
+class SubscribeResponse(BaseModel):
+    """Accepted-subscription payload: the new viewer id and the active viewer count."""
+
+    viewerId: str
+    viewerCount: int
+
+
+class ViewerIdBody(BaseModel):
+    """Body carrying a ``viewerId`` for heartbeat / unsubscribe.
+
+    Supports clients that POST a JSON body (and ``navigator.sendBeacon`` on tab close,
+    which cannot set query params). The ``viewerId`` may alternatively be supplied as a
+    query parameter.
+    """
+
+    viewerId: Optional[str] = None
+
+
+class HeartbeatResponse(BaseModel):
+    """Result of an explicit heartbeat: whether the viewer was refreshed."""
+
+    refreshed: bool
+
+
+class ViewerCountResponse(BaseModel):
+    """Active viewer count for a camera."""
+
+    viewerCount: int
+
+
+def _resolve_viewer_id(query_viewer_id: Optional[str], body: Optional[ViewerIdBody]) -> str:
+    """Return the viewer id from the query param or body, or raise 422 when absent.
+
+    Accepts the id from either source so both query-string clients and JSON-body /
+    ``sendBeacon`` clients work against the same endpoint.
+    """
+    viewer_id = query_viewer_id or (body.viewerId if body is not None else None)
+    if not viewer_id:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="viewerId is required (provide it as a query parameter or in the request body).",
+        )
+    return viewer_id
+
+
+# --- endpoints ------------------------------------------------------------
+
+
+@router.post("/streams/{camera_id}/subscribe")
+def subscribe_stream(
+    camera_id: str, request: SubscribeRequest = SubscribeRequest()
+) -> SubscribeResponse:
+    """Register a new viewer, starting the session on the first subscriber.
+
+    Maps the broadcaster's :class:`SubscribeResult`: accepted -> 200 with the new
+    ``viewerId`` / ``viewerCount``; ``viewer_limit`` -> 429; ``camera_unavailable`` ->
+    503 (Req 1.2, 3.1, 8.1).
+    """
+    result = get_broadcaster().subscribe(camera_id, request.config)
+    if result.accepted:
+        return SubscribeResponse(viewerId=result.viewer_id, viewerCount=result.viewer_count)
+
+    if result.reason == "viewer_limit":
+        raise HTTPException(
+            status_code=HTTP_429_TOO_MANY_REQUESTS,
+            detail=(
+                f"Camera {camera_id} has reached the maximum number of concurrent viewers "
+                f"({result.viewer_count}). Try again when a viewer disconnects."
+            ),
+        )
+    if result.reason == "camera_unavailable":
+        raise HTTPException(
+            status_code=HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                f"Camera {camera_id} is unavailable and could not start streaming. "
+                f"Check the camera connection and try again."
+            ),
+        )
+    # Defensive: any other rejection reason is surfaced as a generic 503.
+    raise HTTPException(
+        status_code=HTTP_503_SERVICE_UNAVAILABLE,
+        detail=f"Unable to subscribe to camera {camera_id}: {result.reason}.",
+    )
+
+
+@router.get("/streams/{camera_id}/frame")
+def get_stream_frame(camera_id: str, viewerId: str = Query(...)) -> Response:
+    """Return the latest frame for a viewer; the request doubles as a heartbeat.
+
+    Maps the broadcaster's :class:`FrameResult` status:
+
+    * ``OK``   -> 200 with the raw frame bytes as the body and ``X-Frame-Status: ok``.
+    * ``STALE``-> 200 with the (still-served) frame bytes and ``X-Frame-Status: stale``
+      so the client can flag staleness (Req 4.7).
+    * ``NO_FRAME`` -> 204 No Content (session up, nothing published yet — Req 2.6).
+    * ``DISCONNECTED`` -> 503 (camera dropped or not streaming — Req 7.5).
+
+    Frame metadata (sequence, dimensions, acquired-at) is returned in ``X-Frame-*``
+    headers alongside the binary body.
+    """
+    result = get_broadcaster().get_frame(camera_id, viewerId)
+
+    if result.status in (FrameStatus.OK, FrameStatus.STALE):
+        frame = result.frame
+        if frame is None:
+            # Defensive: OK/STALE should always carry a frame; treat a missing payload
+            # as "nothing to serve yet" rather than emitting an empty body.
+            return Response(status_code=HTTP_204_NO_CONTENT)
+        headers = {
+            "X-Frame-Status": result.status.value,
+            "X-Frame-Seq": str(frame.seq),
+            "X-Frame-Width": str(frame.width),
+            "X-Frame-Height": str(frame.height),
+            "X-Frame-Acquired-At": str(frame.acquired_at),
+        }
+        return Response(
+            content=frame.data,
+            media_type="application/octet-stream",
+            headers=headers,
+        )
+
+    if result.status == FrameStatus.NO_FRAME:
+        # Session is up but no frame has been published yet.
+        return Response(
+            status_code=HTTP_204_NO_CONTENT,
+            headers={"X-Frame-Status": FrameStatus.NO_FRAME.value},
+        )
+
+    # DISCONNECTED: the camera has dropped or there is no active session.
+    raise HTTPException(
+        status_code=HTTP_503_SERVICE_UNAVAILABLE,
+        detail=result.error
+        or f"Camera {camera_id} is disconnected; no live frame is available.",
+    )
+
+
+@router.post("/streams/{camera_id}/heartbeat")
+def heartbeat_stream(
+    camera_id: str,
+    viewerId: Optional[str] = Query(default=None),
+    body: Optional[ViewerIdBody] = Body(default=None),
+) -> HeartbeatResponse:
+    """Refresh a viewer's keep-alive timestamp.
+
+    Returns 200 with ``refreshed=True`` when the viewer exists and was refreshed; 404
+    when the camera has no session or the viewer id is unknown / expired so the client
+    knows to re-subscribe (Req 8.2, 8.3).
+    """
+    viewer_id = _resolve_viewer_id(viewerId, body)
+    refreshed = get_broadcaster().heartbeat(camera_id, viewer_id)
+    if not refreshed:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=(
+                f"Viewer {viewer_id} is not subscribed to camera {camera_id} "
+                f"(unknown or expired); re-subscribe to continue."
+            ),
+        )
+    return HeartbeatResponse(refreshed=True)
+
+
+@router.post("/streams/{camera_id}/unsubscribe")
+def unsubscribe_stream(
+    camera_id: str,
+    viewerId: Optional[str] = Query(default=None),
+    body: Optional[ViewerIdBody] = Body(default=None),
+) -> ViewerCountResponse:
+    """Deregister a viewer; stop the session if it was the last (Req 3.6, 8.8).
+
+    Unsubscribing is idempotent — removing an unknown camera/viewer is a no-op — so this
+    always returns 200 with the resulting active viewer count.
+    """
+    viewer_id = _resolve_viewer_id(viewerId, body)
+    broadcaster = get_broadcaster()
+    broadcaster.unsubscribe(camera_id, viewer_id)
+    return ViewerCountResponse(viewerCount=broadcaster.viewer_count(camera_id))
+
+
+@router.get("/streams/{camera_id}/viewers")
+def get_stream_viewers(camera_id: str) -> ViewerCountResponse:
+    """Return the active viewer count for a camera (0 when not streaming) (Req 8.4)."""
+    return ViewerCountResponse(viewerCount=get_broadcaster().viewer_count(camera_id))
+
+
+@router.post("/streams/{camera_id}/settings")
+def apply_stream_settings(camera_id: str, features: dict = Body(default={})) -> dict:
+    """Apply gain/exposure/advanced controls to the live session (Req 5.1, 5.2).
+
+    Forwards the request body to the broadcaster's ``apply_settings`` and returns the
+    device-accepted values. Maps the broadcaster's errors: ``NoActiveSessionError`` ->
+    409 (the camera is not streaming, so there is no live session to adjust);
+    ``SettingsApplyError`` -> 422 naming the failed control while the prior values are
+    retained and the session stays active (Req 5.5).
+    """
+    try:
+        accepted = get_broadcaster().apply_settings(camera_id, features)
+    except NoActiveSessionError as exc:
+        raise HTTPException(
+            status_code=HTTP_409_CONFLICT,
+            detail=(
+                f"Camera {camera_id} is not streaming; subscribe before applying settings. "
+                f"({exc})"
+            ),
+        )
+    except SettingsApplyError as exc:
+        raise HTTPException(
+            status_code=HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Failed to apply control(s) [{exc.control}] for camera {camera_id}: {exc}",
+        )
+    return accepted if isinstance(accepted, dict) else {"accepted": accepted}

--- a/src/backend/utils/camera_manager.py
+++ b/src/backend/utils/camera_manager.py
@@ -599,59 +599,44 @@ def _get_camera_frame(camera_id, camera, camera_config):
         return None
 
 def get_camera_frame(camera_id, camera_config=None):
-    """Return a single inference/capture frame for ``camera_id``.
+    """Return a single inference/capture/preview frame for ``camera_id``.
 
-    Rewired onto the broadcast-model stream stack (task 7.2): instead of opening a
-    private per-request device claim, this routes through
-    ``StreamBroadcaster.get_inference_frame`` so that *all* device access for a
-    camera is mediated by the one process-wide registry that enforces the
-    single-open-claim-per-camera invariant. When a live preview session is already
-    running the broadcaster reuses that claim (no second device open); when none
-    exists it opens exactly one dedicated claim, grabs, and releases it — the same
-    behavior the legacy dedicated grab used to provide here.
+    Uses the cached, persistent ``Camera`` connection model: the camera is opened
+    once via ``connect_camera`` (stored in ``camera_objects``) and **reused** across
+    calls — each call performs a per-request ``start_acquisition`` / ``get_frame`` /
+    ``stop_acquisition`` on that already-claimed device, but does NOT release the USB
+    claim between calls. This is what the live-preview poll (~2 Hz) and the
+    capture/workflow callers depend on.
 
-    The return contract is preserved for existing callers (``digital_input_*``,
-    ``workflow``, and the capture / preview endpoints): on success it returns the
-    same ``{'data', 'height', 'width'}`` dict that the legacy path returned (via
-    ``pickle.loads(camera.get_frame())``), and on no-frame / failure it raises an
-    ``Exception`` exactly as before. ``broadcaster.get_inference_frame`` already
-    returns that unpickled dict (task 7.1) — or ``None`` — so this function only has
-    to translate the ``None`` case back into the historical raised exception.
+    NOTE (regression fix): an earlier revision routed this through
+    ``StreamBroadcaster.get_inference_frame``, whose no-session path opened AND
+    closed a fresh device claim on every call. On real USB3Vision hardware the
+    ~500 ms preview poll then overlapped successive open/close cycles and the device
+    rejected the next claim with ``LIBUSB_ERROR_BUSY``, breaking the live view. The
+    broadcast (``/streams``) stack remains available for the viewer subscribe path,
+    but the preview/capture/inference hot path reuses the single cached connection
+    again to avoid that claim thrash.
 
-    ``get_broadcaster`` is imported lazily inside the function to avoid a circular
-    import at module load: the broadcaster imports the backend adapters, which in
-    turn lazily import this ``camera_manager`` module, so a top-level import here
-    would form an import cycle.
-
-    Args:
-        camera_id: Identifier of the physical camera.
-        camera_config: Optional image-source / per-capture configuration, passed
-            through unchanged to the broadcaster (used only by the dedicated-claim
-            fallback when no live session exists; ignored while a session is active
-            and its already-applied config is reused).
-
-    Returns:
-        The frame as a ``{'data', 'height', 'width'}`` dict.
-
-    Raises:
-        Exception: When no frame is available (broadcaster returned ``None``),
-            preserving the legacy contract relied on by the capture / workflow
-            callers that surface this as an HTTP error.
+    Returns the ``{'data', 'height', 'width'}`` dict produced by the camera, and
+    raises ``Exception`` on no-frame/failure (the contract ``digital_input_*`` /
+    ``workflow`` / capture / preview callers rely on to surface an HTTP error).
     """
-    # Lazy import to avoid a module-load import cycle (broadcaster -> backends ->
-    # camera_manager). A function-level import is safe and cheap after first load.
-    from utils.streaming.broadcaster import get_broadcaster
-
-    # ``get_frame_lock`` is retained so the get_camera_frame entry point keeps its
-    # historical serialization semantics for callers. The broadcaster also guards
-    # device access with its own registry lock, so this outer lock is no longer
-    # strictly required for correctness; it is kept to avoid any behavioral change
-    # for existing concurrent callers of this function.
     get_frame_lock.acquire()
+    if camera_id not in camera_objects:
+        logger.error("Attempting to create camera object")
+        connect_camera(camera_id)
+
+    camera = camera_objects.get(camera_id)
+    if camera is None:
+        logger.error(f"Camera not found for ID {camera_id}")
+        raise Exception(f"Camera not able to connect for ID {camera_id}")
     try:
-        frame = get_broadcaster().get_inference_frame(camera_id, camera_config)
+        frame = _get_camera_frame(camera_id, camera, camera_config)
         if frame is not None:
             return frame
+        else:
+            raise Exception(f"Unable to get camera frame for camera id: {camera_id}")
+    except Exception:
         raise Exception(f"Unable to get camera frame for camera id: {camera_id}")
     finally:
         get_frame_lock.release()

--- a/src/backend/utils/camera_manager.py
+++ b/src/backend/utils/camera_manager.py
@@ -599,22 +599,59 @@ def _get_camera_frame(camera_id, camera, camera_config):
         return None
 
 def get_camera_frame(camera_id, camera_config=None):
-    get_frame_lock.acquire()
-    if camera_id not in camera_objects:
-        logger.error("Attempting to create camera object")
-        connect_camera(camera_id)
+    """Return a single inference/capture frame for ``camera_id``.
 
-    camera = camera_objects.get(camera_id)
-    if camera is None:
-        logger.error(f"Camera not found for ID {camera_id}")
-        raise Exception(f"Camera not able to connect for ID {camera_id}")
+    Rewired onto the broadcast-model stream stack (task 7.2): instead of opening a
+    private per-request device claim, this routes through
+    ``StreamBroadcaster.get_inference_frame`` so that *all* device access for a
+    camera is mediated by the one process-wide registry that enforces the
+    single-open-claim-per-camera invariant. When a live preview session is already
+    running the broadcaster reuses that claim (no second device open); when none
+    exists it opens exactly one dedicated claim, grabs, and releases it — the same
+    behavior the legacy dedicated grab used to provide here.
+
+    The return contract is preserved for existing callers (``digital_input_*``,
+    ``workflow``, and the capture / preview endpoints): on success it returns the
+    same ``{'data', 'height', 'width'}`` dict that the legacy path returned (via
+    ``pickle.loads(camera.get_frame())``), and on no-frame / failure it raises an
+    ``Exception`` exactly as before. ``broadcaster.get_inference_frame`` already
+    returns that unpickled dict (task 7.1) — or ``None`` — so this function only has
+    to translate the ``None`` case back into the historical raised exception.
+
+    ``get_broadcaster`` is imported lazily inside the function to avoid a circular
+    import at module load: the broadcaster imports the backend adapters, which in
+    turn lazily import this ``camera_manager`` module, so a top-level import here
+    would form an import cycle.
+
+    Args:
+        camera_id: Identifier of the physical camera.
+        camera_config: Optional image-source / per-capture configuration, passed
+            through unchanged to the broadcaster (used only by the dedicated-claim
+            fallback when no live session exists; ignored while a session is active
+            and its already-applied config is reused).
+
+    Returns:
+        The frame as a ``{'data', 'height', 'width'}`` dict.
+
+    Raises:
+        Exception: When no frame is available (broadcaster returned ``None``),
+            preserving the legacy contract relied on by the capture / workflow
+            callers that surface this as an HTTP error.
+    """
+    # Lazy import to avoid a module-load import cycle (broadcaster -> backends ->
+    # camera_manager). A function-level import is safe and cheap after first load.
+    from utils.streaming.broadcaster import get_broadcaster
+
+    # ``get_frame_lock`` is retained so the get_camera_frame entry point keeps its
+    # historical serialization semantics for callers. The broadcaster also guards
+    # device access with its own registry lock, so this outer lock is no longer
+    # strictly required for correctness; it is kept to avoid any behavioral change
+    # for existing concurrent callers of this function.
+    get_frame_lock.acquire()
     try:
-        frame = _get_camera_frame(camera_id, camera, camera_config)
+        frame = get_broadcaster().get_inference_frame(camera_id, camera_config)
         if frame is not None:
             return frame
-        else:
-            raise Exception(f"Unable to get camera frame for camera id: {camera_id}")
-    except Exception:
         raise Exception(f"Unable to get camera frame for camera id: {camera_id}")
     finally:
         get_frame_lock.release()

--- a/src/backend/utils/streaming/__init__.py
+++ b/src/backend/utils/streaming/__init__.py
@@ -1,0 +1,15 @@
+#
+#  Copyright 2025 Amazon Web Services, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#

--- a/src/backend/utils/streaming/backends.py
+++ b/src/backend/utils/streaming/backends.py
@@ -1,0 +1,948 @@
+#
+#  Copyright 2025 Amazon Web Services, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Backend abstraction for the concurrent camera stream broadcaster.
+
+A single ``CameraBackend`` interface lets the ``StreamBroadcaster`` /
+``StreamSession`` treat both camera families (GenICam / USB3Vision via Aravis
+and NVIDIA CSI / ICAM via GStreamer) identically (Req 2.8). Each backend owns
+exactly one ``Device_Claim`` for its physical camera; the acquisition worker is
+the only code that drives a backend, looping ``grab()`` -> publish.
+
+``AravisBackend`` wraps the existing Aravis ``Camera`` acquisition path;
+``GStreamerBackend`` wraps a persistent GStreamer pipeline that ends in an
+``appsink`` pull loop (replacing the one-shot ``execute_image_source_pipeline``
+for the live-view path). Both keep their ``gi`` imports lazy so this module stays
+importable on hosts without the GenICam / GStreamer stack.
+"""
+import logging
+import os
+import time
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Optional, Protocol, runtime_checkable
+
+from utils.streaming.models import StreamConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RawFrame:
+    """A single frame as returned by a backend ``grab()``.
+
+    Carries the raw image payload plus the dimensions needed to build a
+    ``LatestFrame``. The monotonic sequence number and acquired-at timestamp
+    that complete a ``LatestFrame`` are assigned by the session at publish time,
+    not by the backend, so they are intentionally absent here.
+
+    Attributes:
+        data: Raw image payload bytes (same shape as today's ``get_frame``
+            dict ``data`` field).
+        width: Image width in pixels.
+        height: Image height in pixels.
+    """
+
+    data: bytes
+    width: int
+    height: int
+
+
+@runtime_checkable
+class CameraBackend(Protocol):
+    """Common interface over the Aravis and GStreamer acquisition paths.
+
+    Implementations hold a single ``Device_Claim`` per physical camera. The
+    broadcaster/session drives the lifecycle: ``open()`` -> ``start_stream()``
+    -> repeated ``grab()`` -> ``stop_stream()`` -> ``close()``. ``apply_features``
+    may be called on a running stream to adjust live controls.
+    """
+
+    def open(self) -> None:
+        """Acquire the single ``Device_Claim`` for the camera.
+
+        Implementations attempt the open at most ``max_open_attempts`` (3) times
+        within the configured open timeout (Req 7.6). Raises on failure so the
+        broadcaster can reject the subscribe with ``camera_unavailable``.
+        """
+        ...
+
+    def start_stream(self) -> None:
+        """Begin continuous acquisition.
+
+        Aravis cameras switch from per-request software-trigger to a
+        worker-driven continuous acquisition; GStreamer cameras start a
+        persistent ``appsink`` pull loop.
+        """
+        ...
+
+    def grab(self, timeout_ms: int) -> "RawFrame | None":
+        """Grab the next frame, waiting at most ``timeout_ms`` milliseconds.
+
+        Returns a ``RawFrame`` on success, or ``None`` on timeout / acquisition
+        failure (which the worker treats as a disconnect signal, Req 7.1).
+        """
+        ...
+
+    def apply_features(self, features: dict) -> dict:
+        """Apply camera control values (gain / exposure / advanced GenICam
+        features) to the live stream.
+
+        Returns the device-accepted values so callers can reflect what the
+        hardware actually applied (values may be coerced/clamped).
+        """
+        ...
+
+    def stop_stream(self) -> None:
+        """Stop continuous acquisition without releasing the device claim."""
+        ...
+
+    def close(self) -> None:
+        """Release the single ``Device_Claim`` for the camera."""
+        ...
+
+
+# Default device-open retry budget (Req 7.6) used when a StreamConfig is absent.
+_DEFAULT_MAX_OPEN_ATTEMPTS = 3
+
+
+class CaptureConfigValidationError(ValueError):
+    """Raised when a per-capture image-source config has an out-of-range value.
+
+    Carries the name of the offending ``parameter`` so callers (and the
+    inference/capture path) can surface exactly which control was invalid while
+    rejecting the request (Req 6.5). Subclasses :class:`ValueError` so this stays
+    a plain, import-safe exception with no ``gi`` / hardware dependency.
+    """
+
+    def __init__(self, parameter, message):
+        self.parameter = parameter
+        super().__init__(message)
+
+
+# Top-level image-source-config keys that carry numeric controls; each is range
+# checked against the same-named entry in a ``get_feature_bounds`` map.
+_NUMERIC_TOP_LEVEL_KEYS = ("gain", "exposure")
+
+
+def _as_number(value):
+    """Return ``value`` as a number, or ``None`` if it is not numeric.
+
+    Booleans are intentionally rejected (returned as ``None``) so a boolean
+    supplied for a numeric control (gain / exposure) is treated as invalid rather
+    than silently coerced to 0/1.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_boolean_like(value):
+    """True when ``value`` is a valid boolean control value (true/false)."""
+    if isinstance(value, bool):
+        return True
+    if isinstance(value, int) and value in (0, 1):
+        return True
+    if isinstance(value, str) and value.strip().lower() in ("true", "false", "0", "1"):
+        return True
+    return False
+
+
+def _validate_against_entry(name, value, entry):
+    """Validate a single control ``value`` against its bounds ``entry``.
+
+    Raises :class:`CaptureConfigValidationError` (naming ``name``) when the value
+    is outside the entry's accepted range: not one of an enumeration's options,
+    not a valid boolean, non-numeric for a numeric control, or below ``min`` /
+    above ``max``.
+    """
+    kind = entry.get("type")
+
+    if kind == "enumeration":
+        options = entry.get("options") or []
+        # Only enforce membership when the device reported the allowed set.
+        if options and str(value) not in options:
+            raise CaptureConfigValidationError(
+                name, f"{name} '{value}' is not one of {options}"
+            )
+        return
+
+    if kind == "boolean":
+        if not _is_boolean_like(value):
+            raise CaptureConfigValidationError(
+                name,
+                f"{name} '{value}' is not a valid boolean (expected true or false)",
+            )
+        return
+
+    # Numeric controls (float / integer): range-check against min/max when known.
+    numeric = _as_number(value)
+    if numeric is None:
+        raise CaptureConfigValidationError(
+            name, f"{name} '{value}' is not a valid number"
+        )
+    lo = entry.get("min")
+    hi = entry.get("max")
+    if (lo is not None and numeric < lo) or (hi is not None and numeric > hi):
+        raise CaptureConfigValidationError(
+            name, f"{name} {value} is outside the allowed range [{lo}, {hi}]"
+        )
+
+
+def validate_config_against_bounds(config, bounds):
+    """Validate a per-capture image-source configuration against feature bounds.
+
+    Pure validation logic (no device / ``gi`` access) so it is unit-testable in a
+    bare checkout. Given an image-source-style ``config`` (``gain`` / ``exposure``
+    floats plus an ``advancedSettings`` dict of enumeration / boolean / numeric
+    controls) and a ``bounds`` map in the shape produced by
+    ``Camera.get_feature_bounds`` (keyed by control, each entry carrying ``type``
+    and ``min`` / ``max`` / ``options``), raise
+    :class:`CaptureConfigValidationError` naming the first offending parameter
+    when any supplied value falls outside its accepted range.
+
+    Parameters absent from ``bounds`` (no known range for this device) are left
+    unvalidated. ``None`` values are skipped (the control is simply not being
+    set). Returns ``None`` on success and never mutates ``config`` or ``bounds``,
+    so a rejected config leaves the previously active configuration unchanged
+    (Req 6.5).
+    """
+    if not config or not bounds:
+        return None
+
+    # Top-level numeric controls (gain / exposure).
+    for key in _NUMERIC_TOP_LEVEL_KEYS:
+        value = config.get(key)
+        if value is None:
+            continue
+        entry = bounds.get(key)
+        if entry:
+            _validate_against_entry(key, value, entry)
+
+    # Advanced controls (enumeration / boolean / numeric), e.g. balanceWhiteAuto,
+    # reverseX / reverseY.
+    advanced = config.get("advancedSettings") or {}
+    for key, value in advanced.items():
+        if value is None:
+            continue
+        entry = bounds.get(key)
+        if entry:
+            _validate_against_entry(key, value, entry)
+
+    return None
+
+
+def _load_aravis_runtime() -> SimpleNamespace:
+    """Lazily import the Aravis-backed camera runtime.
+
+    The ``gi`` / Aravis bindings — and ``camera_manager`` itself, which imports
+    them at module load and additionally spins up a multiprocessing manager — are
+    imported here rather than at module top level. This keeps ``backends.py``
+    importable in a bare checkout / on hosts without the GenICam stack, which is
+    why the ``CameraBackend`` Protocol and ``GStreamerBackend`` can live alongside
+    ``AravisBackend`` without forcing a hard dependency on Aravis. It mirrors the
+    ``gi.require_version('Aravis', '0.8')`` usage already in ``camera_manager``.
+
+    Returns:
+        A namespace bundling ``Aravis``, the existing ``Camera`` class,
+        ``CONFIG_FEATURE_MAP``, ``CameraStatusEnum``, ``Timer`` and
+        ``AravisCameraException`` for use by :class:`AravisBackend`.
+    """
+    import gi
+
+    gi.require_version("Aravis", "0.8")
+    from gi.repository import Aravis  # noqa: E402
+
+    from utils.camera_manager import Camera, CONFIG_FEATURE_MAP
+    from utils.common import CameraStatusEnum
+    from metrics.collector import Timer
+    from exceptions.api.aravis_camera_exception import AravisCameraException
+
+    return SimpleNamespace(
+        Aravis=Aravis,
+        Camera=Camera,
+        CONFIG_FEATURE_MAP=CONFIG_FEATURE_MAP,
+        CameraStatusEnum=CameraStatusEnum,
+        Timer=Timer,
+        AravisCameraException=AravisCameraException,
+    )
+
+
+class AravisBackend:
+    """``CameraBackend`` adapter over the existing Aravis ``Camera`` path.
+
+    Wraps the ``Camera`` class from ``camera_manager`` and converts its
+    per-request software-trigger model into the broadcaster's worker-driven
+    continuous acquisition:
+
+    * :meth:`open` connects (acquiring the single ``Device_Claim``) reusing the
+      ``Aravis.Camera.new`` connect plus the register-cache-disable + trigger
+      setup from ``Camera.set_camera``; it retries at most
+      ``max_open_attempts`` (3) times within ``open_timeout_ms`` (Req 7.6).
+    * :meth:`start_stream` calls ``start_acquisition`` once (continuous mode).
+    * :meth:`grab` issues a ``software_trigger`` then a bounded
+      ``timeout_pop_buffer`` read, returning a :class:`RawFrame`.
+    * :meth:`stop_stream` calls ``stop_acquisition`` (claim retained).
+    * :meth:`close` disconnects, releasing the ``Device_Claim``.
+
+    ``apply_features`` is routed through the existing ``apply_device_features`` /
+    ``_apply_config_features`` logic so gain / exposure / advanced GenICam
+    controls are applied exactly as the legacy path applies them.
+
+    This adapter is intended to be driven by a single acquisition worker thread
+    (the only code that touches the device handle), matching the broadcast
+    design's single-producer model.
+    """
+
+    def __init__(self, camera_id, image_source_config=None, stream_config=None):
+        """Create an adapter for one physical camera.
+
+        Args:
+            camera_id: Identifier passed to ``Aravis.Camera.new`` (e.g. a
+                discovered device id or a ``Fake_*`` id).
+            image_source_config: Optional image-source config (gain / exposure /
+                ``advancedSettings``) applied when acquisition starts, reusing the
+                ``Camera.start_acquisition`` path.
+            stream_config: :class:`StreamConfig` governing open retry budget and
+                open timeout; defaults are used when omitted.
+        """
+        self.camera_id = camera_id
+        self._image_source_config = image_source_config
+        self._stream_config = stream_config or StreamConfig()
+        self._rt = None          # lazily-loaded Aravis runtime namespace
+        self._camera = None      # the wrapped Camera instance == the Device_Claim
+        self._streaming = False
+
+    def open(self) -> None:
+        """Acquire the single ``Device_Claim`` for the camera.
+
+        Attempts to connect at most ``max_open_attempts`` (3) times and never past
+        the ``open_timeout_ms`` deadline. Each attempt constructs a ``Camera``
+        (which runs the ``Aravis.Camera.new`` connect plus the trigger /
+        register-cache setup) and accepts it only when it reports
+        ``CONNECTED``. Raises ``AravisCameraException`` when every attempt fails so
+        the broadcaster can reject the subscribe with ``camera_unavailable``
+        (Req 7.6).
+        """
+        rt = _load_aravis_runtime()
+        self._rt = rt
+
+        max_attempts = max(1, int(self._stream_config.max_open_attempts or _DEFAULT_MAX_OPEN_ATTEMPTS))
+        deadline = time.monotonic() + (self._stream_config.open_timeout_ms / 1000.0)
+        last_error = None
+        attempt = 0
+        for attempt in range(1, max_attempts + 1):
+            try:
+                camera = rt.Camera(self.camera_id)
+                status = camera.get_status()
+                if status is not None and status.status == rt.CameraStatusEnum.CONNECTED:
+                    self._camera = camera
+                    logger.info(
+                        f"AravisBackend {self.camera_id}: opened device claim on attempt {attempt}"
+                    )
+                    return
+                last_error = getattr(status, "error", None) or "camera did not reach CONNECTED state"
+                logger.warning(
+                    f"AravisBackend {self.camera_id}: open attempt {attempt} not connected: {last_error}"
+                )
+                self._safe_disconnect(camera)
+            except Exception as e:
+                last_error = str(e)
+                logger.warning(f"AravisBackend {self.camera_id}: open attempt {attempt} failed: {e}")
+
+            if time.monotonic() >= deadline:
+                logger.error(
+                    f"AravisBackend {self.camera_id}: open timeout exceeded after {attempt} attempt(s)"
+                )
+                break
+
+        raise rt.AravisCameraException(
+            f"Unable to open camera {self.camera_id} after {attempt} attempt(s): {last_error}"
+        )
+
+    def start_stream(self) -> None:
+        """Begin continuous acquisition.
+
+        Calls ``Camera.start_acquisition`` once with the configured image-source
+        config (applying gain / exposure / advanced controls via the existing
+        path), replacing the legacy per-request start/stop cycle.
+        """
+        self._require_open()
+        self._camera.start_acquisition(self._image_source_config)
+        self._streaming = True
+        logger.info(f"AravisBackend {self.camera_id}: continuous acquisition started")
+
+    def grab(self, timeout_ms: int) -> "RawFrame | None":
+        """Grab the next frame, waiting at most ``timeout_ms`` milliseconds.
+
+        Software-triggers the camera and pops a buffer with a bounded
+        ``timeout_pop_buffer`` (reusing the legacy ``Camera.get_frame`` read
+        logic). Returns a :class:`RawFrame` on success, or ``None`` on timeout or
+        a non-success buffer status — which the acquisition worker treats as a
+        disconnect signal (Req 7.1).
+        """
+        cam = self._camera
+        if cam is None or getattr(cam, "camera", None) is None:
+            return None
+        rt = self._rt
+        Aravis = rt.Aravis
+        timeout_us = int(max(0, timeout_ms) * 1000)
+
+        cam._lock.acquire()
+        try:
+            with rt.Timer(metric_name="CameraGetFrameTime"):
+                cam.camera.software_trigger()
+                arv_buffer = cam.stream.timeout_pop_buffer(timeout_us)
+                if arv_buffer is None:
+                    logger.error(
+                        f"AravisBackend {self.camera_id}: timed out after {timeout_us} us waiting for a frame"
+                    )
+                    cam.update_camera_status(
+                        rt.CameraStatusEnum.DISCONNECTED,
+                        "Timed out waiting for a frame from the camera",
+                    )
+                    return None
+                # Re-arm the stream with a fresh buffer for the next grab.
+                cam.set_buffer()
+                if arv_buffer.get_status() != Aravis.BufferStatus.SUCCESS:
+                    logger.error(f"AravisBackend {self.camera_id}: failed to get frame")
+                    cam.update_camera_status(rt.CameraStatusEnum.DISCONNECTED, "Failed to get frame")
+                    return None
+                data = arv_buffer.get_data()
+                width = arv_buffer.get_image_width()
+                height = arv_buffer.get_image_height()
+                cam.update_camera_status(rt.CameraStatusEnum.CONNECTED)
+                return RawFrame(data=data, width=width, height=height)
+        finally:
+            cam._lock.release()
+
+    def apply_features(self, features: dict) -> dict:
+        """Apply gain / exposure / advanced GenICam controls to the live stream.
+
+        Routes through the existing ``Camera.apply_device_features`` logic (which
+        also reuses the ``CONFIG_FEATURE_MAP`` used by ``_apply_config_features``).
+        Accepts either a device-feature list (``[{"feature","type","value"}, ...]``)
+        or an image-source-style dict with ``gain`` / ``exposure`` /
+        ``advancedSettings`` keys, normalizing the latter into the device-feature
+        list form. Because ``apply_device_features`` stops acquisition while it
+        writes, continuous acquisition is resumed afterwards so the live session
+        keeps producing frames. Returns the device-accepted values.
+
+        A per-capture image-source-style config (dict) is validated against the
+        device's feature bounds *before* anything is written, so an out-of-range
+        value is rejected with :class:`CaptureConfigValidationError` naming the
+        offending parameter and the already-applied device configuration is left
+        unchanged (Req 6.5).
+        """
+        self._require_open()
+        self._validate_capture_config(features)
+        feature_list = self._normalize_features(features)
+        applied = self._camera.apply_device_features(feature_list) if feature_list else {}
+        if self._streaming:
+            # apply_device_features stops acquisition before writing features;
+            # resume the continuous stream for the live session.
+            self._camera.start_acquisition(None)
+        return applied
+
+    def stop_stream(self) -> None:
+        """Stop continuous acquisition without releasing the device claim."""
+        if self._camera is None or not self._streaming:
+            return
+        self._camera.stop_acquisition()
+        self._streaming = False
+        logger.info(f"AravisBackend {self.camera_id}: continuous acquisition stopped")
+
+    def close(self) -> None:
+        """Release the single ``Device_Claim`` for the camera."""
+        if self._camera is None:
+            return
+        try:
+            self._camera.disconnect()
+        finally:
+            self._camera = None
+            self._streaming = False
+            logger.info(f"AravisBackend {self.camera_id}: device claim released")
+
+    # --- internal helpers -------------------------------------------------
+
+    def _require_open(self) -> None:
+        """Raise if the device claim has not been acquired via :meth:`open`."""
+        if self._camera is None:
+            rt = self._rt or _load_aravis_runtime()
+            raise rt.AravisCameraException(
+                f"Camera {self.camera_id} is not open; call open() before this operation"
+            )
+
+    def _validate_capture_config(self, features) -> None:
+        """Reject an out-of-range per-capture image-source config before applying.
+
+        Only image-source-style dict configs (``gain`` / ``exposure`` /
+        ``advancedSettings``) are validated; already-built device-feature lists are
+        left to the existing apply path. Bounds are read from the live device via
+        ``Camera.get_feature_bounds`` (the same shape ``get_camera_feature_bounds``
+        exposes); when no bounds are readable the config is left unvalidated.
+        Raises :class:`CaptureConfigValidationError` (naming the offending
+        parameter) so the caller can reject the request with the active
+        configuration untouched (Req 6.5).
+        """
+        if not isinstance(features, dict):
+            return
+        try:
+            bounds = self._camera.get_feature_bounds()
+        except Exception as e:  # pragma: no cover - bounds read best-effort
+            logger.warning(
+                f"AravisBackend {self.camera_id}: unable to read feature bounds for validation: {e}"
+            )
+            return
+        validate_config_against_bounds(features, bounds)
+
+    def _safe_disconnect(self, camera) -> None:
+        """Best-effort disconnect of a failed/rejected ``Camera`` instance."""
+        try:
+            camera.disconnect()
+        except Exception as e:  # pragma: no cover - best-effort cleanup
+            logger.warning(f"AravisBackend {self.camera_id}: error cleaning up failed open: {e}")
+
+    def _normalize_features(self, features) -> list:
+        """Normalize an ``apply_features`` argument into a device-feature list.
+
+        Accepts either an already-built device-feature list, or an image-source
+        config dict with ``gain`` / ``exposure`` / ``advancedSettings`` (and/or an
+        explicit ``features`` list), returning the
+        ``[{"feature","type","value"}, ...]`` form expected by
+        ``Camera.apply_device_features``. Advanced settings are mapped through the
+        existing ``CONFIG_FEATURE_MAP`` so only supported safe controls are sent.
+        """
+        if not features:
+            return []
+        if isinstance(features, list):
+            return features
+
+        rt = self._rt or _load_aravis_runtime()
+        feature_list = []
+
+        explicit = features.get("features")
+        if isinstance(explicit, list):
+            feature_list.extend(explicit)
+
+        if features.get("gain") is not None:
+            feature_list.append({"feature": "Gain", "type": "float", "value": features["gain"]})
+        if features.get("exposure") is not None:
+            feature_list.append(
+                {"feature": "ExposureTime", "type": "float", "value": features["exposure"]}
+            )
+
+        advanced = features.get("advancedSettings") or {}
+        for key, value in advanced.items():
+            if value is None:
+                continue
+            mapping = rt.CONFIG_FEATURE_MAP.get(key)
+            if not mapping:
+                continue
+            genicam_feature, kind = mapping
+            feature_list.append({"feature": genicam_feature, "type": kind, "value": value})
+
+        return feature_list
+
+
+def _load_gstreamer_runtime() -> SimpleNamespace:
+    """Lazily import the GStreamer-backed live-view runtime.
+
+    The ``gi`` / ``Gst`` / ``GstApp`` bindings — and the GStreamer pipeline
+    helpers that import them transitively — are imported here rather than at
+    module load. This keeps ``backends.py`` importable in a bare checkout / on
+    hosts without the GStreamer stack, exactly as :func:`_load_aravis_runtime`
+    does for Aravis. It mirrors the ``gi.require_version('Gst', '1.0')`` /
+    ``GstApp`` usage already in ``gstreamer/gst_pipeline.py``.
+
+    Returns:
+        A namespace bundling ``Gst``, ``GstApp``, ``GLib``, the existing
+        ``GstPipelineBuilder``, ``Timer``, ``PipelineExecutionException`` and the
+        ``utils`` module for use by :class:`GStreamerBackend`.
+    """
+    import gi
+
+    gi.require_version("Gst", "1.0")
+    gi.require_version("GstApp", "1.0")
+    from gi.repository import Gst, GstApp, GLib  # noqa: E402
+
+    from gstreamer.pipeline_builder import GstPipelineBuilder
+    from metrics.collector import Timer
+    from exceptions.api.gst_pipeline_exception import PipelineExecutionException
+    from utils import utils
+
+    return SimpleNamespace(
+        Gst=Gst,
+        GstApp=GstApp,
+        GLib=GLib,
+        GstPipelineBuilder=GstPipelineBuilder,
+        Timer=Timer,
+        PipelineExecutionException=PipelineExecutionException,
+        utils=utils,
+    )
+
+
+class GStreamerBackend:
+    """``CameraBackend`` adapter over a persistent GStreamer ``appsink`` pipeline.
+
+    Replaces the one-shot ``execute_image_source_pipeline`` (build → run → tear
+    down per request) used for the live-view path with a single long-lived
+    pipeline that ends in an ``appsink``, which the acquisition worker pulls in a
+    loop. NVIDIA CSI / ICAM cameras therefore switch from per-request capture to
+    the broadcast design's single-producer continuous model, the GStreamer mirror
+    of :class:`AravisBackend`'s continuous-acquisition switch.
+
+    Lifecycle (driven by the broadcaster / acquisition worker):
+
+    * :meth:`open` builds the live pipeline (reusing ``GstPipelineBuilder`` to add
+      the configured image source, then appending
+      ``videoconvert ! video/x-raw,format=RGB ! appsink``) and sets it to
+      ``PAUSED`` — passing through ``READY`` — which opens the device and acquires
+      the single source claim. It retries at most ``max_open_attempts`` (3) times
+      within ``open_timeout_ms`` (Req 7.6).
+    * :meth:`start_stream` sets the pipeline to ``PLAYING`` (begins acquisition).
+    * :meth:`grab` pulls one sample from the ``appsink`` with a bounded timeout and
+      returns a :class:`RawFrame`; a timeout / missing sample returns ``None`` so
+      the worker can treat it as a disconnect signal (Req 7.1).
+    * :meth:`stop_stream` sets the pipeline back to ``PAUSED`` (claim retained).
+    * :meth:`close` sets the pipeline to ``NULL``, releasing the source claim.
+
+    The ``appsink`` is configured ``sync=false max-buffers=1 drop=true`` so the
+    pipeline always holds only the most recent frame (drop-to-latest), matching
+    the broadcast model's no-backpressure latest-frame slot.
+
+    This adapter is intended to be driven by a single acquisition worker thread
+    (the only code that touches the pipeline), matching the single-producer model.
+    """
+
+    _APPSINK_NAME = "appsink"
+
+    def __init__(self, camera_id, image_source=None, stream_config=None, pipeline_description=None):
+        """Create an adapter for one GStreamer-driven camera.
+
+        Args:
+            camera_id: Identifier of the physical camera (used for logging /
+                claim tracking).
+            image_source: The image-source description understood by
+                ``GstPipelineBuilder.add_image_source`` (``type`` +
+                ``imageSourceConfiguration``), used to build the source portion of
+                the live pipeline. Ignored when ``pipeline_description`` is given.
+            stream_config: :class:`StreamConfig` governing open retry budget and
+                open timeout; defaults are used when omitted.
+            pipeline_description: Optional explicit GStreamer launch string for the
+                source portion of the pipeline (everything before the appended
+                ``appsink`` stage). When provided it is used verbatim instead of
+                building from ``image_source`` — useful for ICAM/CSI variants or a
+                simulated source in tests.
+        """
+        self.camera_id = camera_id
+        self._image_source = image_source
+        self._stream_config = stream_config or StreamConfig()
+        self._pipeline_description = pipeline_description
+        self._rt = None          # lazily-loaded GStreamer runtime namespace
+        self._pipeline = None     # the persistent pipeline == the source claim
+        self._appsink = None      # the appsink element pulled by grab()
+        self._streaming = False
+
+    def open(self) -> None:
+        """Acquire the single source claim by building and prerolling the pipeline.
+
+        Builds the live ``appsink`` pipeline and sets it to ``PAUSED`` (which
+        transitions through ``READY``, opening the device). Attempts at most
+        ``max_open_attempts`` (3) times and never past the ``open_timeout_ms``
+        deadline, tearing a failed pipeline back down to ``NULL`` between attempts.
+        Raises ``PipelineExecutionException`` when every attempt fails so the
+        broadcaster can reject the subscribe with ``camera_unavailable`` (Req 7.6).
+        """
+        rt = _load_gstreamer_runtime()
+        self._rt = rt
+        Gst = rt.Gst
+
+        # Mirror gst_pipeline.run_pipeline: ensure the DDA GStreamer plugins are
+        # discoverable before initializing/parsing the pipeline.
+        try:
+            os.environ["GST_PLUGIN_PATH"] = rt.utils.get_gst_plugins_path()
+        except Exception as e:  # pragma: no cover - env best-effort
+            logger.warning(f"GStreamerBackend {self.camera_id}: could not set GST_PLUGIN_PATH: {e}")
+        Gst.init(None)
+
+        pipeline_str = self._build_pipeline_string()
+        logger.info(f"GStreamerBackend {self.camera_id}: live pipeline = {pipeline_str}")
+
+        max_attempts = max(1, int(self._stream_config.max_open_attempts or _DEFAULT_MAX_OPEN_ATTEMPTS))
+        open_timeout_s = self._stream_config.open_timeout_ms / 1000.0
+        deadline = time.monotonic() + open_timeout_s
+        last_error = None
+        attempt = 0
+        for attempt in range(1, max_attempts + 1):
+            pipeline = None
+            try:
+                pipeline = Gst.parse_launch(pipeline_str)
+                appsink = pipeline.get_by_name(self._APPSINK_NAME)
+                if appsink is None:
+                    raise rt.PipelineExecutionException(
+                        f"live pipeline for {self.camera_id} has no '{self._APPSINK_NAME}' element"
+                    )
+                self._configure_appsink(appsink)
+
+                ret = pipeline.set_state(Gst.State.PAUSED)
+                if ret == Gst.StateChangeReturn.FAILURE:
+                    raise rt.PipelineExecutionException(
+                        f"pipeline for {self.camera_id} failed to change state to PAUSED"
+                    )
+                # Bounded wait for the state change to settle (live sources report
+                # NO_PREROLL rather than SUCCESS; only FAILURE is fatal).
+                remaining_s = max(0.0, deadline - time.monotonic())
+                state_ret, _state, _pending = pipeline.get_state(int(remaining_s * Gst.SECOND))
+                if state_ret == Gst.StateChangeReturn.FAILURE:
+                    raise rt.PipelineExecutionException(
+                        f"pipeline for {self.camera_id} failed to reach PAUSED/READY"
+                    )
+
+                self._pipeline = pipeline
+                self._appsink = appsink
+                logger.info(
+                    f"GStreamerBackend {self.camera_id}: opened source claim on attempt {attempt}"
+                )
+                return
+            except Exception as e:
+                last_error = str(e)
+                logger.warning(
+                    f"GStreamerBackend {self.camera_id}: open attempt {attempt} failed: {e}"
+                )
+                self._safe_null(pipeline)
+
+            if time.monotonic() >= deadline:
+                logger.error(
+                    f"GStreamerBackend {self.camera_id}: open timeout exceeded after {attempt} attempt(s)"
+                )
+                break
+
+        raise rt.PipelineExecutionException(
+            f"Unable to open camera {self.camera_id} after {attempt} attempt(s): {last_error}"
+        )
+
+    def start_stream(self) -> None:
+        """Begin continuous acquisition by setting the pipeline to ``PLAYING``."""
+        self._require_open()
+        Gst = self._rt.Gst
+        ret = self._pipeline.set_state(Gst.State.PLAYING)
+        if ret == Gst.StateChangeReturn.FAILURE:
+            raise self._rt.PipelineExecutionException(
+                f"pipeline for {self.camera_id} failed to change state to PLAYING"
+            )
+        self._streaming = True
+        logger.info(f"GStreamerBackend {self.camera_id}: pipeline PLAYING (acquisition started)")
+
+    def grab(self, timeout_ms: int) -> "RawFrame | None":
+        """Pull the next frame from the ``appsink``, waiting at most ``timeout_ms``.
+
+        Uses ``appsink.try_pull_sample`` with a bounded (nanosecond) timeout. On a
+        timeout or a missing/unmappable sample returns ``None`` — which the
+        acquisition worker treats as a disconnect signal (Req 7.1). On success maps
+        the buffer to copy out the raw payload and reads the width/height from the
+        sample caps, returning a :class:`RawFrame`.
+        """
+        if self._pipeline is None or self._appsink is None:
+            return None
+        rt = self._rt
+        Gst = rt.Gst
+        timeout_ns = int(max(0, timeout_ms)) * 1_000_000
+
+        with rt.Timer(metric_name="CameraGetFrameTime"):
+            sample = self._appsink.try_pull_sample(timeout_ns)
+            if sample is None:
+                logger.error(
+                    f"GStreamerBackend {self.camera_id}: timed out after {timeout_ms} ms waiting for a frame"
+                )
+                return None
+
+            buffer = sample.get_buffer()
+            if buffer is None:
+                logger.error(f"GStreamerBackend {self.camera_id}: sample had no buffer")
+                return None
+            width, height = self._frame_dimensions(sample.get_caps())
+
+            success, map_info = buffer.map(Gst.MapFlags.READ)
+            if not success:
+                logger.error(f"GStreamerBackend {self.camera_id}: failed to map frame buffer")
+                return None
+            try:
+                # Copy the bytes out before unmapping so the payload outlives the
+                # GStreamer buffer (which is recycled by the pipeline).
+                data = bytes(map_info.data)
+            finally:
+                buffer.unmap(map_info)
+            return RawFrame(data=data, width=width, height=height)
+
+    def apply_features(self, features: dict) -> dict:
+        """Apply gain / exposure / advanced controls to the live source.
+
+        GStreamer sources (NVIDIA CSI host-capture service, v4l2 ICAM) take their
+        gain / exposure / crop from the image-source configuration that
+        ``GstPipelineBuilder`` writes when the source is added (e.g. the CSI host
+        config file). This merges the supplied values into the adapter's stored
+        image-source configuration and returns the merged values as the accepted
+        set. The live session keeps running throughout.
+
+        Accepts either an image-source-style dict (``gain`` / ``exposure`` /
+        ``advancedSettings``) or a device-feature list (normalized into the same
+        keys). Returns the accepted values.
+        """
+        self._require_open()
+        accepted = self._merge_features(features)
+        logger.info(f"GStreamerBackend {self.camera_id}: applied features {accepted}")
+        return accepted
+
+    def stop_stream(self) -> None:
+        """Stop acquisition without releasing the claim (pipeline back to PAUSED)."""
+        if self._pipeline is None or not self._streaming:
+            return
+        Gst = self._rt.Gst
+        self._pipeline.set_state(Gst.State.PAUSED)
+        self._streaming = False
+        logger.info(f"GStreamerBackend {self.camera_id}: pipeline PAUSED (acquisition stopped)")
+
+    def close(self) -> None:
+        """Release the single source claim by tearing the pipeline down to NULL."""
+        if self._pipeline is None:
+            return
+        try:
+            self._pipeline.set_state(self._rt.Gst.State.NULL)
+        finally:
+            self._pipeline = None
+            self._appsink = None
+            self._streaming = False
+            logger.info(f"GStreamerBackend {self.camera_id}: source claim released")
+
+    # --- internal helpers -------------------------------------------------
+
+    def _require_open(self) -> None:
+        """Raise if the pipeline has not been built/opened via :meth:`open`."""
+        if self._pipeline is None:
+            rt = self._rt or _load_gstreamer_runtime()
+            raise rt.PipelineExecutionException(
+                f"Camera {self.camera_id} is not open; call open() before this operation"
+            )
+
+    def _build_pipeline_string(self) -> str:
+        """Build the persistent live-view pipeline string ending in an ``appsink``.
+
+        Uses ``pipeline_description`` verbatim for the source portion when provided;
+        otherwise reuses ``GstPipelineBuilder.add_image_source`` (mirroring the
+        existing live-view source construction) to assemble the source plugins.
+        Appends a ``videoconvert ! video/x-raw,format=RGB ! appsink`` tail so the
+        worker pulls raw RGB frames.
+        """
+        rt = self._rt
+        if self._pipeline_description:
+            source_str = self._pipeline_description.strip().rstrip("!").strip()
+        else:
+            if not self._image_source:
+                raise rt.PipelineExecutionException(
+                    f"GStreamerBackend {self.camera_id} requires an image source or pipeline_description"
+                )
+            builder = rt.GstPipelineBuilder()
+            builder.add_image_source(self._image_source)
+            source_str = builder.pipeline_config.build_pipeline_string()
+
+        appsink_tail = (
+            "videoconvert ! video/x-raw,format=RGB ! "
+            f"appsink name={self._APPSINK_NAME} sync=false max-buffers=1 drop=true emit-signals=false"
+        )
+        return f"{source_str} ! {appsink_tail}"
+
+    def _configure_appsink(self, appsink) -> None:
+        """Configure the ``appsink`` for drop-to-latest, pull-based acquisition."""
+        try:
+            appsink.set_property("sync", False)
+            appsink.set_property("max-buffers", 1)
+            appsink.set_property("drop", True)
+            appsink.set_property("emit-signals", False)
+        except Exception as e:  # pragma: no cover - properties already set via launch string
+            logger.warning(f"GStreamerBackend {self.camera_id}: could not set appsink properties: {e}")
+
+    def _frame_dimensions(self, caps):
+        """Read width/height from a sample's caps, defaulting to 0 when absent."""
+        width = height = 0
+        if caps is not None and caps.get_size() > 0:
+            structure = caps.get_structure(0)
+            ok_w, w = structure.get_int("width")
+            ok_h, h = structure.get_int("height")
+            if ok_w:
+                width = w
+            if ok_h:
+                height = h
+        return width, height
+
+    def _merge_features(self, features) -> dict:
+        """Merge an ``apply_features`` argument into the stored image-source config.
+
+        Normalizes either an image-source-style dict or a device-feature list into
+        ``gain`` / ``exposure`` / ``advancedSettings`` keys, updates the adapter's
+        ``imageSourceConfiguration`` in place (so a future pipeline rebuild picks up
+        the values), and returns the accepted values.
+        """
+        accepted: dict = {}
+        if not features:
+            return accepted
+
+        if isinstance(features, list):
+            for item in features:
+                name = item.get("feature")
+                value = item.get("value")
+                if name in ("Gain", "gain"):
+                    accepted["gain"] = value
+                elif name in ("ExposureTime", "exposure"):
+                    accepted["exposure"] = value
+                elif name is not None:
+                    accepted.setdefault("advancedSettings", {})[name] = value
+        else:
+            if features.get("gain") is not None:
+                accepted["gain"] = features["gain"]
+            if features.get("exposure") is not None:
+                accepted["exposure"] = features["exposure"]
+            advanced = features.get("advancedSettings") or {}
+            if advanced:
+                accepted["advancedSettings"] = dict(advanced)
+
+        # Reflect accepted values into the stored image-source configuration so a
+        # subsequent pipeline build (CSI host config / v4l2 properties) uses them.
+        if accepted and isinstance(self._image_source, dict):
+            config = self._image_source.get("imageSourceConfiguration")
+            if not isinstance(config, dict):
+                config = {}
+                self._image_source["imageSourceConfiguration"] = config
+            for key, value in accepted.items():
+                if key == "advancedSettings":
+                    config.setdefault("advancedSettings", {}).update(value)
+                else:
+                    config[key] = value
+
+        return accepted
+
+    def _safe_null(self, pipeline) -> None:
+        """Best-effort teardown of a failed/rejected pipeline to ``NULL``."""
+        if pipeline is None:
+            return
+        try:
+            pipeline.set_state(self._rt.Gst.State.NULL)
+        except Exception as e:  # pragma: no cover - best-effort cleanup
+            logger.warning(f"GStreamerBackend {self.camera_id}: error cleaning up failed open: {e}")

--- a/src/backend/utils/streaming/broadcaster.py
+++ b/src/backend/utils/streaming/broadcaster.py
@@ -1,0 +1,1013 @@
+#
+#  Copyright 2025 Amazon Web Services, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Process-wide ``StreamBroadcaster``: the registry of per-camera stream sessions.
+
+The :class:`StreamBroadcaster` is the single place that mediates device access for
+the broadcast-model live preview. It holds a ``{camera_id -> StreamSession}`` map
+and enforces the **single device-claim invariant**: while a camera has at least one
+subscribed viewer there is exactly one open backend claim for it, and when the last
+viewer leaves the claim is released (Req 1.2, 2.1, 3.4).
+
+Lifecycle (this module, task 5.1):
+
+* :meth:`subscribe` — *start-on-first-viewer*. The first viewer for a camera with no
+  session creates the session, opens the backend (acquiring the single claim),
+  starts the acquisition worker, and registers the viewer. Subsequent viewers reuse
+  the existing session and claim (Req 1.2, 3.1, 8.1).
+* :meth:`unsubscribe` — *stop-on-last-viewer*. Removing the last viewer stops the
+  worker, stops the stream and closes the backend (releasing the claim), and removes
+  the session from the registry (Req 3.3, 3.7, 8.7, 8.8).
+* :meth:`viewer_count` — the active viewer count for a camera (Req 8.4).
+* :meth:`apply_settings` — *live edit-settings*. Applies gain/exposure/advanced
+  controls to a running session's claim, keeping it RUNNING with its viewer set
+  unchanged (task 8.1). On any control failure it retains (and best-effort restores)
+  the prior in-effect values, keeps the session active, and raises
+  :class:`SettingsApplyError` naming the failed control (task 8.2, Req 5.5).
+
+Thread-safety: a single re-entrant lock guards the registry dict and the per-session
+viewer mutations, so concurrent subscribe/unsubscribe calls can never create two
+sessions (two claims) for the same camera or race the start/stop transitions.
+
+This module is pure orchestration logic with **no** ``gi`` / device imports at module
+load (``backends.py`` keeps its GenICam / GStreamer imports lazy), so it stays
+importable on hosts without the camera stack. It is made testable by injecting a
+``backend_factory`` (to supply a mock :class:`CameraBackend`) and a ``time_fn`` clock.
+
+:meth:`preview_with_override` (task 8.3) serves the single-frame override preview used
+by ``POST /image-sources/{id}/preview``: it returns a preview frame reflecting a
+per-request config override **without** mutating the live session's applied control
+values or the shared latest-frame slot other viewers read (Req 5.4, Property 20).
+
+:meth:`get_inference_frame` (task 7.1) reuses an active session's claim for the
+inference/capture path and falls back to a single dedicated claim when no session
+exists, so the broadcaster mediates *all* device access for a camera.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from typing import Callable, Optional
+
+from utils.streaming.backends import AravisBackend, CameraBackend, GStreamerBackend
+from utils.streaming.models import (
+    FrameResult,
+    FrameStatus,
+    SessionState,
+    StreamConfig,
+    SubscribeResult,
+    Viewer,
+)
+from utils.streaming.session import StreamSession
+from utils.streaming.worker import AcquisitionWorker
+
+logger = logging.getLogger(__name__)
+
+
+class NoActiveSessionError(Exception):
+    """Raised when a live-session-only operation targets a camera with no session.
+
+    :meth:`StreamBroadcaster.apply_settings` applies controls to the *running* claim
+    and must never open a new claim itself (subscribing is the only path that starts a
+    session / acquires a claim). When no session is active for the requested camera this
+    is raised so the caller gets a clear "camera is not streaming" indication rather than
+    a second claim being opened behind its back (Req 5.1).
+    """
+
+
+class SettingsApplyError(Exception):
+    """Raised when applying a camera control to the live session fails (Req 5.5).
+
+    :meth:`StreamBroadcaster.apply_settings` applies gain / exposure / advanced
+    GenICam controls to the running claim. If the backend's ``apply_features`` raises
+    for any control, the broadcaster surfaces this descriptive error which **names the
+    failed control(s)** (the ``control`` attribute), retains the camera control values
+    that were in effect *before* the failed request (the ``retained`` attribute, also
+    best-effort re-applied to the device), and leaves the session active (RUNNING) with
+    its viewer set unchanged (Property 19).
+
+    Attributes:
+        camera_id: The camera whose live apply failed.
+        control: Human-readable name(s) of the control(s) in the failed request.
+        retained: The prior in-effect device-accepted control values that were
+            retained (the session's ``applied_features`` snapshot before the request).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        camera_id: str,
+        control: str,
+        retained: Optional[dict] = None,
+    ) -> None:
+        super().__init__(message)
+        self.camera_id = camera_id
+        self.control = control
+        self.retained = retained or {}
+
+
+def _describe_failed_controls(features) -> str:
+    """Return a human-readable name for the control(s) in an apply request.
+
+    Used to name the failed control in :class:`SettingsApplyError` (Req 5.5). Accepts
+    either an image-source-style dict (``gain`` / ``exposure`` / ``advancedSettings``)
+    or a device-feature list (``[{"feature","value"}, ...]``) — the same shapes the
+    backend's ``apply_features`` accepts — and extracts the control names. Falls back to
+    a generic label when no name can be derived so the error is always descriptive.
+    """
+    names: list[str] = []
+    if isinstance(features, dict):
+        for key, value in features.items():
+            if key == "advancedSettings" and isinstance(value, (list, tuple)):
+                for entry in value:
+                    if isinstance(entry, dict):
+                        name = entry.get("feature") or entry.get("name")
+                        if name:
+                            names.append(str(name))
+            else:
+                names.append(str(key))
+    elif isinstance(features, (list, tuple)):
+        for entry in features:
+            if isinstance(entry, dict):
+                name = entry.get("feature") or entry.get("name")
+                if name:
+                    names.append(str(name))
+    # De-duplicate while preserving order.
+    seen: set[str] = set()
+    ordered = [n for n in names if not (n in seen or seen.add(n))]
+    return ", ".join(ordered) if ordered else "<unknown control>"
+
+
+# Image-source ``type`` values used to pick a backend in the default factory. These
+# mirror ``model.image_source.ImageSourceType`` but are kept as literals so this
+# module does not depend on the model layer. ``Camera`` (GenICam / USB3Vision) maps
+# to Aravis; NVIDIA CSI and ICAM smart cameras map to the GStreamer pipeline path.
+_ARAVIS_SOURCE_TYPE = "Camera"
+_GSTREAMER_SOURCE_TYPES = ("NvidiaCSI", "ICam")
+
+
+class StreamBroadcaster:
+    """Process-wide registry of per-camera :class:`StreamSession`s.
+
+    Owns the ``{camera_id -> StreamSession}`` map and the worker bound to each
+    session, and is the single enforcement point for the one-open-claim-per-camera
+    invariant. Construct directly with an injected ``backend_factory`` / ``time_fn``
+    for tests; use :func:`get_broadcaster` for the process-wide singleton.
+
+    Attributes:
+        stream_config: Default :class:`StreamConfig` applied to new sessions /
+            backends when a subscribe does not imply its own.
+    """
+
+    def __init__(
+        self,
+        *,
+        stream_config: Optional[StreamConfig] = None,
+        backend_factory: Optional[Callable[[str, Optional[dict]], CameraBackend]] = None,
+        time_fn: Callable[[], float] = time.time,
+    ) -> None:
+        """Create a broadcaster.
+
+        Args:
+            stream_config: Default :class:`StreamConfig` for new sessions; defaults
+                are used when omitted.
+            backend_factory: Callable ``(camera_id, config) -> CameraBackend`` used
+                to build the backend for a new session. Injected by tests to supply a
+                mock backend; defaults to :meth:`_default_backend_factory`, which
+                selects :class:`AravisBackend` vs :class:`GStreamerBackend` from the
+                config's image-source ``type``.
+            time_fn: Wall-clock source returning epoch seconds, used to stamp viewer
+                ``subscribed_at`` / ``last_active``; injected for deterministic tests
+                (defaults to :func:`time.time`).
+        """
+        self.stream_config = stream_config or StreamConfig()
+        self._backend_factory = backend_factory or self._default_backend_factory
+        self._time = time_fn
+
+        # The registry and the per-session worker handles. Both are only ever
+        # mutated while holding ``_lock`` (re-entrant so internal helpers that also
+        # take the lock can be called from already-locked sections).
+        self._sessions: dict[str, StreamSession] = {}
+        self._workers: dict[str, AcquisitionWorker] = {}
+        self._lock = threading.RLock()
+
+    # --- subscription lifecycle ------------------------------------------
+
+    def subscribe(self, camera_id: str, config: Optional[dict] = None) -> SubscribeResult:
+        """Register a new viewer for ``camera_id``, starting the session if needed.
+
+        Start-on-first-viewer: when no session exists for the camera, one is created
+        — the backend is built via the factory, :meth:`CameraBackend.open` acquires
+        the single device claim, :meth:`CameraBackend.start_stream` begins continuous
+        acquisition, and an :class:`AcquisitionWorker` is started as the session's
+        single producer. A new :class:`Viewer` with a server-issued uuid is then
+        registered (Req 1.2, 2.1, 3.1, 8.1).
+
+        Args:
+            camera_id: Identifier of the physical camera to subscribe to.
+            config: Optional image-source / stream configuration used by the backend
+                factory when a new session is created. Ignored when a session already
+                exists (the existing claim is reused).
+
+        Rejection handling (task 5.2):
+
+        * **Viewer limit** — when the camera already has ``max_viewers`` active
+          viewers the subscribe is rejected with reason ``"viewer_limit"`` and the
+          (unchanged) current viewer count, without adding a viewer and without
+          disturbing the existing viewers or session (Req 1.3, 1.6).
+        * **Open failure** — when starting a new session fails (the backend's
+          ``open()`` raises after its internal ``<= max_open_attempts`` retries,
+          Req 7.6), the subscribe is rejected with reason ``"camera_unavailable"``
+          and a viewer count of 0, leaving no session and zero claims for that
+          camera and not affecting any other camera (Req 1.7, 3.2).
+
+        Returns:
+            A :class:`SubscribeResult` carrying the new ``viewer_id`` and the active
+            viewer count after registration, or — on rejection — ``viewer_id=None``
+            with ``accepted=False`` and the ``"viewer_limit"`` / ``"camera_unavailable"``
+            reason.
+        """
+        with self._lock:
+            session = self._sessions.get(camera_id)
+            if session is not None:
+                # Reuse the existing claim, but enforce the per-camera viewer cap
+                # first: at the limit, reject without touching existing viewers or
+                # the running session (Req 1.3, 1.6).
+                current = session.viewer_count()
+                if current >= self.stream_config.max_viewers:
+                    logger.info(
+                        f"StreamBroadcaster {camera_id}: subscribe rejected (viewer_limit) "
+                        f"at {current}/{self.stream_config.max_viewers} viewers"
+                    )
+                    return SubscribeResult(
+                        viewer_id=None,
+                        accepted=False,
+                        reason="viewer_limit",
+                        viewer_count=current,
+                    )
+            else:
+                # Start-on-first-viewer. A failed open leaves no session and zero
+                # claims; surface it as a graceful camera_unavailable rejection
+                # rather than propagating the exception (Req 1.7, 3.2, 7.6).
+                session = self._start_session(camera_id, config)
+                if session is None:
+                    return SubscribeResult(
+                        viewer_id=None,
+                        accepted=False,
+                        reason="camera_unavailable",
+                        viewer_count=0,
+                    )
+
+            viewer = Viewer(
+                viewer_id=str(uuid.uuid4()),
+                camera_id=camera_id,
+                subscribed_at=self._time(),
+                last_active=self._time(),
+            )
+            session.add_viewer(viewer)
+            count = session.viewer_count()
+            logger.info(
+                f"StreamBroadcaster {camera_id}: viewer {viewer.viewer_id} subscribed "
+                f"(viewer_count={count})"
+            )
+            return SubscribeResult(
+                viewer_id=viewer.viewer_id,
+                accepted=True,
+                reason=None,
+                viewer_count=count,
+            )
+
+    def unsubscribe(self, camera_id: str, viewer_id: str) -> None:
+        """Deregister a viewer; stop the session if it was the last one.
+
+        Stop-on-last-viewer: removing the final viewer stops the acquisition worker,
+        stops the stream and closes the backend (releasing the single device claim),
+        and removes the session from the registry so a future subscribe starts fresh
+        (Req 3.3, 3.7, 8.7, 8.8). Removing an unknown camera or viewer id is a no-op.
+
+        Args:
+            camera_id: Identifier of the physical camera.
+            viewer_id: Id of the viewer to remove.
+        """
+        with self._lock:
+            session = self._sessions.get(camera_id)
+            if session is None:
+                return
+
+            now_empty = session.remove_viewer(viewer_id)
+            logger.info(
+                f"StreamBroadcaster {camera_id}: viewer {viewer_id} unsubscribed "
+                f"(viewer_count={session.viewer_count()})"
+            )
+            if now_empty:
+                self._stop_session(camera_id)
+
+    def viewer_count(self, camera_id: str) -> int:
+        """Return the active viewer count for ``camera_id`` (0 when no session)."""
+        with self._lock:
+            session = self._sessions.get(camera_id)
+            return session.viewer_count() if session is not None else 0
+
+    # --- internal session start/stop -------------------------------------
+
+    def _start_session(self, camera_id: str, config: Optional[dict]) -> Optional[StreamSession]:
+        """Create, open, and start a session for ``camera_id`` (caller holds lock).
+
+        Builds the backend via the factory, opens it (acquiring the single claim),
+        starts continuous acquisition, launches the worker, and registers the session.
+        The backend's ``open()`` itself retries up to ``max_open_attempts`` internally
+        (Req 7.6); this method only needs to catch the resulting failure.
+
+        On any failure the partially-created session is torn down (claim released if it
+        was opened) and **not** left in the registry, so the single-claim invariant
+        holds even on a failed start. Rather than re-raising, ``None`` is returned so
+        :meth:`subscribe` can surface a graceful ``camera_unavailable`` rejection
+        (Req 1.7, 3.2). Other cameras are untouched because nothing was registered.
+
+        Returns:
+            The started :class:`StreamSession`, or ``None`` when the start failed.
+        """
+        backend = self._backend_factory(camera_id, config)
+        session = StreamSession(
+            camera_id=camera_id,
+            backend=backend,
+            stream_config=self.stream_config,
+            state=SessionState.STARTING,
+        )
+        try:
+            backend.open()           # acquire the single Device_Claim (retries internally)
+            backend.start_stream()   # begin continuous acquisition
+            # Bind the worker to the broadcaster's clock so each published frame's
+            # acquired_at is stamped with the SAME time source the broadcaster uses
+            # for read_latest / heartbeats. Otherwise the worker would default to
+            # time.monotonic while the broadcaster reads with time.time (wall clock),
+            # mixing two unrelated epochs in the OK/STALE freshness comparison and
+            # corrupting StreamConfig.stale_after_s semantics in production. sleep_fn
+            # is left at its default; StreamSession/worker stay injectable for tests.
+            worker = AcquisitionWorker(
+                session, stream_config=self.stream_config, time_fn=self._time
+            )
+            worker.start()
+        except Exception:
+            # Roll back any partial start so no orphaned claim / session survives,
+            # then report the failure to subscribe as a graceful rejection.
+            logger.exception(
+                f"StreamBroadcaster {camera_id}: failed to start session; rejecting as "
+                f"camera_unavailable"
+            )
+            self._safe_close_backend(camera_id, backend)
+            return None
+
+        self._sessions[camera_id] = session
+        self._workers[camera_id] = worker
+        logger.info(f"StreamBroadcaster {camera_id}: session started (claim acquired)")
+        return session
+
+    def _stop_session(self, camera_id: str) -> None:
+        """Stop the worker, release the claim, and drop the session (caller holds lock).
+
+        Drives the full teardown: signal/join the worker, ``stop_stream()`` then
+        ``close()`` the backend to release the single claim, and remove the session and
+        worker from the registry. The claim release is best-effort-guaranteed: even if
+        ``stop_stream()`` raises, ``close()`` is still attempted (design "force claim
+        release"), so the registry never retains a session whose claim leaked.
+        """
+        session = self._sessions.get(camera_id)
+        if session is None:
+            return
+
+        session.state = SessionState.STOPPING
+        worker = self._workers.get(camera_id)
+        if worker is not None:
+            try:
+                worker.stop()
+                worker.join(timeout=self.stream_config.frame_timeout_ms / 1000.0)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning(f"StreamBroadcaster {camera_id}: error stopping worker: {e}")
+
+        backend = session.backend
+        try:
+            if backend is not None:
+                backend.stop_stream()
+        except Exception as e:
+            logger.warning(f"StreamBroadcaster {camera_id}: stop_stream failed: {e}")
+        finally:
+            self._safe_close_backend(camera_id, backend)
+
+        session.state = SessionState.STOPPED
+        self._sessions.pop(camera_id, None)
+        self._workers.pop(camera_id, None)
+        logger.info(f"StreamBroadcaster {camera_id}: session stopped (claim released)")
+
+    def _safe_close_backend(self, camera_id: str, backend: Optional[CameraBackend]) -> None:
+        """Best-effort ``close()`` to release the device claim, swallowing errors."""
+        if backend is None:
+            return
+        try:
+            backend.close()
+        except Exception as e:  # pragma: no cover - best-effort cleanup
+            logger.warning(f"StreamBroadcaster {camera_id}: backend close failed: {e}")
+
+    # --- backend factory --------------------------------------------------
+
+    def _default_backend_factory(self, camera_id: str, config: Optional[dict]) -> CameraBackend:
+        """Build the default :class:`CameraBackend` for ``camera_id`` from ``config``.
+
+        Selects the adapter from the image-source ``type`` in ``config``: ``Camera``
+        (GenICam / USB3Vision) -> :class:`AravisBackend`; ``NvidiaCSI`` / ``ICam`` ->
+        :class:`GStreamerBackend`. Defaults to :class:`AravisBackend` when the type is
+        absent or unrecognized. Tests inject their own factory to bypass this and
+        supply a mock backend.
+        """
+        source_type = (config or {}).get("type")
+        if source_type in _GSTREAMER_SOURCE_TYPES:
+            return GStreamerBackend(camera_id, image_source=config, stream_config=self.stream_config)
+        return AravisBackend(
+            camera_id,
+            image_source_config=(config or {}).get("imageSourceConfiguration"),
+            stream_config=self.stream_config,
+        )
+
+    # --- seams for later tasks -------------------------------------------
+    # The following methods are intentionally unimplemented in task 5.1. They are
+    # declared here so the class shape is stable and later tasks fill in the logic
+    # against the registry/lock established above.
+
+    def heartbeat(self, camera_id: str, viewer_id: str) -> bool:
+        """Refresh a viewer's last-active timestamp to "now" (Req 3.8, 8.2, 8.3).
+
+        Looks the viewer up under the registry lock and stamps its ``last_active``
+        with the current clock value (``self._time()``), which is exactly the time
+        the stale-viewer sweep compares against. A viewer that keeps heartbeating
+        therefore never crosses the stale window, so abandoned tabs (which stop
+        heartbeating) are the only ones the sweep reaps.
+
+        Args:
+            camera_id: Identifier of the physical camera the viewer is watching.
+            viewer_id: Id of the viewer to refresh.
+
+        Returns:
+            ``True`` if the viewer exists and was refreshed; ``False`` when the
+            camera has no session or the viewer id is unknown / already expired
+            (e.g. swept away), so callers can treat a ``False`` as "re-subscribe".
+        """
+        with self._lock:
+            session = self._sessions.get(camera_id)
+            if session is None:
+                return False
+            viewer = session.viewers.get(viewer_id)
+            if viewer is None:
+                return False
+            viewer.last_active = self._time()
+            return True
+
+    def sweep_stale_viewers(self, now: float) -> None:
+        """Deregister viewers past the stale timeout; stop emptied sessions (Req 3.8, 8.6, 8.7).
+
+        Backstop for abandoned tabs that subscribed but stopped heartbeating /
+        polling. Across every session, a viewer is removed exactly when it has been
+        inactive *longer than* the configured window — ``now - last_active >
+        stale_timeout_s`` (:class:`StreamConfig.stale_timeout_s`, default 30). The
+        boundary ``now - last_active == stale_timeout_s`` is **not** stale (strict
+        ``>``), matching the heartbeat/staleness contract pinned by the property test
+        in ``test_session_heartbeat.py`` (task 3.6).
+
+        Removing stale viewers decrements the active count accordingly; when a
+        session is emptied as a result it is stopped via :meth:`_stop_session`, which
+        releases the single device claim (Req 8.7) — the same stop-on-last teardown
+        an explicit unsubscribe drives. The whole sweep runs under the registry lock
+        so it never races subscribe/unsubscribe.
+
+        Args:
+            now: Current epoch seconds (injected clock) to compare against each
+                viewer's ``last_active``.
+        """
+        with self._lock:
+            stale_timeout_s = self.stream_config.stale_timeout_s
+            # Snapshot the camera ids: _stop_session mutates self._sessions, so we
+            # must not iterate the dict directly while emptying it.
+            for camera_id in list(self._sessions.keys()):
+                session = self._sessions.get(camera_id)
+                if session is None:
+                    continue
+
+                stale_viewer_ids = [
+                    viewer_id
+                    for viewer_id, viewer in session.viewers.items()
+                    if (now - viewer.last_active) > stale_timeout_s
+                ]
+                if not stale_viewer_ids:
+                    continue
+
+                now_empty = session.is_empty()
+                for viewer_id in stale_viewer_ids:
+                    now_empty = session.remove_viewer(viewer_id)
+                logger.info(
+                    f"StreamBroadcaster {camera_id}: swept {len(stale_viewer_ids)} stale "
+                    f"viewer(s) (viewer_count={session.viewer_count()})"
+                )
+                if now_empty:
+                    self._stop_session(camera_id)
+
+    def get_frame(self, camera_id: str, viewer_id: str) -> FrameResult:
+        """Return the latest frame + state for a viewer, refreshing its heartbeat.
+
+        The frame GET doubles as a heartbeat: when the viewer exists its
+        ``last_active`` is stamped with the current clock as a side effect, so a
+        viewer that keeps polling stays alive without a separate heartbeat call
+        (Req 8.3). The result classifies the latest-frame slot against ``now``:
+
+        * ``OK`` with the :class:`~utils.streaming.models.LatestFrame` when a fresh
+          frame is available,
+        * ``NO_FRAME`` when the session is up but nothing has been published yet
+          (Req 2.6),
+        * ``STALE`` when the latest frame is older than the freshness ceiling
+          (Req 4.7),
+        * ``DISCONNECTED`` (no payload) when the camera has dropped or there is no
+          session for the camera (Req 7.5).
+
+        Disconnection cascade (Req 3.5, 3.11, 7.2, 7.3, 7.4, 7.5): the acquisition
+        worker transitions the session to :attr:`SessionState.ERROR` when a grab
+        times out / fails on an established stream (``WorkerStopReason.DISCONNECTED``)
+        or no first frame ever arrives (``FIRST_FRAME_TIMEOUT``). On observing that
+        ERROR state here, the session is torn down via :meth:`_stop_session` — which
+        releases the single device claim **before** this call returns — and
+        ``DISCONNECTED`` is reported with ``frame=None``. A previously cached frame
+        is **never** served once the camera is disconnected. Because the session is
+        dropped from the registry by the cascade, every subsequent ``get_frame`` for
+        that (now absent) camera also returns ``DISCONNECTED``. A camera that never
+        had a session likewise returns ``DISCONNECTED`` (it is not streaming).
+
+        Args:
+            camera_id: Identifier of the physical camera.
+            viewer_id: Id of the requesting viewer; used to refresh its heartbeat.
+
+        Returns:
+            A :class:`FrameResult` carrying the status and, when ``OK``, the frame.
+        """
+        with self._lock:
+            session = self._sessions.get(camera_id)
+            if session is None:
+                # No session => the camera is not streaming (never started, or
+                # already torn down by a prior disconnection cascade): DISCONNECTED.
+                return FrameResult(status=FrameStatus.DISCONNECTED, frame=None)
+
+            # Disconnection takes priority over any cached frame. The worker marks
+            # the session ERROR on a disconnect / first-frame timeout; cascade the
+            # teardown so the claim is released BEFORE we report completion, and
+            # never hand back a stale cached payload (Req 7.2-7.5, 3.5, 3.11).
+            if session.state == SessionState.ERROR:
+                logger.info(
+                    f"StreamBroadcaster {camera_id}: disconnect detected (session ERROR); "
+                    f"stopping session and reporting DISCONNECTED"
+                )
+                self._stop_session(camera_id)
+                return FrameResult(status=FrameStatus.DISCONNECTED, frame=None)
+
+            # Healthy session: the frame GET doubles as a heartbeat (Req 8.3).
+            viewer = session.viewers.get(viewer_id)
+            if viewer is not None:
+                viewer.last_active = self._time()
+
+            # Classify the latest-frame slot (OK / NO_FRAME / STALE).
+            return session.read_latest(self._time())
+
+    def get_inference_frame(
+        self, camera_id: str, config: Optional[dict] = None
+    ) -> Optional[dict]:
+        """Return a single frame for the inference/capture path, sharing the claim.
+
+        This is the broadcaster's mediation of *all* non-viewer device access, so the
+        one-open-claim-per-camera invariant stays enforced in a single place. The
+        return value matches the legacy ``camera_manager.get_camera_frame`` payload —
+        an unpickled ``{"data", "height", "width"}`` dict (or ``None``) — so existing
+        callers (``digital_input_*`` / ``workflow`` / capture) are unaffected once
+        :meth:`camera_manager.get_camera_frame` is rewired onto this method (task 7.2).
+
+        Two paths, both honoring the single-claim invariant:
+
+        * **Active session (Req 6.1, 6.4):** when a session is running for the camera,
+          the running claim is *reused* — the session's current latest frame is read
+          from the latest-frame slot and converted to the legacy dict shape. **No
+          second** ``Device_Claim`` is opened. The read is a non-blocking slot copy
+          (a pure function of the slot, like :meth:`get_frame`); if no frame has been
+          published yet ``None`` is returned. Whatever the outcome, the session and its
+          claim are left intact (Req 6.6) — this method never tears the session down.
+        * **No session (Req 6.3):** the legacy dedicated-claim fallback runs so
+          inference still works when nobody is watching. Exactly one claim is opened
+          via the backend factory (``open`` -> ``start_stream`` -> one ``grab`` ->
+          ``stop_stream`` -> ``close``) and is always released in a ``finally`` (the
+          claim count returns to 0), even when the grab fails.
+
+        The whole operation runs under the registry lock so the no-session fallback
+        cannot race a concurrent :meth:`subscribe` into opening a second claim for the
+        same camera (which would violate the single-claim invariant).
+
+        Args:
+            camera_id: Identifier of the physical camera.
+            config: Optional image-source / per-capture configuration used only by the
+                dedicated-claim fallback when no session exists. Ignored while a
+                session is active (the running claim — and its already-applied config —
+                is reused).
+
+        Returns:
+            The frame as a legacy ``{"data", "height", "width"}`` dict, or ``None`` when
+            no frame is available (no frame published yet on an active session, or the
+            dedicated grab failed). On failure with an active session, ``None`` is
+            returned while the session + claim are left intact (Req 6.6).
+        """
+        with self._lock:
+            session = self._sessions.get(camera_id)
+            if session is not None:
+                # Active session: reuse the running claim. Read the latest-frame slot
+                # (non-blocking, no device grab, no second claim) and leave the
+                # session + claim untouched regardless of outcome (Req 6.1, 6.4, 6.6).
+                return self._inference_frame_from_session(camera_id, session)
+
+            # No session: legacy dedicated-claim fallback (Req 6.3). Held under the
+            # registry lock so a concurrent subscribe cannot open a second claim for
+            # this camera while the dedicated claim is in flight.
+            return self._dedicated_inference_frame(camera_id, config)
+
+    def _inference_frame_from_session(
+        self, camera_id: str, session: StreamSession
+    ) -> Optional[dict]:
+        """Read the active session's latest frame as a legacy dict (caller holds lock).
+
+        Reuses the running claim: the frame is copied out of the session's latest-frame
+        slot (a pure slot read — no device grab, no second claim). Returns ``None`` when
+        no frame has been published yet. Any unexpected error is swallowed and reported
+        as ``None`` so the session and its claim are left intact (Req 6.6).
+        """
+        try:
+            result = session.read_latest(self._time())
+        except Exception:
+            # Defensive: a slot read should not fail, but never let an inference
+            # request tear down or disturb the live session (Req 6.6).
+            logger.exception(
+                f"StreamBroadcaster {camera_id}: inference slot read failed; "
+                f"leaving session intact and returning None"
+            )
+            return None
+
+        frame = result.frame
+        if frame is None:
+            # Session is up but nothing published yet (NO_FRAME). Keep it simple and
+            # non-blocking: report no frame; the session stays active (Req 6.6).
+            logger.info(
+                f"StreamBroadcaster {camera_id}: inference reused session claim but no "
+                f"frame is available yet"
+            )
+            return None
+
+        return {"data": frame.data, "height": frame.height, "width": frame.width}
+
+    def _dedicated_inference_frame(
+        self, camera_id: str, config: Optional[dict]
+    ) -> Optional[dict]:
+        """Open one dedicated claim, grab a single frame, and release it (caller holds lock).
+
+        The legacy fallback for when no session exists (Req 6.3): builds a backend via
+        the factory and drives ``open`` -> ``start_stream`` -> one ``grab`` ->
+        ``stop_stream`` -> ``close``. The claim release is guaranteed in a ``finally``
+        so the claim count returns to 0 even when the open/grab fails. Returns the
+        grabbed frame as a legacy ``{"data", "height", "width"}`` dict, or ``None``.
+        """
+        backend = self._backend_factory(camera_id, config)
+        frame: Optional[dict] = None
+        opened = False
+        try:
+            backend.open()  # acquire exactly one dedicated Device_Claim
+            opened = True
+            backend.start_stream()
+            raw = backend.grab(self.stream_config.frame_timeout_ms)
+            if raw is not None:
+                frame = {"data": raw.data, "height": raw.height, "width": raw.width}
+            else:
+                logger.warning(
+                    f"StreamBroadcaster {camera_id}: dedicated inference grab returned no frame"
+                )
+        except Exception:
+            logger.exception(
+                f"StreamBroadcaster {camera_id}: dedicated inference grab failed"
+            )
+            frame = None
+        finally:
+            # Always release the dedicated claim (count returns to 0), even on failure.
+            if opened:
+                try:
+                    backend.stop_stream()
+                except Exception as e:
+                    logger.warning(
+                        f"StreamBroadcaster {camera_id}: dedicated inference stop_stream failed: {e}"
+                    )
+            self._safe_close_backend(camera_id, backend)
+        return frame
+
+    def apply_settings(self, camera_id: str, features: dict) -> dict:
+        """Apply gain/exposure/advanced controls to the live session (Req 5.1-5.3).
+
+        Edit-settings path: when a session is active for ``camera_id`` the supplied
+        camera control values (gain / exposure / advanced GenICam features) are applied
+        to the *live* claim via :meth:`CameraBackend.apply_features`, so the change takes
+        effect on the running stream without tearing it down or re-opening the device.
+        The session is left fully intact (Req 5.3): its lifecycle state is **not** moved
+        away from ``RUNNING`` on success, its viewer set is untouched, and the
+        latest-frame slot is never cleared, so every subscribed viewer keeps reading the
+        live stream throughout the apply.
+
+        The whole operation runs under the registry lock so it cannot race a concurrent
+        subscribe/unsubscribe/stop that would otherwise change the session or its claim
+        underneath the apply. The backend's ``apply_features`` returns the values the
+        device actually accepted (which may be coerced/clamped), and those are returned
+        verbatim so callers can reflect what the hardware applied.
+
+        This deliberately does **not** open a new claim when no session exists —
+        subscribing is the only path that starts a session / acquires a claim. A request
+        to apply settings to a camera that is not streaming is therefore rejected with a
+        :class:`NoActiveSessionError` rather than silently opening a second claim.
+
+        Args:
+            camera_id: Identifier of the physical camera whose live session to adjust.
+            features: Camera control values to apply. Accepts either an image-source
+                style dict (``gain`` / ``exposure`` / ``advancedSettings``) or a device
+                feature list; the backend normalizes the shape.
+
+        Returns:
+            The device-accepted control values (exactly what
+            :meth:`CameraBackend.apply_features` returned).
+
+        Raises:
+            NoActiveSessionError: When ``camera_id`` has no active session (the camera is
+                not streaming). No claim is opened.
+            SettingsApplyError: When the backend fails to apply a control. The error
+                names the failed control(s); the prior in-effect values are retained
+                (and best-effort re-applied to the device) and the session is left
+                active (RUNNING) with its viewer set unchanged (Req 5.5).
+        """
+        with self._lock:
+            session = self._sessions.get(camera_id)
+            if session is None:
+                # No active session: do NOT open a new claim here (subscribing is the
+                # path that starts sessions). Surface a clear "no active session"
+                # indication to the caller (Req 5.1).
+                raise NoActiveSessionError(
+                    f"no active stream session for camera {camera_id}; "
+                    f"subscribe before applying settings"
+                )
+
+            # Capture the control values in effect *before* this request so we can
+            # retain (and best-effort restore) them if the apply fails (Req 5.5).
+            prior = dict(session.applied_features)
+
+            # Apply the controls to the live claim. The session is left intact: state is
+            # not moved away from RUNNING, the viewer registry is untouched, and the
+            # latest-frame slot is never cleared, so viewers keep reading throughout
+            # (Req 5.2, 5.3).
+            try:
+                accepted = session.backend.apply_features(features)
+            except Exception as exc:
+                # A control failed to apply. Do not leave partial state: keep the
+                # session active (its state and viewer set are untouched here), retain
+                # the prior in-effect values, and surface a descriptive error naming
+                # the failed control (Req 5.5, Property 19).
+                control = _describe_failed_controls(features)
+                logger.warning(
+                    f"StreamBroadcaster {camera_id}: failed to apply control(s) "
+                    f"[{control}] to running session; retaining prior values and keeping "
+                    f"session active (state={session.state.value}): {exc}"
+                )
+                # Best-effort restore of the prior in-effect values so the device does
+                # not retain a partially-applied control set. session.applied_features is
+                # deliberately NOT updated, so the recorded in-effect values stay at the
+                # prior set regardless of whether the device restore succeeds.
+                self._restore_prior_features(camera_id, session, prior)
+                raise SettingsApplyError(
+                    f"failed to apply control(s) [{control}] for camera {camera_id}: {exc}",
+                    camera_id=camera_id,
+                    control=control,
+                    retained=prior,
+                ) from exc
+
+            # Success: record the new device-accepted values as the in-effect set so a
+            # later failed apply can retain them.
+            if isinstance(accepted, dict):
+                session.applied_features.update(accepted)
+            logger.info(
+                f"StreamBroadcaster {camera_id}: applied live settings to running session "
+                f"(state={session.state.value}, viewer_count={session.viewer_count()})"
+            )
+            return accepted
+
+    def _restore_prior_features(
+        self, camera_id: str, session: StreamSession, prior: dict
+    ) -> None:
+        """Best-effort re-apply of the prior in-effect control values (caller holds lock).
+
+        Invoked after a failed apply so the device does not retain a partially-applied
+        control set: the values that were in effect before the failed request are
+        re-applied. This is strictly best-effort — any error here is logged and
+        swallowed so a restore failure can never tear down or further disturb the live
+        session (the recorded in-effect values remain the prior set regardless).
+        """
+        if not prior:
+            return
+        try:
+            session.backend.apply_features(dict(prior))
+        except Exception as e:  # pragma: no cover - best-effort restore
+            logger.warning(
+                f"StreamBroadcaster {camera_id}: best-effort restore of prior control "
+                f"values failed (session left active, prior values retained as recorded): {e}"
+            )
+
+    def preview_with_override(
+        self, camera_id: str, override_config: Optional[dict] = None
+    ) -> Optional[dict]:
+        """Return a single preview frame reflecting a per-request config override.
+
+        Backs ``POST /image-sources/{id}/preview`` (wired in task 9.2). The point of
+        this path is **isolation** (Req 5.4, Property 20): producing a preview that
+        reflects ``override_config`` must NOT mutate the live session's applied control
+        values (``session.applied_features``) and must NOT alter the shared latest-frame
+        slot that other viewers read. The hard post-condition this method guarantees is:
+        *after it returns, the session's ``applied_features`` and its latest-frame slot
+        are exactly what they were before the call* — for any subscribed viewer the
+        override is invisible.
+
+        Two paths, both honoring the single-claim invariant and the isolation
+        post-condition, run under the registry lock so neither can race a concurrent
+        subscribe/unsubscribe/apply:
+
+        * **Active session — isolated, non-mutating read (documented limitation).**
+          A second ``Device_Claim`` on the same camera while a session is active would
+          violate the single-claim invariant, and applying the override to the *live*
+          claim (then restoring) would briefly disturb the running session's controls
+          and the frames the acquisition worker publishes into the shared slot — exactly
+          what Req 5.4 forbids. With the current single-claim backends there is no way
+          to grab an override-reflecting frame in true isolation while a session holds
+          the only claim. The correct, isolation-preserving behavior is therefore to
+          return the session's **current** latest frame via a pure slot read (the same
+          non-blocking copy :meth:`get_frame` / inference reuse perform) and leave both
+          ``applied_features`` and the slot untouched. **Limitation:** while a session is
+          active the returned preview reflects the session's in-effect controls, *not*
+          the requested override; the override cannot be applied in isolation without
+          breaking the single-claim invariant or disturbing other viewers. Returns
+          ``None`` when no frame has been published yet.
+
+        * **No active session — dedicated-claim override grab.** With no session there is
+          nothing to disturb, so a dedicated short-lived claim is opened to produce a
+          genuinely override-reflecting frame: build a backend from ``override_config``
+          via the factory, ``open`` (acquire exactly one claim) -> ``start_stream`` ->
+          ``apply_features(override_config)`` (apply the override) -> one ``grab`` ->
+          ``stop_stream`` -> ``close``. The claim release is guaranteed in a ``finally``
+          so the claim count returns to 0 even on failure. Returns the grabbed frame as a
+          legacy ``{"data", "height", "width"}`` dict, or ``None`` when the grab/apply
+          fails (e.g. an out-of-range override is rejected by validation).
+
+        Args:
+            camera_id: Identifier of the physical camera to preview.
+            override_config: The per-request image-source / control override
+                (``gain`` / ``exposure`` / ``advancedSettings`` ...). With an active
+                session it is intentionally *not* applied (see the limitation above);
+                with no session it configures the dedicated claim and is applied to it.
+
+        Returns:
+            The preview frame as a legacy ``{"data", "height", "width"}`` dict, or
+            ``None`` when no frame is available. The live session (if any) — its
+            ``applied_features`` and its latest-frame slot — is left exactly unchanged.
+        """
+        with self._lock:
+            session = self._sessions.get(camera_id)
+            if session is not None:
+                # Active session: isolation wins over reflecting the override. Return a
+                # pure slot read of the current latest frame WITHOUT touching the live
+                # claim, applied_features, or the shared slot (Req 5.4, Property 20).
+                return self._isolated_preview_from_session(camera_id, session)
+
+            # No session: safe to open a dedicated short-lived claim and actually apply
+            # the override to produce an override-reflecting preview frame. Held under
+            # the registry lock so a concurrent subscribe cannot open a second claim for
+            # this camera while the dedicated preview claim is in flight.
+            return self._dedicated_override_preview(camera_id, override_config)
+
+    def _isolated_preview_from_session(
+        self, camera_id: str, session: StreamSession
+    ) -> Optional[dict]:
+        """Return the live session's current frame without disturbing it (caller holds lock).
+
+        A pure read of the latest-frame slot — no device grab, no second claim, and no
+        mutation of ``session.applied_features`` or the slot — so the isolation
+        post-condition (Property 20) holds by construction. The override is deliberately
+        NOT applied here (see :meth:`preview_with_override` for the documented
+        limitation). Returns ``None`` when nothing has been published yet, or on any
+        unexpected read error (which is swallowed so the live session is never disturbed).
+        """
+        try:
+            result = session.read_latest(self._time())
+        except Exception:
+            # Defensive: a slot read should not fail, but never let a preview request
+            # disturb the live session (Req 5.4).
+            logger.exception(
+                f"StreamBroadcaster {camera_id}: override-preview slot read failed; "
+                f"leaving session intact and returning None"
+            )
+            return None
+
+        logger.info(
+            f"StreamBroadcaster {camera_id}: override preview served the live session's "
+            f"current frame (override not applied while a session is active; isolation "
+            f"preserved — applied_features and latest slot unchanged)"
+        )
+        frame = result.frame
+        if frame is None:
+            return None
+        return {"data": frame.data, "height": frame.height, "width": frame.width}
+
+    def _dedicated_override_preview(
+        self, camera_id: str, override_config: Optional[dict]
+    ) -> Optional[dict]:
+        """Open one dedicated claim, apply the override, grab a frame, release it.
+
+        The no-session path (caller holds lock): builds a backend from
+        ``override_config`` and drives ``open`` -> ``start_stream`` ->
+        ``apply_features(override_config)`` -> one ``grab`` -> ``stop_stream`` ->
+        ``close``. Because no session exists there is nothing to disturb, so the override
+        can be applied for real. The claim release is guaranteed in a ``finally`` (the
+        claim count returns to 0) even when the open / apply / grab fails. Returns the
+        grabbed frame as a legacy ``{"data", "height", "width"}`` dict, or ``None``.
+        """
+        backend = self._backend_factory(camera_id, override_config)
+        frame: Optional[dict] = None
+        opened = False
+        try:
+            backend.open()  # acquire exactly one dedicated Device_Claim
+            opened = True
+            backend.start_stream()
+            # Apply the per-request override to this isolated claim so the preview
+            # reflects it. An out-of-range override raises here and is reported as None.
+            if override_config:
+                backend.apply_features(override_config)
+            raw = backend.grab(self.stream_config.frame_timeout_ms)
+            if raw is not None:
+                frame = {"data": raw.data, "height": raw.height, "width": raw.width}
+            else:
+                logger.warning(
+                    f"StreamBroadcaster {camera_id}: dedicated override preview grab "
+                    f"returned no frame"
+                )
+        except Exception:
+            logger.exception(
+                f"StreamBroadcaster {camera_id}: dedicated override preview failed"
+            )
+            frame = None
+        finally:
+            # Always release the dedicated claim (count returns to 0), even on failure.
+            if opened:
+                try:
+                    backend.stop_stream()
+                except Exception as e:
+                    logger.warning(
+                        f"StreamBroadcaster {camera_id}: dedicated override preview "
+                        f"stop_stream failed: {e}"
+                    )
+            self._safe_close_backend(camera_id, backend)
+        return frame
+
+
+# --- process-wide singleton ----------------------------------------------
+
+_broadcaster: Optional[StreamBroadcaster] = None
+_broadcaster_lock = threading.Lock()
+
+
+def get_broadcaster() -> StreamBroadcaster:
+    """Return the process-wide :class:`StreamBroadcaster` singleton.
+
+    Lazily constructs the singleton on first use (with default config, the default
+    backend factory, and the wall clock). The stream API endpoints and the
+    inference/capture path share this one instance so all device access for a camera
+    is mediated by a single registry, which is what enforces the one-claim-per-camera
+    invariant process-wide. Tests construct their own :class:`StreamBroadcaster`
+    instances with injected dependencies instead of using this singleton.
+    """
+    global _broadcaster
+    if _broadcaster is None:
+        with _broadcaster_lock:
+            if _broadcaster is None:
+                _broadcaster = StreamBroadcaster()
+    return _broadcaster

--- a/src/backend/utils/streaming/models.py
+++ b/src/backend/utils/streaming/models.py
@@ -1,0 +1,181 @@
+#
+#  Copyright 2025 Amazon Web Services, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Core data models for the broadcast-style camera streaming stack.
+
+These types are the shared vocabulary used by the ``StreamSession`` (latest-frame
+slot + viewer registry) and the ``StreamBroadcaster`` (process-wide registry of
+sessions). They are intentionally pure data holders with no device or threading
+dependencies so the broadcaster/session logic can be exercised deterministically
+against a mock backend and an injected clock.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class LatestFrame:
+    """The most recently acquired frame held for a single physical camera.
+
+    A new ``LatestFrame`` is published into a session's single-slot buffer
+    wholesale on every successful grab, so readers always observe a complete,
+    consistent frame (Req 2.2, 2.5).
+
+    Attributes:
+        data: Raw image payload (same shape as today's ``get_frame`` payload).
+        width: Frame width in pixels.
+        height: Frame height in pixels.
+        seq: Monotonic per-session sequence number identifying an acquisition
+            interval. Two reads observing the same ``seq`` observe identical bytes.
+        acquired_at: Epoch seconds when the frame was grabbed from the device.
+    """
+
+    data: bytes
+    width: int
+    height: int
+    seq: int
+    acquired_at: float
+
+
+@dataclass
+class Viewer:
+    """A single client subscription to a camera stream.
+
+    Each browser tab / client polling a camera corresponds to one ``Viewer``.
+    Duplicate subscriptions to the same camera produce distinct viewer ids and
+    each counts toward the active viewer total (Req 8.5).
+
+    Attributes:
+        viewer_id: Server-issued unique id (e.g. a uuid).
+        camera_id: Identifier of the physical camera this viewer is watching.
+        subscribed_at: Epoch seconds when the viewer subscribed.
+        last_active: Epoch seconds of the viewer's most recent heartbeat / frame
+            GET; refreshed on activity and used for stale-viewer detection (Req 8.3).
+    """
+
+    viewer_id: str
+    camera_id: str
+    subscribed_at: float
+    last_active: float
+
+
+class SessionState(Enum):
+    """Lifecycle state of a stream session for one physical camera."""
+
+    STARTING = "starting"
+    RUNNING = "running"
+    STOPPING = "stopping"
+    STOPPED = "stopped"
+    ERROR = "error"
+
+
+class FrameStatus(Enum):
+    """Status returned to a viewer when it requests the current preview frame."""
+
+    OK = "ok"
+    NO_FRAME = "no_frame"          # session up, no frame published yet (Req 2.6, 4.2)
+    STALE = "stale"               # latest frame older than the freshness ceiling (Req 4.7)
+    DISCONNECTED = "disconnected"  # camera dropped / disconnected (Req 7.5)
+
+
+@dataclass
+class FrameResult:
+    """Outcome of a viewer's request for the current preview frame.
+
+    Attributes:
+        status: Classification of the result (OK / NO_FRAME / STALE / DISCONNECTED).
+        frame: The frame payload when ``status`` is ``OK``; otherwise ``None``.
+        error: Optional human-readable error/context for non-OK statuses.
+    """
+
+    status: FrameStatus
+    frame: Optional[LatestFrame] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class SubscribeResult:
+    """Outcome of a viewer's subscription attempt.
+
+    Attributes:
+        viewer_id: Server-issued viewer id when accepted; ``None`` when rejected.
+        accepted: Whether the subscription was accepted.
+        reason: Rejection reason when not accepted: ``"viewer_limit"`` (Req 1.6)
+            or ``"camera_unavailable"`` (Req 1.7, 3.2); ``None`` when accepted.
+        viewer_count: Active viewer count for the camera after the attempt.
+    """
+
+    viewer_id: Optional[str]
+    accepted: bool
+    reason: Optional[str]
+    viewer_count: int
+
+
+# Bounds for timeout clamping (Req 7.1). Configured frame/open timeouts are
+# clamped into this inclusive range on construction so a misconfigured value can
+# never starve acquisition (too small) or hang the worker indefinitely (too large).
+_MIN_TIMEOUT_MS = 500
+_MAX_TIMEOUT_MS = 30000
+
+
+def _clamp_timeout_ms(value: int) -> int:
+    """Clamp a millisecond timeout into the accepted [500, 30000] range (Req 7.1)."""
+    return max(_MIN_TIMEOUT_MS, min(_MAX_TIMEOUT_MS, value))
+
+
+@dataclass
+class StreamConfig:
+    """Configurable bounds governing a stream session's timing and limits.
+
+    These values tune acquisition timeouts, the device-open retry budget, viewer
+    capacity, heartbeat/stale lifecycle windows, and frame freshness. They are pure
+    data so the broadcaster/session logic can be exercised deterministically against
+    a mock backend and an injected clock.
+
+    ``frame_timeout_ms`` and ``open_timeout_ms`` are clamped into the inclusive range
+    [500, 30000] ms on construction (Req 7.1), so out-of-range configuration values
+    are corrected rather than rejected.
+
+    Attributes:
+        frame_timeout_ms: Bounded wait for a single grab; clamped to [500, 30000].
+        open_timeout_ms: Bounded wait for a device open attempt; clamped to [500, 30000].
+        max_open_attempts: Maximum device-open attempts before reporting the camera
+            unavailable (Req 7.6).
+        max_viewers: Maximum concurrent viewers per camera (Req 1.6).
+        heartbeat_interval_s: Expected interval between viewer heartbeats.
+        stale_timeout_s: Viewer is considered stale when inactive longer than this.
+        first_frame_timeout_s: Maximum wait for the first published frame after start.
+        stale_after_s: Freshness ceiling for served frames; older frames read STALE
+            (Req 4.6).
+        min_refresh_fps: Minimum target refresh rate for a fast-enough source (Req 4.3).
+    """
+
+    frame_timeout_ms: int = 5000      # clamp [500, 30000]
+    open_timeout_ms: int = 5000       # clamp [500, 30000]
+    max_open_attempts: int = 3
+    max_viewers: int = 8
+    heartbeat_interval_s: int = 10
+    stale_timeout_s: int = 30
+    first_frame_timeout_s: int = 10
+    stale_after_s: float = 2.0        # freshness ceiling for served frames (Req 4.6)
+    min_refresh_fps: float = 5.0      # Req 4.3
+
+    def __post_init__(self) -> None:
+        """Clamp the frame and open timeouts into [500, 30000] ms (Req 7.1)."""
+        self.frame_timeout_ms = _clamp_timeout_ms(self.frame_timeout_ms)
+        self.open_timeout_ms = _clamp_timeout_ms(self.open_timeout_ms)

--- a/src/backend/utils/streaming/session.py
+++ b/src/backend/utils/streaming/session.py
@@ -1,0 +1,224 @@
+#
+#  Copyright 2025 Amazon Web Services, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Per-camera ``StreamSession``: latest-frame slot + viewer registry.
+
+A :class:`StreamSession` owns exactly one physical camera's broadcast state:
+
+* a **single-writer / many-reader latest-frame slot**. The acquisition worker is
+  the only writer; it calls :meth:`publish` to replace the slot wholesale under a
+  brief writer lock, assigning a monotonic sequence number and an acquired-at
+  timestamp. Any number of viewers call :meth:`read_latest`, which copies the
+  current reference out under the same lock and releases immediately — readers
+  never hold the lock across I/O and never touch the device. Because the slot is
+  replaced wholesale, two reads observing the same ``seq`` observe byte-identical
+  frames (Req 2.2, 2.5) and repeated reads with no intervening publish return the
+  same frame without a device grab (Req 2.4).
+* a **viewer registry** (``add_viewer`` / ``remove_viewer`` / ``is_empty``) used by
+  the broadcaster to drive start-on-first / stop-on-last lifecycle.
+* the session **lifecycle state** (:class:`SessionState`) and a reference to the
+  owning ``CameraBackend``.
+
+:meth:`read_latest` classifies the slot against an injected ``now``:
+``NO_FRAME`` when nothing has been published yet (Req 2.6), ``STALE`` when the
+latest frame is older than ``stream_config.stale_after_s`` (Req 4.6, 4.7), and
+``OK`` with the :class:`LatestFrame` otherwise.
+
+This module is intentionally pure logic with no device or ``gi`` dependencies so
+the session can be exercised deterministically against a mock backend and an
+injected clock.
+"""
+from __future__ import annotations
+
+import threading
+from typing import Optional, Union
+
+from utils.streaming.backends import RawFrame
+from utils.streaming.models import (
+    FrameResult,
+    FrameStatus,
+    LatestFrame,
+    SessionState,
+    StreamConfig,
+    Viewer,
+)
+
+
+class StreamSession:
+    """Owns one camera's latest-frame slot, viewer registry, and lifecycle state.
+
+    The acquisition worker is the single producer driving :meth:`publish`; viewers
+    are the many readers calling :meth:`read_latest`. Producer and readers are
+    decoupled by a brief writer lock held only for the slot swap / reference copy,
+    so readers never block each other or the producer (Req 2.4, 4.5).
+
+    Attributes:
+        camera_id: Identifier of the physical camera this session serves.
+        backend: The ``CameraBackend`` holding this camera's single device claim.
+            Stored as an opaque reference; the session never drives it directly.
+        state: Current :class:`SessionState` lifecycle value.
+        viewers: Mapping ``{viewer_id -> Viewer}`` of active subscriptions.
+        latest: The current :class:`LatestFrame`, or ``None`` before the first
+            publish.
+        applied_features: The device-accepted camera control values currently in
+            effect on the live claim, maintained by the broadcaster's settings-apply
+            path so a failed apply can retain the prior in-effect values (Req 5.5).
+    """
+
+    def __init__(
+        self,
+        camera_id: str,
+        backend: object = None,
+        stream_config: Optional[StreamConfig] = None,
+        state: SessionState = SessionState.STARTING,
+    ) -> None:
+        """Create a session for one physical camera.
+
+        Args:
+            camera_id: Identifier of the physical camera.
+            backend: The ``CameraBackend`` for this camera (opaque reference).
+            stream_config: :class:`StreamConfig` governing freshness
+                (``stale_after_s``); defaults are used when omitted.
+            state: Initial lifecycle state (defaults to ``STARTING``).
+        """
+        self.camera_id = camera_id
+        self.backend = backend
+        self.stream_config = stream_config or StreamConfig()
+        self.state = state
+        self.viewers: dict[str, Viewer] = {}
+        self.latest: Optional[LatestFrame] = None
+
+        # The camera control values currently in effect on the live claim (the
+        # device-accepted gain / exposure / advanced GenICam values from the most
+        # recent successful apply). Maintained by
+        # ``StreamBroadcaster.apply_settings`` so that, when a later apply fails, the
+        # broadcaster can both report which control failed and retain (and best-effort
+        # restore) the values that were in effect *before* the failed request
+        # (Req 5.5, Property 19). Empty until the first successful apply.
+        self.applied_features: dict = {}
+
+        # Guards both the latest-frame slot and the monotonic sequence counter.
+        # Held only for the brief slot swap (writer) or reference copy (reader).
+        self._slot_lock = threading.Lock()
+        self._seq = 0
+
+    # --- viewer registry --------------------------------------------------
+
+    def add_viewer(self, viewer: Viewer) -> None:
+        """Register a viewer in this session's registry.
+
+        Duplicate subscriptions produce distinct viewer ids upstream, so each
+        ``viewer.viewer_id`` is unique and counts toward the active total (Req 8.5).
+        """
+        self.viewers[viewer.viewer_id] = viewer
+
+    def remove_viewer(self, viewer_id: str) -> bool:
+        """Deregister a viewer by id.
+
+        Args:
+            viewer_id: The id of the viewer to remove. Removing an unknown id is a
+                no-op.
+
+        Returns:
+            ``True`` if the registry is now empty (the caller should stop the
+            session / release the claim), ``False`` otherwise.
+        """
+        self.viewers.pop(viewer_id, None)
+        return self.is_empty()
+
+    def is_empty(self) -> bool:
+        """Return ``True`` when no viewers are currently registered."""
+        return len(self.viewers) == 0
+
+    def viewer_count(self) -> int:
+        """Return the number of currently registered viewers."""
+        return len(self.viewers)
+
+    # --- latest-frame slot ------------------------------------------------
+
+    def publish(
+        self,
+        frame: Union[RawFrame, bytes],
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+        now: float = 0.0,
+    ) -> LatestFrame:
+        """Publish a newly acquired frame into the single latest-frame slot.
+
+        The single producer (acquisition worker) calls this on every successful
+        grab. A monotonic sequence number and the supplied ``now`` (acquired-at)
+        timestamp are assigned, and the slot is replaced wholesale under a brief
+        writer lock so readers always observe a complete, consistent frame
+        (Req 2.2, 2.5).
+
+        Args:
+            frame: Either a :class:`RawFrame` (carrying ``data`` / ``width`` /
+                ``height``) or the raw payload ``bytes``. When ``bytes`` are passed,
+                ``width`` and ``height`` must also be supplied.
+            width: Frame width in pixels; required when ``frame`` is ``bytes``,
+                ignored when ``frame`` is a :class:`RawFrame`.
+            height: Frame height in pixels; required when ``frame`` is ``bytes``,
+                ignored when ``frame`` is a :class:`RawFrame`.
+            now: Epoch seconds when the frame was grabbed (injected clock).
+
+        Returns:
+            The :class:`LatestFrame` that was published (with its assigned ``seq``).
+        """
+        if isinstance(frame, RawFrame):
+            data, frame_width, frame_height = frame.data, frame.width, frame.height
+        else:
+            if width is None or height is None:
+                raise ValueError("width and height are required when publishing raw bytes")
+            data, frame_width, frame_height = frame, width, height
+
+        with self._slot_lock:
+            self._seq += 1
+            published = LatestFrame(
+                data=data,
+                width=frame_width,
+                height=frame_height,
+                seq=self._seq,
+                acquired_at=now,
+            )
+            self.latest = published
+        return published
+
+    def read_latest(self, now: float) -> FrameResult:
+        """Read the current latest frame and classify its freshness.
+
+        Copies the current slot reference out under the writer lock and releases
+        immediately (readers never hold the lock across work, never re-grab — the
+        result is a pure function of the slot, Req 2.4). Classification:
+
+        * ``NO_FRAME`` when no frame has been published yet (Req 2.6, 4.2).
+        * ``STALE`` when ``now - acquired_at > stale_after_s`` (Req 4.6, 4.7).
+        * ``OK`` with the :class:`LatestFrame` otherwise.
+
+        Args:
+            now: Current epoch seconds (injected clock) used for the freshness check.
+
+        Returns:
+            A :class:`FrameResult` carrying the status and, when ``OK``, the frame.
+        """
+        with self._slot_lock:
+            frame = self.latest
+
+        if frame is None:
+            return FrameResult(status=FrameStatus.NO_FRAME, frame=None)
+
+        if now - frame.acquired_at > self.stream_config.stale_after_s:
+            return FrameResult(status=FrameStatus.STALE, frame=frame)
+
+        return FrameResult(status=FrameStatus.OK, frame=frame)

--- a/src/backend/utils/streaming/worker.py
+++ b/src/backend/utils/streaming/worker.py
@@ -1,0 +1,263 @@
+#
+#  Copyright 2025 Amazon Web Services, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""Acquisition worker: the single producer driving one :class:`StreamSession`.
+
+Each active stream session owns exactly one :class:`AcquisitionWorker`. The
+worker is the *only* code that touches the session's ``CameraBackend`` handle; it
+loops ``grab()`` -> ``session.publish(...)`` and is the single writer of the
+session's latest-frame slot (matching the broadcast design's single-producer /
+many-reader model).
+
+Loop behaviour (see the "Acquisition worker" section of the design):
+
+* **Grab -> publish.** On every successful ``grab(frame_timeout_ms)`` the raw
+  frame is published into the session's latest-frame slot with the current clock
+  time as its acquired-at stamp, and the session transitions to ``RUNNING`` on
+  the first frame.
+* **Rate ceiling, never below device cadence (Req 4.3, 4.4).** After each
+  iteration the worker sleeps only the remainder of ``1 / min_refresh_fps`` not
+  already consumed by the grab/publish. When the device is slower than that
+  ceiling the grab already overruns the interval, so no delay is added and the
+  loop tracks the device's own cadence. No delay is ever added beyond what the
+  ceiling needs.
+* **First-frame timeout (Req 3.10, 3.11).** If no frame is published within
+  ``first_frame_timeout_s`` of the loop starting, the session is transitioned to
+  ``ERROR`` and the loop stops. Transient failed grabs during start-up are
+  tolerated (retried) until this deadline.
+* **Disconnect detection (Req 7.1).** Once a stream is established, a ``grab()``
+  that returns ``None`` (timeout / acquisition failure) or raises marks the
+  camera disconnected, transitions the session to ``ERROR``, and stops the loop.
+* **Last-good-frame retention (Req 2.7).** A failed grab never calls
+  ``publish``, so the latest-frame slot keeps the last successfully published
+  frame; it is not overwritten by the failure.
+
+The worker takes an injected **time function** and **sleep function** (defaulting
+to :func:`time.monotonic` / :func:`time.sleep`) plus a stop :class:`threading.Event`,
+so the loop can be driven deterministically against a mock backend and a virtual
+clock and stopped cleanly. This module is pure logic with no device or ``gi``
+dependency, so it is import-safe on hosts without the GenICam / GStreamer stack.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from enum import Enum
+from typing import Callable, Optional
+
+from utils.streaming.models import SessionState, StreamConfig
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerStopReason(Enum):
+    """Why an :class:`AcquisitionWorker` loop terminated.
+
+    Attributes:
+        STOPPED: The stop :class:`~threading.Event` was set (clean shutdown,
+            e.g. the last viewer unsubscribed).
+        FIRST_FRAME_TIMEOUT: No frame was published within
+            ``first_frame_timeout_s`` of the loop starting (Req 3.10, 3.11).
+        DISCONNECTED: A grab failed/timed out on an established stream, so the
+            camera was marked disconnected (Req 7.1).
+    """
+
+    STOPPED = "stopped"
+    FIRST_FRAME_TIMEOUT = "first_frame_timeout"
+    DISCONNECTED = "disconnected"
+
+
+class AcquisitionWorker:
+    """One acquisition loop bound to a single :class:`StreamSession`.
+
+    The worker reads the session's ``backend`` and ``stream_config`` and drives
+    the ``grab -> publish`` loop until a stop condition is met. It is designed to
+    run on its own thread (see :meth:`start`) but :meth:`run` can also be called
+    inline (e.g. from a test) since all timing is injected.
+
+    Attributes:
+        session: The :class:`StreamSession` this worker produces frames for.
+        stream_config: The :class:`StreamConfig` governing grab timeout, refresh
+            ceiling, and first-frame timeout (defaults to the session's config).
+        stop_event: A :class:`threading.Event`; setting it stops the loop after
+            the current iteration.
+        stop_reason: The :class:`WorkerStopReason` once the loop has terminated,
+            or ``None`` while running / before start.
+        error: A human-readable description of the failure when the loop stopped
+            on an error condition; ``None`` for a clean stop.
+    """
+
+    def __init__(
+        self,
+        session,
+        *,
+        stream_config: Optional[StreamConfig] = None,
+        stop_event: Optional[threading.Event] = None,
+        time_fn: Callable[[], float] = time.monotonic,
+        sleep_fn: Callable[[float], None] = time.sleep,
+    ) -> None:
+        """Create a worker for ``session``.
+
+        Args:
+            session: The :class:`StreamSession` to produce frames for. Its
+                ``backend`` is driven by ``grab()`` and its ``publish()`` is the
+                only slot writer.
+            stream_config: Optional :class:`StreamConfig` override; defaults to
+                ``session.stream_config``.
+            stop_event: Optional externally-owned stop event so the broadcaster
+                can stop the worker; a fresh :class:`threading.Event` is created
+                when omitted.
+            time_fn: Monotonic time source returning seconds; injected for
+                deterministic tests (defaults to :func:`time.monotonic`).
+            sleep_fn: Sleep function taking seconds; injected for deterministic
+                tests (defaults to :func:`time.sleep`).
+        """
+        self.session = session
+        self.stream_config = stream_config or getattr(session, "stream_config", None) or StreamConfig()
+        self.stop_event = stop_event or threading.Event()
+        self._time = time_fn
+        self._sleep = sleep_fn
+
+        self.stop_reason: Optional[WorkerStopReason] = None
+        self.error: Optional[str] = None
+        self._thread: Optional[threading.Thread] = None
+
+    # --- lifecycle --------------------------------------------------------
+
+    def start(self) -> threading.Thread:
+        """Run :meth:`run` on a dedicated daemon thread and return that thread.
+
+        Convenience for the broadcaster, which runs one worker thread per
+        session. Tests typically call :meth:`run` directly with an injected clock
+        instead.
+        """
+        thread = threading.Thread(
+            target=self.run,
+            name=f"acquisition-worker-{getattr(self.session, 'camera_id', '?')}",
+            daemon=True,
+        )
+        self._thread = thread
+        thread.start()
+        return thread
+
+    def stop(self) -> None:
+        """Signal the loop to stop after the current iteration (idempotent)."""
+        self.stop_event.set()
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        """Join the background thread started by :meth:`start`, if any."""
+        if self._thread is not None:
+            self._thread.join(timeout)
+
+    # --- the loop ---------------------------------------------------------
+
+    def run(self) -> WorkerStopReason:
+        """Drive the ``grab -> publish`` loop until a stop condition is met.
+
+        Returns the :class:`WorkerStopReason` describing why the loop ended. Side
+        effects: publishes frames into ``session`` and transitions
+        ``session.state`` (``RUNNING`` on the first frame, ``ERROR`` on
+        first-frame timeout or disconnect).
+        """
+        backend = self.session.backend
+        frame_timeout_ms = int(self.stream_config.frame_timeout_ms)
+        first_frame_timeout_s = float(self.stream_config.first_frame_timeout_s)
+        target_interval = self._target_interval()
+
+        start = self._time()
+        published_any = False
+        camera_id = getattr(self.session, "camera_id", "?")
+
+        while not self.stop_event.is_set():
+            iter_start = self._time()
+
+            frame = self._safe_grab(backend, frame_timeout_ms, camera_id)
+
+            if frame is not None:
+                # Successful grab: publish into the single latest-frame slot and
+                # mark the session running on the first frame (Req 4.3 producer).
+                self.session.publish(frame, now=self._time())
+                if not published_any:
+                    published_any = True
+                    self.session.state = SessionState.RUNNING
+                    logger.info(f"AcquisitionWorker {camera_id}: first frame published; session RUNNING")
+            elif not published_any:
+                # Start-up phase: tolerate transient failed grabs until the
+                # first-frame deadline, then surface a first-frame timeout so the
+                # session does not hang waiting for a stream that never starts
+                # (Req 3.10, 3.11). The slot has nothing to retain yet.
+                if self._time() - start >= first_frame_timeout_s:
+                    self.session.state = SessionState.ERROR
+                    self.error = (
+                        f"camera {camera_id} produced no frame within "
+                        f"{first_frame_timeout_s:g}s of stream start"
+                    )
+                    self.stop_reason = WorkerStopReason.FIRST_FRAME_TIMEOUT
+                    logger.error(f"AcquisitionWorker {camera_id}: {self.error}")
+                    return self.stop_reason
+                # Otherwise keep trying; do NOT publish (nothing to overwrite).
+            else:
+                # Established stream lost a frame: mark disconnected and stop. The
+                # last good frame stays in the slot because publish was not called
+                # (Req 2.7); the broadcaster releases the claim on this ERROR
+                # transition (Req 7.x cascade).
+                self.session.state = SessionState.ERROR
+                self.error = f"camera {camera_id} disconnected: failed to acquire a frame"
+                self.stop_reason = WorkerStopReason.DISCONNECTED
+                logger.error(f"AcquisitionWorker {camera_id}: {self.error}")
+                return self.stop_reason
+
+            # Rate ceiling: sleep only the time not already spent this iteration,
+            # so we never exceed min_refresh_fps but never add delay below the
+            # device's own cadence (Req 4.3, 4.4).
+            if target_interval > 0.0:
+                elapsed = self._time() - iter_start
+                remaining = target_interval - elapsed
+                if remaining > 0.0:
+                    self._sleep(remaining)
+
+        # Clean stop requested via the stop event.
+        self.stop_reason = WorkerStopReason.STOPPED
+        logger.info(f"AcquisitionWorker {camera_id}: stop requested; loop exited cleanly")
+        return self.stop_reason
+
+    # --- helpers ----------------------------------------------------------
+
+    def _target_interval(self) -> float:
+        """Minimum seconds per loop iteration implied by the refresh ceiling.
+
+        Returns ``1 / min_refresh_fps`` (the rate ceiling) or ``0.0`` when no
+        positive ceiling is configured, in which case the worker grabs as fast as
+        the device delivers.
+        """
+        fps = float(getattr(self.stream_config, "min_refresh_fps", 0.0) or 0.0)
+        if fps <= 0.0:
+            return 0.0
+        return 1.0 / fps
+
+    def _safe_grab(self, backend, frame_timeout_ms: int, camera_id: str):
+        """Grab one frame, treating an exception as a failed grab (``None``).
+
+        The real backends already convert acquisition failures into ``None``; a
+        raised exception is logged and treated identically so a misbehaving
+        backend cannot crash the worker thread — it is handled by the same
+        disconnect / first-frame-timeout path as a ``None`` result.
+        """
+        try:
+            return backend.grab(frame_timeout_ms)
+        except Exception as e:  # pragma: no cover - defensive; mocks may raise
+            logger.error(f"AcquisitionWorker {camera_id}: grab raised {e!r}; treating as failed grab")
+            return None

--- a/src/frontend/src/api/StreamAPI.ts
+++ b/src/frontend/src/api/StreamAPI.ts
@@ -1,0 +1,270 @@
+/*
+ *
+ * Copyright 2025 Amazon Web Services, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Client for the broadcast-model live-preview stream API
+ * (`/streams/{camera_id}/...`). These are thin wrappers over the backend
+ * endpoints in `src/backend/endpoints/streams.py`: a viewer subscribes to a
+ * camera (start-on-first-viewer), polls the frame endpoint (the GET doubles as
+ * a heartbeat), and unsubscribes on teardown (stop-on-last-viewer).
+ */
+import axios from "axios";
+import { ImageSourceConfiguration } from "components/image-source/types";
+import { APIList } from "config/Interface";
+
+/** Fill the `{camera_id}` template in an APIList stream URL. */
+function streamUrl(template: string, cameraId: string): string {
+  return template.replace("{camera_id}", encodeURIComponent(cameraId));
+}
+
+/**
+ * Optional config forwarded verbatim to the broadcaster on subscribe. It is
+ * only used when starting a brand-new session; an existing session reuses its
+ * claim and ignores the config.
+ */
+export interface StreamSubscribeConfig {
+  type?: string;
+  imageSourceConfiguration?: ImageSourceConfiguration;
+  [key: string]: unknown;
+}
+
+/** Accepted-subscription payload: the server-issued viewer id + viewer count. */
+export interface SubscribeStreamResponse {
+  viewerId: string;
+  viewerCount: number;
+}
+
+/**
+ * Frame freshness/availability as exposed to the UI. `ok`/`stale` carry a
+ * decoded object URL; the remaining states carry no image and let the consumer
+ * render appropriate feedback (handled by task 11.2).
+ *
+ * - `ok` / `stale`     — frame served (200); `stale` flags an aged frame.
+ * - `no_frame`         — session up, nothing published yet (204).
+ * - `disconnected`     — camera dropped / no active session (503).
+ * - `limit`            — subscribe rejected, viewer limit reached (429).
+ * - `unavailable`      — subscribe rejected, camera unavailable (503).
+ * - `error`            — any other/unexpected failure.
+ */
+export type StreamFrameStatus =
+  | "ok"
+  | "stale"
+  | "no_frame"
+  | "disconnected"
+  | "limit"
+  | "unavailable"
+  | "error";
+
+/**
+ * Result of a single frame poll. When `objectUrl` is set the caller owns it and
+ * must `URL.revokeObjectURL` it once the image is no longer displayed.
+ */
+export interface StreamFrameResult {
+  status: StreamFrameStatus;
+  /** Object URL for the decoded frame bytes, or null when no image is available. */
+  objectUrl: string | null;
+  /** Monotonic per-session sequence number, when provided by the backend. */
+  seq?: number;
+  width?: number;
+  height?: number;
+  /** Epoch seconds when the frame was grabbed, when provided by the backend. */
+  acquiredAt?: number;
+  /** Human-readable detail for non-image states (e.g. disconnect reason). */
+  message?: string;
+}
+
+export interface UnsubscribeStreamResponse {
+  viewerCount: number;
+}
+
+/**
+ * Register a new viewer for a camera, starting the session on the first
+ * subscriber. Rejections surface as thrown errors via axios:
+ *   - 429 -> viewer limit reached
+ *   - 503 -> camera unavailable
+ * Callers can inspect `error.response?.status` to distinguish them.
+ */
+export async function subscribeStream(
+  cameraId: string,
+  config?: StreamSubscribeConfig,
+): Promise<SubscribeStreamResponse> {
+  const endpoint = streamUrl(APIList.streamSubscribeAPI, cameraId);
+  const { data } = await axios.post<SubscribeStreamResponse>(endpoint, {
+    config: config ?? null,
+  });
+  return data;
+}
+
+/** Map the backend `X-Frame-Status` header to the UI status enum. */
+function normalizeFrameStatus(header: string | undefined): StreamFrameStatus {
+  const value = (header ?? "").toLowerCase();
+  if (value === "ok" || value === "stale" || value === "no_frame") {
+    return value;
+  }
+  return "ok";
+}
+
+function toNumber(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Fetch the latest frame for a viewer. The GET doubles as the viewer's
+ * heartbeat on the backend, so polling this keeps the subscription alive.
+ *
+ * Distinct outcomes are encoded in {@link StreamFrameResult.status}:
+ *   - 200 -> `ok` / `stale` (per the `X-Frame-Status` header) with an object URL
+ *   - 204 -> `no_frame` (session up, nothing published yet)
+ *   - 503 -> `disconnected`
+ *   - anything else -> `error`
+ *
+ * The frame bytes are read as an ArrayBuffer and converted to a Blob object URL
+ * suitable for an `<img>` element. The caller is responsible for revoking the
+ * returned object URL to avoid leaks.
+ */
+export async function getStreamFrame(
+  cameraId: string,
+  viewerId: string,
+): Promise<StreamFrameResult> {
+  const endpoint = streamUrl(APIList.streamFrameAPI, cameraId);
+  try {
+    const response = await axios.get<ArrayBuffer>(endpoint, {
+      params: { viewerId },
+      responseType: "arraybuffer",
+      // Treat 2xx and 204 as resolved; 4xx/5xx fall through to the catch so we
+      // can classify disconnects vs. unexpected errors.
+      validateStatus: (status) => status >= 200 && status < 300,
+    });
+
+    if (response.status === 204) {
+      return { status: "no_frame", objectUrl: null };
+    }
+
+    const headers = response.headers ?? {};
+    const status = normalizeFrameStatus(headers["x-frame-status"]);
+    const contentType =
+      (headers["content-type"] as string | undefined) ??
+      "application/octet-stream";
+    const blob = new Blob([response.data], { type: contentType });
+    const objectUrl = URL.createObjectURL(blob);
+
+    return {
+      status,
+      objectUrl,
+      seq: toNumber(headers["x-frame-seq"]),
+      width: toNumber(headers["x-frame-width"]),
+      height: toNumber(headers["x-frame-height"]),
+      acquiredAt: toNumber(headers["x-frame-acquired-at"]),
+    };
+  } catch (error: any) {
+    const httpStatus = error?.response?.status;
+    if (httpStatus === 503) {
+      return {
+        status: "disconnected",
+        objectUrl: null,
+        message: extractErrorMessage(error),
+      };
+    }
+    return {
+      status: "error",
+      objectUrl: null,
+      message: extractErrorMessage(error),
+    };
+  }
+}
+
+/**
+ * Best-effort decode of a FastAPI error body that arrived as an ArrayBuffer
+ * (because the request used `responseType: 'arraybuffer'`).
+ */
+function extractErrorMessage(error: any): string | undefined {
+  const data = error?.response?.data;
+  if (!data) {
+    return error?.message;
+  }
+  try {
+    const text =
+      data instanceof ArrayBuffer
+        ? new TextDecoder().decode(new Uint8Array(data))
+        : typeof data === "string"
+          ? data
+          : JSON.stringify(data);
+    try {
+      const parsed = JSON.parse(text);
+      return parsed?.detail ?? parsed?.message ?? text;
+    } catch {
+      return text;
+    }
+  } catch {
+    return error?.message;
+  }
+}
+
+/**
+ * Explicit keep-alive for a viewer. Resolves to `true` when the viewer was
+ * refreshed and `false` when the backend reports the viewer is unknown/expired
+ * (404), signalling the caller to re-subscribe.
+ */
+export async function heartbeatStream(
+  cameraId: string,
+  viewerId: string,
+): Promise<boolean> {
+  const endpoint = streamUrl(APIList.streamHeartbeatAPI, cameraId);
+  try {
+    await axios.post(endpoint, { viewerId });
+    return true;
+  } catch (error: any) {
+    if (error?.response?.status === 404) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Deregister a viewer; the backend stops the session if it was the last viewer.
+ * Idempotent and always safe to call on teardown.
+ */
+export async function unsubscribeStream(
+  cameraId: string,
+  viewerId: string,
+): Promise<UnsubscribeStreamResponse> {
+  const endpoint = streamUrl(APIList.streamUnsubscribeAPI, cameraId);
+  const { data } = await axios.post<UnsubscribeStreamResponse>(endpoint, {
+    viewerId,
+  });
+  return data;
+}
+
+/**
+ * Build the unsubscribe URL (with the viewer id as a query parameter) for use
+ * with `navigator.sendBeacon` on `pagehide` / `beforeunload`. `sendBeacon`
+ * cannot set a JSON body reliably, so the viewer id is passed as a query param,
+ * which the backend's unsubscribe endpoint also accepts.
+ */
+export function buildUnsubscribeBeaconUrl(
+  cameraId: string,
+  viewerId: string,
+): string {
+  const endpoint = streamUrl(APIList.streamUnsubscribeAPI, cameraId);
+  return `${endpoint}?viewerId=${encodeURIComponent(viewerId)}`;
+}

--- a/src/frontend/src/components/live-result/StreamPreview.tsx
+++ b/src/frontend/src/components/live-result/StreamPreview.tsx
@@ -1,0 +1,217 @@
+/*
+ *
+ * Copyright 2025 Amazon Web Services, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Presentational live-preview for the broadcast-model stream
+ * (concurrent-camera-stream-viewing, task 11.2).
+ *
+ * It drives the lifecycle via {@link useCameraStream} (task 11.1) and renders
+ * clear, distinct feedback for each state instead of leaving a frozen image on
+ * screen:
+ *
+ *  Subscription lifecycle (subscriptionStatus):
+ *   - "subscribing" -> loading placeholder ("Connecting to camera").
+ *   - "limit"       -> "maximum viewers reached" warning (Req 1.6).
+ *   - "unavailable" -> "camera unavailable" error (Req 1.7).
+ *   - "error"       -> generic error with the server message.
+ *
+ *  Per-frame status (frameStatus, once subscribed):
+ *   - "ok"           -> show the latest frame.
+ *   - "stale"        -> show the last frame plus a "reconnecting" indicator
+ *                       (Req 4.7).
+ *   - "no_frame"     -> loading placeholder ("Waiting for first frame")
+ *                       (Req 2.6).
+ *   - "disconnected" -> "camera disconnected" error and NO frame (Req 7.5).
+ *   - "error"        -> generic error with the server message.
+ *
+ * The component is self-contained and reusable: pass a `cameraId` (plus an
+ * optional `enabled`/`config`) and it manages everything else.
+ */
+import { ReactNode, useMemo } from "react";
+import {
+  Alert,
+  Box,
+  SpaceBetween,
+  Spinner,
+  StatusIndicator,
+} from "@cloudscape-design/components";
+import InteractableImage from "components/live-result/InteractableImage";
+import ImagePreviewError from "components/live-result/ImagePreviewError";
+import ImagePlaceholder from "components/common/ImagePlaceholder";
+import { fullWidthStyle } from "components/live-result/styles";
+import { StreamSubscribeConfig } from "api/StreamAPI";
+import useCameraStream from "components/live-result/useCameraStream";
+
+interface StreamPreviewProps {
+  /** Camera/stream id to subscribe to. */
+  cameraId: string;
+  /** When false, the hook stays idle (no subscribe / poll). Defaults to true. */
+  enabled?: boolean;
+  /** Optional config forwarded to the broadcaster when starting a new session. */
+  config?: StreamSubscribeConfig;
+  /** Poll interval in ms; defaults to the hook's PREVIEW_REFRESH_INTERVAL_MS. */
+  refreshIntervalMs?: number;
+  /** Optional alt text for the rendered frame. */
+  alt?: string;
+  /** Optional extra actions rendered alongside the image controls. */
+  extraActions?: JSX.Element;
+}
+
+const SUBSCRIBE_LIMIT_MESSAGE =
+  "Maximum viewers reached for this camera. Close another live view and try again.";
+const SUBSCRIBE_UNAVAILABLE_MESSAGE =
+  "Camera unavailable. It could not be opened for streaming.";
+const DISCONNECTED_MESSAGE =
+  "Camera disconnected. The live stream has stopped.";
+
+/** Wrap placeholder/feedback content so it occupies the preview area. */
+function PreviewFeedback({ content }: { content: ReactNode }): JSX.Element {
+  return (
+    <div className={fullWidthStyle}>
+      <ImagePlaceholder placement="center" content={content} />
+    </div>
+  );
+}
+
+function LoadingFeedback({ label }: { label: string }): JSX.Element {
+  return (
+    <PreviewFeedback
+      content={
+        <SpaceBetween direction="vertical" size="m" alignItems="center">
+          <Spinner size="big" />
+          <p>{label}</p>
+        </SpaceBetween>
+      }
+    />
+  );
+}
+
+export default function StreamPreview({
+  cameraId,
+  enabled = true,
+  config,
+  refreshIntervalMs,
+  alt,
+  extraActions,
+}: StreamPreviewProps): JSX.Element {
+  const { frameUrl, frameStatus, subscriptionStatus, message } =
+    useCameraStream({ cameraId, enabled, config, refreshIntervalMs });
+
+  // The frame element is reused for "ok" and "stale" so a transient stale
+  // window does not unmount/flash the last good image.
+  const frame = useMemo(() => {
+    if (!frameUrl) {
+      return null;
+    }
+    return (
+      <InteractableImage
+        imageSrc={frameUrl}
+        alt={alt ?? "Live camera frame"}
+        extraActions={extraActions}
+      />
+    );
+  }, [frameUrl, alt, extraActions]);
+
+  // 1) Subscription-level outcomes take precedence: until we are subscribed
+  //    there is no meaningful per-frame status to show.
+  switch (subscriptionStatus) {
+    case "idle":
+      return (
+        <PreviewFeedback
+          content={
+            <Box variant="p" color="text-status-inactive">
+              Live preview is not active.
+            </Box>
+          }
+        />
+      );
+    case "subscribing":
+      return <LoadingFeedback label="Connecting to camera" />;
+    case "limit":
+      return (
+        <PreviewFeedback
+          content={
+            <Alert type="warning" header="Maximum viewers reached">
+              {message ?? SUBSCRIBE_LIMIT_MESSAGE}
+            </Alert>
+          }
+        />
+      );
+    case "unavailable":
+      return (
+        <PreviewFeedback
+          content={
+            <Alert type="error" header="Camera unavailable">
+              {message ?? SUBSCRIBE_UNAVAILABLE_MESSAGE}
+            </Alert>
+          }
+        />
+      );
+    case "error":
+      return (
+        <PreviewFeedback content={<ImagePreviewError errorMsg={message} />} />
+      );
+    case "subscribed":
+    default:
+      break;
+  }
+
+  // 2) Subscribed: render based on the latest per-frame status.
+  switch (frameStatus) {
+    case "ok":
+      // Fresh frame available.
+      return frame ?? <LoadingFeedback label="Waiting for first frame" />;
+
+    case "stale":
+      // Keep showing the last frame, but make staleness explicit.
+      if (frame) {
+        return (
+          <SpaceBetween direction="vertical" size="xs">
+            <StatusIndicator type="loading">
+              Stream is stale, reconnecting…
+            </StatusIndicator>
+            {frame}
+          </SpaceBetween>
+        );
+      }
+      return <LoadingFeedback label="Waiting for first frame" />;
+
+    case "disconnected":
+      // Hard failure: never keep a frozen frame on screen (Req 7.5).
+      return (
+        <PreviewFeedback
+          content={
+            <Alert type="error" header="Camera disconnected">
+              {message ?? DISCONNECTED_MESSAGE}
+            </Alert>
+          }
+        />
+      );
+
+    case "error":
+      return (
+        <PreviewFeedback content={<ImagePreviewError errorMsg={message} />} />
+      );
+
+    case "no_frame":
+    case null:
+    default:
+      // Subscribed but nothing published yet (Req 2.6).
+      return <LoadingFeedback label="Waiting for first frame" />;
+  }
+}

--- a/src/frontend/src/components/live-result/useCameraStream.ts
+++ b/src/frontend/src/components/live-result/useCameraStream.ts
@@ -1,0 +1,261 @@
+/*
+ *
+ * Copyright 2025 Amazon Web Services, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * React hook that drives the broadcast-model live-preview lifecycle for one
+ * camera (concurrent-camera-stream-viewing, task 11.1):
+ *
+ *  - subscribes on mount and stores the server-issued viewer id,
+ *  - polls the frame endpoint on {@link PREVIEW_REFRESH_INTERVAL_MS} (the GET
+ *    doubles as the viewer's heartbeat, so no separate heartbeat call is needed
+ *    while polling is active),
+ *  - exposes the latest frame object URL plus a status the UI can render,
+ *  - unsubscribes on unmount, and
+ *  - registers a `navigator.sendBeacon` unsubscribe on `pagehide` /
+ *    `beforeunload` so an abandoned tab releases the device promptly.
+ *
+ * Object URLs are revoked as they are replaced and on teardown to avoid leaks.
+ *
+ * NOTE: This hook only *exposes* the frame/subscription status. Rendering the
+ * rich frame-state and rejection feedback is task 11.2.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { PREVIEW_REFRESH_INTERVAL_MS } from "components/image-settings/constants";
+import {
+  buildUnsubscribeBeaconUrl,
+  getStreamFrame,
+  StreamFrameStatus,
+  StreamSubscribeConfig,
+  subscribeStream,
+  unsubscribeStream,
+} from "api/StreamAPI";
+
+/**
+ * Subscription lifecycle status, distinct from the per-frame status so the UI
+ * can tell "still subscribing" / "rejected" apart from "subscribed but no
+ * frame yet".
+ */
+export type StreamSubscriptionStatus =
+  | "idle" // not enabled / no camera
+  | "subscribing" // subscribe in flight
+  | "subscribed" // active viewer, polling frames
+  | "limit" // subscribe rejected: viewer limit reached (429)
+  | "unavailable" // subscribe rejected: camera unavailable (503)
+  | "error"; // unexpected subscribe failure
+
+export interface UseCameraStreamOptions {
+  /** Camera/stream id to subscribe to. */
+  cameraId: string;
+  /** When false, the hook stays idle (no subscribe / poll). Defaults to true. */
+  enabled?: boolean;
+  /** Optional config forwarded to the broadcaster when starting a new session. */
+  config?: StreamSubscribeConfig;
+  /** Poll interval in ms; defaults to PREVIEW_REFRESH_INTERVAL_MS. */
+  refreshIntervalMs?: number;
+}
+
+export interface UseCameraStreamResult {
+  /** Object URL for the latest decoded frame, or null when none is available. */
+  frameUrl: string | null;
+  /** Latest per-frame status (ok/stale/no_frame/disconnected/error). */
+  frameStatus: StreamFrameStatus | null;
+  /** Subscription lifecycle status. */
+  subscriptionStatus: StreamSubscriptionStatus;
+  /** Server-issued viewer id while subscribed, else null. */
+  viewerId: string | null;
+  /** Current active viewer count reported by the backend (best-effort). */
+  viewerCount: number | null;
+  /** Human-readable detail for rejected/disconnected/error states. */
+  message?: string;
+}
+
+export default function useCameraStream({
+  cameraId,
+  enabled = true,
+  config,
+  refreshIntervalMs = PREVIEW_REFRESH_INTERVAL_MS,
+}: UseCameraStreamOptions): UseCameraStreamResult {
+  const [frameUrl, setFrameUrl] = useState<string | null>(null);
+  const [frameStatus, setFrameStatus] = useState<StreamFrameStatus | null>(null);
+  const [subscriptionStatus, setSubscriptionStatus] =
+    useState<StreamSubscriptionStatus>("idle");
+  const [viewerId, setViewerId] = useState<string | null>(null);
+  const [viewerCount, setViewerCount] = useState<number | null>(null);
+  const [message, setMessage] = useState<string | undefined>(undefined);
+
+  // Refs let the polling loop and teardown read the latest values without
+  // re-binding the interval or the unload listener on every render.
+  const viewerIdRef = useRef<string | null>(null);
+  const cameraIdRef = useRef<string>(cameraId);
+  const currentObjectUrlRef = useRef<string | null>(null);
+  const isMountedRef = useRef<boolean>(true);
+
+  cameraIdRef.current = cameraId;
+
+  // Replace the displayed frame, revoking the previously displayed object URL.
+  const swapFrameUrl = useCallback((nextUrl: string | null) => {
+    const previous = currentObjectUrlRef.current;
+    if (previous && previous !== nextUrl) {
+      URL.revokeObjectURL(previous);
+    }
+    currentObjectUrlRef.current = nextUrl;
+    setFrameUrl(nextUrl);
+  }, []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    if (!enabled || !cameraId) {
+      setSubscriptionStatus("idle");
+      return;
+    }
+
+    let pollTimer: ReturnType<typeof setInterval> | null = null;
+    let cancelled = false;
+
+    const poll = async (): Promise<void> => {
+      const activeViewerId = viewerIdRef.current;
+      if (!activeViewerId) {
+        return;
+      }
+      const result = await getStreamFrame(cameraIdRef.current, activeViewerId);
+      if (cancelled || !isMountedRef.current) {
+        // Component went away mid-flight; drop the freshly created object URL.
+        if (result.objectUrl) {
+          URL.revokeObjectURL(result.objectUrl);
+        }
+        return;
+      }
+      setFrameStatus(result.status);
+      setMessage(result.message);
+      if (result.objectUrl) {
+        swapFrameUrl(result.objectUrl);
+      }
+      // For no_frame/disconnected/error we keep the last good frame URL (if any)
+      // so 11.2 can decide how to present staleness vs. a hard failure.
+    };
+
+    const startPolling = (): void => {
+      // Kick off an immediate poll, then settle into the interval cadence.
+      void poll();
+      pollTimer = setInterval(() => void poll(), refreshIntervalMs);
+    };
+
+    const subscribe = async (): Promise<void> => {
+      setSubscriptionStatus("subscribing");
+      setMessage(undefined);
+      try {
+        const { viewerId: newViewerId, viewerCount: count } =
+          await subscribeStream(cameraId, config);
+        if (cancelled || !isMountedRef.current) {
+          // Subscribed after unmount: immediately release the viewer slot.
+          void unsubscribeStream(cameraId, newViewerId).catch(() => undefined);
+          return;
+        }
+        viewerIdRef.current = newViewerId;
+        setViewerId(newViewerId);
+        setViewerCount(count);
+        setSubscriptionStatus("subscribed");
+        startPolling();
+      } catch (error: any) {
+        if (cancelled || !isMountedRef.current) {
+          return;
+        }
+        const httpStatus = error?.response?.status;
+        const detail =
+          error?.response?.data?.detail ??
+          error?.response?.data?.message ??
+          error?.message;
+        if (httpStatus === 429) {
+          setSubscriptionStatus("limit");
+        } else if (httpStatus === 503) {
+          setSubscriptionStatus("unavailable");
+        } else {
+          setSubscriptionStatus("error");
+        }
+        setMessage(detail);
+      }
+    };
+
+    void subscribe();
+
+    return () => {
+      cancelled = true;
+      if (pollTimer) {
+        clearInterval(pollTimer);
+      }
+      const activeViewerId = viewerIdRef.current;
+      const activeCameraId = cameraIdRef.current;
+      if (activeViewerId) {
+        // Best-effort prompt teardown; the backend's stale sweep is the backstop.
+        void unsubscribeStream(activeCameraId, activeViewerId).catch(
+          () => undefined,
+        );
+      }
+      viewerIdRef.current = null;
+      const lastUrl = currentObjectUrlRef.current;
+      if (lastUrl) {
+        URL.revokeObjectURL(lastUrl);
+        currentObjectUrlRef.current = null;
+      }
+    };
+    // Re-subscribe when the target camera, enablement, or cadence changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cameraId, enabled, refreshIntervalMs]);
+
+  // Release the viewer slot promptly when the tab is closed/hidden. `sendBeacon`
+  // survives unload where a normal async request would be cancelled.
+  useEffect(() => {
+    if (!enabled || !cameraId) {
+      return;
+    }
+
+    const releaseOnUnload = (): void => {
+      const activeViewerId = viewerIdRef.current;
+      if (!activeViewerId) {
+        return;
+      }
+      const url = buildUnsubscribeBeaconUrl(cameraIdRef.current, activeViewerId);
+      if (typeof navigator !== "undefined" && navigator.sendBeacon) {
+        navigator.sendBeacon(url);
+      }
+    };
+
+    window.addEventListener("pagehide", releaseOnUnload);
+    window.addEventListener("beforeunload", releaseOnUnload);
+    return () => {
+      window.removeEventListener("pagehide", releaseOnUnload);
+      window.removeEventListener("beforeunload", releaseOnUnload);
+    };
+  }, [cameraId, enabled]);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  return {
+    frameUrl,
+    frameStatus,
+    subscriptionStatus,
+    viewerId,
+    viewerCount,
+    message,
+  };
+}

--- a/src/frontend/src/config/Interface.tsx
+++ b/src/frontend/src/config/Interface.tsx
@@ -64,6 +64,14 @@ export const APIList = {
   executePipelineAPI: `${Connection.ENDPOINT}/cameras/{camera_id}/execute-pipeline`,
   listStreamsAPI: `${Connection.ENDPOINT}/streams`,
   getStreamImageAPI: `${Connection.ENDPOINT}/streams/{stream_id}/images?maxResults=1`,
+  // Broadcast-model live-preview stream lifecycle (concurrent-camera-stream-viewing).
+  // Viewers subscribe on mount, poll the frame endpoint (which doubles as a heartbeat),
+  // and unsubscribe on unmount / tab close.
+  streamSubscribeAPI: `${Connection.ENDPOINT}/streams/{camera_id}/subscribe`,
+  streamFrameAPI: `${Connection.ENDPOINT}/streams/{camera_id}/frame`,
+  streamHeartbeatAPI: `${Connection.ENDPOINT}/streams/{camera_id}/heartbeat`,
+  streamUnsubscribeAPI: `${Connection.ENDPOINT}/streams/{camera_id}/unsubscribe`,
+  streamViewersAPI: `${Connection.ENDPOINT}/streams/{camera_id}/viewers`,
   capturedImageAPI: `${Connection.ENDPOINT}/captured-images`,
   imageSourcesAPI: `${Connection.ENDPOINT}/image-sources`,
   featureConfigurations: `${Connection.ENDPOINT}/feature-configurations`,

--- a/test/backend-test/api-endpoints/test_streams_api.py
+++ b/test/backend-test/api-endpoints/test_streams_api.py
@@ -1,0 +1,314 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Endpoint serialization / status-code tests for the ``/streams/...`` API (task 9.3).
+
+These tests pin the HTTP contract of ``src/backend/endpoints/streams.py`` — the thin
+client layer over the :class:`StreamBroadcaster`. They assert ONLY the endpoint's
+translation of broadcaster domain results into status codes / response bodies / headers;
+the broadcaster's own invariants (single claim, lifecycle, viewer-limit enforcement,
+disconnection cascade) are covered by the property tests under
+``test/backend-test/utils/streaming``.
+
+Strategy: the endpoints call :func:`utils.streaming.broadcaster.get_broadcaster`, imported
+into ``endpoints.streams``. Each test patches ``endpoints.streams.get_broadcaster`` to
+return a small stub broadcaster whose methods return crafted
+:class:`SubscribeResult` / :class:`FrameResult` values or raise
+``NoActiveSessionError`` / ``SettingsApplyError`` so the endpoint mapping is exercised in
+isolation, with no device / threading dependency.
+
+Mapping asserted (from ``streams.py``):
+
+* subscribe accepted        -> 200 ``{viewerId, viewerCount}``
+* subscribe viewer_limit    -> 429
+* subscribe camera_unavailable -> 503
+* frame OK                  -> 200 bytes + ``X-Frame-Status: ok``      (Req 4.6)
+* frame STALE               -> 200 bytes + ``X-Frame-Status: stale``   (Req 4.7)
+* frame NO_FRAME            -> 204                                     (Req 2.6)
+* frame DISCONNECTED        -> 503                                     (Req 7.5)
+* heartbeat refreshed       -> 200 / unknown -> 404
+* unsubscribe               -> 200 ``{viewerCount}``
+* viewers                   -> 200 ``{viewerCount}``
+* settings accepted         -> 200 dict
+* settings NoActiveSession  -> 409
+* settings SettingsApplyError -> 422 (names the failed control)
+* viewer-limit boundary     -> 8th subscribe 200, 9th subscribe 429   (Req 1.3, 1.6)
+
+_Requirements: 1.3, 1.6, 1.7, 2.6, 4.7, 7.5_
+"""
+from unittest.mock import patch
+
+from local_server_base_test_case import LocalServerBaseTestCase
+from fastapi.testclient import TestClient
+
+from utils.streaming.models import (
+    FrameResult,
+    FrameStatus,
+    LatestFrame,
+    SubscribeResult,
+)
+from utils.streaming.broadcaster import NoActiveSessionError, SettingsApplyError
+
+TEST_CAMERA_ID = "Fake_1"
+TEST_VIEWER_ID = "viewer-abc"
+
+
+def _make_frame(seq: int = 7, data: bytes = b"\x01\x02\x03\x04") -> LatestFrame:
+    """Build a deterministic LatestFrame for frame-endpoint body/header assertions."""
+    return LatestFrame(data=data, width=4, height=2, seq=seq, acquired_at=123.5)
+
+
+class _StubBroadcaster:
+    """Configurable stand-in for :class:`StreamBroadcaster` used by the endpoint tests.
+
+    Each attribute holds the value the corresponding endpoint should translate; tests
+    set the one(s) they care about. ``apply_settings`` raises ``apply_settings_exc`` when
+    set so the 409 / 422 error mappings can be exercised.
+    """
+
+    def __init__(self):
+        self.subscribe_result = SubscribeResult(
+            viewer_id=TEST_VIEWER_ID, accepted=True, reason=None, viewer_count=1
+        )
+        self.frame_result = FrameResult(status=FrameStatus.NO_FRAME, frame=None)
+        self.heartbeat_return = True
+        self.viewer_count_return = 0
+        self.apply_settings_return = {}
+        self.apply_settings_exc = None
+        self.unsubscribe_calls = []
+
+    def subscribe(self, camera_id, config=None):
+        return self.subscribe_result
+
+    def get_frame(self, camera_id, viewer_id):
+        return self.frame_result
+
+    def heartbeat(self, camera_id, viewer_id):
+        return self.heartbeat_return
+
+    def unsubscribe(self, camera_id, viewer_id):
+        self.unsubscribe_calls.append((camera_id, viewer_id))
+
+    def viewer_count(self, camera_id):
+        return self.viewer_count_return
+
+    def apply_settings(self, camera_id, features):
+        if self.apply_settings_exc is not None:
+            raise self.apply_settings_exc
+        return self.apply_settings_return
+
+
+class _ViewerLimitBroadcaster:
+    """Stateful stub that accepts subscribes up to ``max_viewers`` then rejects.
+
+    Reproduces the broadcaster's viewer-limit contract (Req 1.3, 1.6) at the endpoint
+    boundary so the test can assert the endpoint maps the Nth-accepted subscribe to 200
+    and the (max+1)th rejected subscribe to 429.
+    """
+
+    def __init__(self, max_viewers=8):
+        self.max_viewers = max_viewers
+        self.count = 0
+
+    def subscribe(self, camera_id, config=None):
+        if self.count >= self.max_viewers:
+            return SubscribeResult(
+                viewer_id=None,
+                accepted=False,
+                reason="viewer_limit",
+                viewer_count=self.count,
+            )
+        self.count += 1
+        return SubscribeResult(
+            viewer_id=f"viewer-{self.count}",
+            accepted=True,
+            reason=None,
+            viewer_count=self.count,
+        )
+
+
+class TestStreamsApi(LocalServerBaseTestCase):
+    def setUp(self):
+        super().setUp()
+        from app import app
+
+        # raise_server_exceptions=False routes errors through the app's exception
+        # handlers (matching the other api-endpoints tests) rather than re-raising.
+        self.app = app
+        self.client = TestClient(app, raise_server_exceptions=False)
+        self.stub = _StubBroadcaster()
+        self._patcher = patch("endpoints.streams.get_broadcaster", return_value=self.stub)
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        super().tearDown()
+
+    # --- subscribe -------------------------------------------------------
+
+    def test_subscribe_accepted_returns_200_with_viewer_id_and_count(self):
+        self.stub.subscribe_result = SubscribeResult(
+            viewer_id=TEST_VIEWER_ID, accepted=True, reason=None, viewer_count=3
+        )
+        response = self.client.post(f"/streams/{TEST_CAMERA_ID}/subscribe", json={})
+        assert response.status_code == 200, f"status_code: {response.status_code}"
+        body = response.json()
+        assert body["viewerId"] == TEST_VIEWER_ID
+        assert body["viewerCount"] == 3
+
+    def test_subscribe_viewer_limit_returns_429(self):
+        self.stub.subscribe_result = SubscribeResult(
+            viewer_id=None, accepted=False, reason="viewer_limit", viewer_count=8
+        )
+        response = self.client.post(f"/streams/{TEST_CAMERA_ID}/subscribe", json={})
+        assert response.status_code == 429, f"status_code: {response.status_code}"
+
+    def test_subscribe_camera_unavailable_returns_503(self):
+        self.stub.subscribe_result = SubscribeResult(
+            viewer_id=None, accepted=False, reason="camera_unavailable", viewer_count=0
+        )
+        response = self.client.post(f"/streams/{TEST_CAMERA_ID}/subscribe", json={})
+        assert response.status_code == 503, f"status_code: {response.status_code}"
+
+    def test_subscribe_viewer_limit_boundary_8th_accepted_9th_rejected(self):
+        """8 subscribes accepted (200), the 9th rejected with 429 (Req 1.3, 1.6)."""
+        limit_stub = _ViewerLimitBroadcaster(max_viewers=8)
+        with patch("endpoints.streams.get_broadcaster", return_value=limit_stub):
+            for i in range(1, 9):
+                response = self.client.post(
+                    f"/streams/{TEST_CAMERA_ID}/subscribe", json={}
+                )
+                assert response.status_code == 200, (
+                    f"subscribe #{i} expected 200, got {response.status_code}"
+                )
+                assert response.json()["viewerCount"] == i
+
+            # The 9th subscribe crosses the limit and must be rejected.
+            ninth = self.client.post(f"/streams/{TEST_CAMERA_ID}/subscribe", json={})
+            assert ninth.status_code == 429, (
+                f"9th subscribe expected 429, got {ninth.status_code}"
+            )
+
+    # --- frame -----------------------------------------------------------
+
+    def test_frame_ok_returns_200_bytes_with_ok_header(self):
+        frame = _make_frame(seq=11, data=b"\xaa\xbb\xcc")
+        self.stub.frame_result = FrameResult(status=FrameStatus.OK, frame=frame)
+        response = self.client.get(
+            f"/streams/{TEST_CAMERA_ID}/frame", params={"viewerId": TEST_VIEWER_ID}
+        )
+        assert response.status_code == 200, f"status_code: {response.status_code}"
+        assert response.content == b"\xaa\xbb\xcc"
+        assert response.headers["X-Frame-Status"] == "ok"
+        assert response.headers["X-Frame-Seq"] == "11"
+        assert response.headers["X-Frame-Width"] == "4"
+        assert response.headers["X-Frame-Height"] == "2"
+
+    def test_frame_stale_returns_200_bytes_with_stale_header(self):
+        frame = _make_frame(seq=12, data=b"\x10\x20")
+        self.stub.frame_result = FrameResult(status=FrameStatus.STALE, frame=frame)
+        response = self.client.get(
+            f"/streams/{TEST_CAMERA_ID}/frame", params={"viewerId": TEST_VIEWER_ID}
+        )
+        assert response.status_code == 200, f"status_code: {response.status_code}"
+        assert response.content == b"\x10\x20"
+        assert response.headers["X-Frame-Status"] == "stale"
+
+    def test_frame_no_frame_returns_204(self):
+        self.stub.frame_result = FrameResult(status=FrameStatus.NO_FRAME, frame=None)
+        response = self.client.get(
+            f"/streams/{TEST_CAMERA_ID}/frame", params={"viewerId": TEST_VIEWER_ID}
+        )
+        assert response.status_code == 204, f"status_code: {response.status_code}"
+        assert response.content == b""
+
+    def test_frame_disconnected_returns_503(self):
+        self.stub.frame_result = FrameResult(status=FrameStatus.DISCONNECTED, frame=None)
+        response = self.client.get(
+            f"/streams/{TEST_CAMERA_ID}/frame", params={"viewerId": TEST_VIEWER_ID}
+        )
+        assert response.status_code == 503, f"status_code: {response.status_code}"
+
+    def test_frame_requires_viewer_id_query_param(self):
+        # viewerId is a required query parameter; omitting it is a 422 validation error.
+        response = self.client.get(f"/streams/{TEST_CAMERA_ID}/frame")
+        assert response.status_code == 422, f"status_code: {response.status_code}"
+
+    # --- heartbeat -------------------------------------------------------
+
+    def test_heartbeat_refreshed_returns_200(self):
+        self.stub.heartbeat_return = True
+        response = self.client.post(
+            f"/streams/{TEST_CAMERA_ID}/heartbeat", params={"viewerId": TEST_VIEWER_ID}
+        )
+        assert response.status_code == 200, f"status_code: {response.status_code}"
+        assert response.json()["refreshed"] is True
+
+    def test_heartbeat_unknown_viewer_returns_404(self):
+        self.stub.heartbeat_return = False
+        response = self.client.post(
+            f"/streams/{TEST_CAMERA_ID}/heartbeat", params={"viewerId": TEST_VIEWER_ID}
+        )
+        assert response.status_code == 404, f"status_code: {response.status_code}"
+
+    # --- unsubscribe -----------------------------------------------------
+
+    def test_unsubscribe_returns_200_with_viewer_count(self):
+        self.stub.viewer_count_return = 2
+        response = self.client.post(
+            f"/streams/{TEST_CAMERA_ID}/unsubscribe", params={"viewerId": TEST_VIEWER_ID}
+        )
+        assert response.status_code == 200, f"status_code: {response.status_code}"
+        assert response.json()["viewerCount"] == 2
+        assert (TEST_CAMERA_ID, TEST_VIEWER_ID) in self.stub.unsubscribe_calls
+
+    # --- viewers ---------------------------------------------------------
+
+    def test_viewers_returns_200_with_viewer_count(self):
+        self.stub.viewer_count_return = 5
+        response = self.client.get(f"/streams/{TEST_CAMERA_ID}/viewers")
+        assert response.status_code == 200, f"status_code: {response.status_code}"
+        assert response.json()["viewerCount"] == 5
+
+    # --- settings --------------------------------------------------------
+
+    def test_settings_accepted_returns_200_dict(self):
+        self.stub.apply_settings_return = {"gain": 10, "exposure": 4000}
+        response = self.client.post(
+            f"/streams/{TEST_CAMERA_ID}/settings", json={"gain": 10, "exposure": 4000}
+        )
+        assert response.status_code == 200, f"status_code: {response.status_code}"
+        assert response.json() == {"gain": 10, "exposure": 4000}
+
+    def test_settings_no_active_session_returns_409(self):
+        self.stub.apply_settings_exc = NoActiveSessionError(
+            f"no active stream session for camera {TEST_CAMERA_ID}"
+        )
+        response = self.client.post(
+            f"/streams/{TEST_CAMERA_ID}/settings", json={"gain": 10}
+        )
+        assert response.status_code == 409, f"status_code: {response.status_code}"
+
+    def test_settings_apply_error_returns_422_naming_control(self):
+        self.stub.apply_settings_exc = SettingsApplyError(
+            "failed to apply control(s) [gain]",
+            camera_id=TEST_CAMERA_ID,
+            control="gain",
+            retained={"gain": 5},
+        )
+        response = self.client.post(
+            f"/streams/{TEST_CAMERA_ID}/settings", json={"gain": 999}
+        )
+        assert response.status_code == 422, f"status_code: {response.status_code}"
+        # The 422 detail names the failed control so the client can surface it.
+        assert "gain" in response.json()["detail"]

--- a/test/backend-test/utils/streaming/integration/test_end_to_end_backends.py
+++ b/test/backend-test/utils/streaming/integration/test_end_to_end_backends.py
@@ -1,0 +1,269 @@
+#
+#  Copyright 2025 Amazon Web Services, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""End-to-end fake-device tests for both backends (Task 12.5).
+
+Feature: concurrent-camera-stream-viewing.
+
+These exercise the **real** broadcast stream stack — :class:`StreamBroadcaster`
++ :class:`StreamSession` + :class:`AcquisitionWorker` — driving the **real**
+``CameraBackend`` adapters end to end, with a fake/simulated device behind each
+adapter so no physical camera is required (Req 2.8):
+
+* **Aravis path** — a Fake Aravis camera. The Aravis "Fake" interface is enabled
+  (``Aravis.enable_interface("Fake")``, the same call ``camera_manager.Camera``
+  makes) and the real :class:`AravisBackend` opens / streams / grabs the fake
+  ``Fake_1`` device through the existing ``camera_manager.Camera`` acquisition
+  path.
+* **GStreamer path** — a simulated source. The real :class:`GStreamerBackend`
+  runs a ``videotestsrc``-based pipeline (supplied via its
+  ``pipeline_description`` override), so frames are produced by GStreamer's own
+  test source rather than hardware.
+
+For each backend the full lifecycle is asserted (Req 2.8 backend parity):
+
+    subscribe -> viewerId issued
+    get_frame -> eventually OK with frame bytes
+    viewer_count -> reflects the number of subscribers
+    unsubscribe (all viewers) -> session released, claim dropped
+    get_frame -> DISCONNECTED (no session)
+
+These are integration/end-to-end tests (NOT property-based tests).
+
+Environment note: the real adapters require the native ``gi`` / Aravis / Gst
+stack, which is not importable in a bare checkout. The native-dependent setup is
+guarded so the tests SKIP cleanly where the stack is absent and RUN in the
+flask-app image / on a host that has ``gi`` + Aravis + Gst. Run, for example:
+
+    PYTHONPATH=src/backend:test/backend-test/utils/streaming \\
+        python -m pytest \\
+        test/backend-test/utils/streaming/integration/test_end_to_end_backends.py \\
+        --noconftest -v
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+# The whole module is meaningless without the native ``gi`` bindings; skip the
+# entire file cleanly on a bare checkout. ``exc_type=ImportError`` also skips when
+# ``gi`` is present as a stub but its native ``_gi`` extension fails to import
+# (the bare-checkout case), instead of erroring.
+pytest.importorskip(
+    "gi",
+    reason="native gi bindings not available in this environment",
+    exc_type=ImportError,
+)
+
+# ``broadcaster`` / ``backends`` are import-safe even without the native stack
+# (their gi imports are lazy), so these top-level imports never trip the skip.
+from utils.streaming.backends import AravisBackend, GStreamerBackend  # noqa: E402
+from utils.streaming.broadcaster import StreamBroadcaster  # noqa: E402
+from utils.streaming.models import FrameStatus, StreamConfig  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Native-stack availability guards (skip cleanly when a backend can't run here)
+# --------------------------------------------------------------------------- #
+def _require_aravis():
+    """Skip unless the Aravis bindings are importable, returning the module.
+
+    Mirrors ``camera_manager`` / ``backends._load_aravis_runtime``:
+    ``gi.require_version('Aravis', '0.8')`` then import ``Aravis``. Any failure
+    (missing typelib, version mismatch) results in a clean skip rather than an
+    error, so this runs only where the GenICam stack is present.
+    """
+    try:
+        import gi
+
+        gi.require_version("Aravis", "0.8")
+        from gi.repository import Aravis
+
+        return Aravis
+    except Exception as exc:  # ValueError / ImportError / etc.
+        pytest.skip(f"Aravis stack not available: {exc}")
+
+
+def _require_gst():
+    """Skip unless the GStreamer bindings are importable, returning the module.
+
+    Mirrors ``backends._load_gstreamer_runtime``: ``gi.require_version('Gst',
+    '1.0')`` / ``GstApp`` then import. Any failure results in a clean skip.
+    """
+    try:
+        import gi
+
+        gi.require_version("Gst", "1.0")
+        gi.require_version("GstApp", "1.0")
+        from gi.repository import Gst
+
+        return Gst
+    except Exception as exc:
+        pytest.skip(f"GStreamer stack not available: {exc}")
+
+
+# --------------------------------------------------------------------------- #
+# Real-backend factories behind a fake/simulated device
+# --------------------------------------------------------------------------- #
+# A short freshness ceiling is fine: the poll loop reads frames promptly so they
+# never age past it, but the lifecycle (start/stop/claim release) is what matters.
+_CONFIG = StreamConfig(max_viewers=8, first_frame_timeout_s=10)
+
+# The Aravis "Fake" interface exposes a single fake device addressed as "Fake_1"
+# (the id used throughout the streaming test-suite and by camera_manager).
+_FAKE_ARAVIS_CAMERA = "Fake_1"
+
+# A self-contained, hardware-free GStreamer source. ``GStreamerBackend`` appends
+# ``! videoconvert ! video/x-raw,format=RGB ! appsink ...`` to this description.
+_GST_PIPELINE_DESCRIPTION = "videotestsrc is-live=true"
+
+
+def _aravis_backend_factory(camera_id, config):
+    """Build a real :class:`AravisBackend` bound to the Fake Aravis device."""
+    return AravisBackend(camera_id, image_source_config=None, stream_config=_CONFIG)
+
+
+def _gstreamer_backend_factory(camera_id, config):
+    """Build a real :class:`GStreamerBackend` driven by a simulated videotestsrc."""
+    return GStreamerBackend(
+        camera_id,
+        stream_config=_CONFIG,
+        pipeline_description=_GST_PIPELINE_DESCRIPTION,
+    )
+
+
+# Each entry: (label, camera_id, broadcaster-factory, native-stack guard).
+_BACKENDS = [
+    pytest.param(
+        "aravis", _FAKE_ARAVIS_CAMERA, _aravis_backend_factory, _require_aravis,
+        id="aravis-fake-device",
+    ),
+    pytest.param(
+        "gstreamer", "GstSim_1", _gstreamer_backend_factory, _require_gst,
+        id="gstreamer-videotestsrc",
+    ),
+]
+
+
+def _poll_until_ok(broadcaster, camera_id, viewer_id, timeout_s=12.0, interval_s=0.1):
+    """Poll ``get_frame`` until it returns OK (or a non-recoverable status).
+
+    The first frame may take a moment to flow through open -> start_stream ->
+    worker grab -> publish, so NO_FRAME is expected transiently. Returns the
+    final :class:`FrameResult` once OK is observed or the deadline passes.
+    """
+    deadline = time.monotonic() + timeout_s
+    result = broadcaster.get_frame(camera_id, viewer_id)
+    while time.monotonic() < deadline:
+        if result.status == FrameStatus.OK:
+            return result
+        if result.status == FrameStatus.DISCONNECTED:
+            # A real disconnect would never recover; surface it for the assertion.
+            return result
+        time.sleep(interval_s)
+        result = broadcaster.get_frame(camera_id, viewer_id)
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end lifecycle, parametrized across both backends (Req 2.8 parity) and a
+# couple of representative subscriber counts (1-3 examples each).
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("num_viewers", [1, 2])
+@pytest.mark.parametrize("label,camera_id,backend_factory,guard", _BACKENDS)
+def test_end_to_end_subscribe_frames_unsubscribe(
+    label, camera_id, backend_factory, guard, num_viewers
+):
+    """subscribe -> frames -> viewer_count -> unsubscribe releases the claim.
+
+    Runs the real broadcaster/session/worker against the real backend adapter
+    with a fake (Aravis) / simulated (GStreamer) device, asserting the same
+    lifecycle for both backends (Req 2.8).
+
+    Validates: Requirements 2.8
+    """
+    # Enable the Aravis Fake interface up front (idempotent; camera_manager.Camera
+    # also does this on construction). For GStreamer this is a no-op guard.
+    native = guard()
+    if label == "aravis":
+        native.enable_interface("Fake")
+
+    broadcaster = StreamBroadcaster(
+        stream_config=_CONFIG, backend_factory=backend_factory
+    )
+    viewer_ids = []
+    try:
+        # --- subscribe: each subscribe issues a distinct viewer id (Req 8.1) ---
+        for _ in range(num_viewers):
+            result = broadcaster.subscribe(camera_id)
+            assert result.accepted is True, (
+                f"[{label}] subscribe was rejected: reason={result.reason}"
+            )
+            assert result.viewer_id is not None
+            viewer_ids.append(result.viewer_id)
+
+        assert len(set(viewer_ids)) == num_viewers, "viewer ids must be distinct"
+
+        # --- viewer_count reflects the number of subscribers (Req 8.4) ---
+        assert broadcaster.viewer_count(camera_id) == num_viewers
+
+        # --- frames: get_frame eventually returns OK with frame bytes (Req 2.3) ---
+        first_viewer = viewer_ids[0]
+        frame_result = _poll_until_ok(broadcaster, camera_id, first_viewer)
+        assert frame_result.status == FrameStatus.OK, (
+            f"[{label}] expected OK frame, got {frame_result.status} "
+            f"(error={frame_result.error})"
+        )
+        assert frame_result.frame is not None
+        assert isinstance(frame_result.frame.data, (bytes, bytearray))
+        assert len(frame_result.frame.data) > 0, "frame payload must be non-empty"
+
+        # Every subscriber reads the identical latest frame within the interval
+        # (single shared acquisition fanned out, Req 2.5).
+        if num_viewers > 1:
+            seqs = {
+                broadcaster.get_frame(camera_id, vid).frame.seq
+                for vid in viewer_ids
+            }
+            assert len(seqs) == 1, "all viewers must observe the same latest frame seq"
+
+        # --- unsubscribe all but the last: session stays up (Req 3.7 / 8.7) ---
+        for vid in viewer_ids[:-1]:
+            broadcaster.unsubscribe(camera_id, vid)
+        assert broadcaster.viewer_count(camera_id) == 1
+        # Still streaming for the remaining viewer.
+        assert broadcaster.get_frame(camera_id, viewer_ids[-1]).status in (
+            FrameStatus.OK,
+            FrameStatus.NO_FRAME,
+            FrameStatus.STALE,
+        )
+
+        # --- unsubscribe the last viewer: stop-on-last releases the claim ---
+        broadcaster.unsubscribe(camera_id, viewer_ids[-1])
+        viewer_ids.clear()
+        assert broadcaster.viewer_count(camera_id) == 0
+
+        # --- a subsequent get_frame returns DISCONNECTED (no session, Req 7.5) ---
+        post = broadcaster.get_frame(camera_id, "nonexistent-viewer")
+        assert post.status == FrameStatus.DISCONNECTED
+        assert post.frame is None
+    finally:
+        # Best-effort teardown so a failed assertion never leaks an open claim.
+        for vid in viewer_ids:
+            try:
+                broadcaster.unsubscribe(camera_id, vid)
+            except Exception:
+                pass

--- a/test/backend-test/utils/streaming/integration/test_inference_timing.py
+++ b/test/backend-test/utils/streaming/integration/test_inference_timing.py
@@ -1,0 +1,316 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Wall-clock timing/integration tests for the inference/capture path (task 12.4).
+
+Feature: concurrent-camera-stream-viewing.
+
+These are **integration / timing** tests (NOT Hypothesis property tests): they
+wire together the *real* :class:`StreamBroadcaster`, the *real*
+:class:`AcquisitionWorker` (running on its own daemon thread against the real
+wall clock), and a hardware-free :class:`MockCameraBackend`, then measure actual
+elapsed wall-clock behaviour to pin the timing acceptance criteria that the
+property tests deliberately do not cover.
+
+Covered acceptance criteria
+----------------------------
+* **Req 6.2** — *While the inference pipeline is acquiring a frame from a camera
+  that has an active stream session, the broadcaster keeps delivering preview
+  frames to each subscribed viewer at a rate no lower than 90% of the session's
+  configured frame rate, with no single inter-frame gap exceeding 500 ms.*
+
+  We run a live session whose worker publishes frames at the configured refresh
+  ceiling (``min_refresh_fps``), then — concurrently, from another thread — hammer
+  :meth:`StreamBroadcaster.get_inference_frame` (which, with an active session, is
+  a pure read of the shared latest-frame slot that reuses the running claim and
+  never grabs the device). Over a short measurement window we sample the frames a
+  viewer observes and assert that the producer's cadence is essentially
+  undisturbed: every inter-frame gap stays at or below 500 ms and the delivered
+  rate stays at or above 90% of the configured rate.
+
+* **Req 6.3 (timing)** — *When the inference pipeline requests a frame from a
+  camera that has no active stream session, the camera manager opens a dedicated
+  claim, acquires the frame, and returns it within 2000 ms.*
+
+  With no session we time a single :meth:`StreamBroadcaster.get_inference_frame`
+  call (the dedicated-claim fallback: open -> start_stream -> grab -> stop_stream
+  -> close) and assert it returns a frame within the 2000 ms bound.
+
+Why this is not flaky
+---------------------
+The mock backend's ``grab`` returns instantly, so the worker's cadence is
+governed purely by its refresh-ceiling sleep (``1 / min_refresh_fps``), i.e. the
+device is "fast" and the broadcaster caps at the configured rate. The wall-clock
+windows are kept small (~1 s) and the assertions carry generous tolerance
+(the 500 ms gap bound is 2.5x the 200 ms target interval; the rate floor is
+checked with headroom) so ordinary scheduler jitter cannot trip them.
+
+Running (bypasses the backend-wide conftest, mirroring the sibling streaming
+tests' import approach)::
+
+    PYTHONPATH=src/backend:test/backend-test/utils/streaming \
+        python3 -m pytest \
+        test/backend-test/utils/streaming/integration/test_inference_timing.py \
+        --noconftest -q
+"""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Dict, List, Optional, Tuple
+
+import pytest
+
+from mock_camera_backend import (
+    BACKEND_KINDS,
+    ClaimRegistry,
+    MockCameraBackend,
+    make_backend,
+    make_raw_frame,
+)
+from utils.streaming.broadcaster import StreamBroadcaster
+from utils.streaming.models import FrameStatus, StreamConfig
+
+# A single physical camera id used across the timing scenarios.
+CAMERA = "Fake_timing_1"
+
+# Configured refresh ceiling for the live session. The mock device is "fast"
+# (instant grabs), so the worker publishes at exactly this rate -> a 200 ms
+# target inter-frame interval at 5 fps.
+CONFIGURED_FPS = 5.0
+TARGET_INTERVAL_S = 1.0 / CONFIGURED_FPS  # 0.2 s
+
+# Req 6.2 hard bound: no single inter-frame gap may exceed 500 ms.
+MAX_GAP_S = 0.5
+# Req 6.2 rate floor: delivered rate must stay >= 90% of the configured rate.
+MIN_RATE_FRACTION = 0.9
+# Req 6.3 timing bound for the dedicated-claim grab.
+DEDICATED_DEADLINE_S = 2.0
+
+# Wall-clock measurement window for the cadence sample (~1 s, kept small).
+MEASURE_WINDOW_S = 1.2
+# Upper bound on how long we wait for the worker's first published frame.
+FIRST_FRAME_DEADLINE_S = 3.0
+
+
+def _make_session_broadcaster(
+    backend_kind: str, registry: ClaimRegistry
+) -> Tuple[StreamBroadcaster, List[MockCameraBackend]]:
+    """Build a broadcaster + factory for the live-session timing scenario.
+
+    The factory builds a mock backend whose ``grab`` always returns a frame
+    (``default_grab`` is a real :class:`RawFrame`), so the worker never sees a
+    timeout/disconnect and keeps publishing at the configured refresh ceiling for
+    the whole window. The real wall clock (``time.time``) and the real
+    :class:`AcquisitionWorker` are used so the measured cadence is genuine.
+    """
+    created: List[MockCameraBackend] = []
+
+    def backend_factory(camera_id, config) -> MockCameraBackend:
+        backend = make_backend(
+            backend_kind,
+            camera_id,
+            claim_registry=registry,
+            # Every grab returns a frame so the worker publishes continuously.
+            default_grab=make_raw_frame(seq=0, width=8, height=8),
+        )
+        created.append(backend)
+        return backend
+
+    broadcaster = StreamBroadcaster(
+        stream_config=StreamConfig(
+            min_refresh_fps=CONFIGURED_FPS,
+            # Generous freshness ceiling so polled frames never read STALE during
+            # the window; not the subject of this test.
+            stale_after_s=5.0,
+        ),
+        backend_factory=backend_factory,
+        # time_fn left at the default (time.time) -> real wall clock.
+    )
+    return broadcaster, created
+
+
+def _wait_for_first_frame(broadcaster: StreamBroadcaster, viewer_id: str) -> None:
+    """Block until the worker has published its first frame (or fail on timeout)."""
+    deadline = time.monotonic() + FIRST_FRAME_DEADLINE_S
+    while time.monotonic() < deadline:
+        result = broadcaster.get_frame(CAMERA, viewer_id)
+        if result.status == FrameStatus.OK and result.frame is not None:
+            return
+        time.sleep(0.005)
+    pytest.fail(
+        f"worker did not publish a first frame within {FIRST_FRAME_DEADLINE_S:g}s"
+    )
+
+
+def _sample_viewer_cadence(
+    broadcaster: StreamBroadcaster, viewer_id: str, window_s: float
+) -> List[float]:
+    """Poll the viewer's frame for ``window_s`` and return per-frame acquired-at stamps.
+
+    Returns the ``acquired_at`` timestamp of each *distinct* frame (by ``seq``)
+    the viewer observed, in order. Inter-frame gaps are the consecutive
+    differences of this list. Polling is tight (5 ms) so we never miss a published
+    frame at the 200 ms cadence.
+    """
+    seen_seqs: set = set()
+    stamps: List[float] = []
+    end = time.monotonic() + window_s
+    while time.monotonic() < end:
+        result = broadcaster.get_frame(CAMERA, viewer_id)
+        frame = result.frame
+        if (
+            result.status == FrameStatus.OK
+            and frame is not None
+            and frame.seq not in seen_seqs
+        ):
+            seen_seqs.add(frame.seq)
+            stamps.append(frame.acquired_at)
+        time.sleep(0.005)
+    return stamps
+
+
+@pytest.mark.parametrize("backend_kind", BACKEND_KINDS)
+def test_inference_during_session_preserves_viewer_cadence(backend_kind):
+    """Req 6.2: concurrent inference grabs do not disturb the viewer frame cadence.
+
+    A live session publishes at the configured 5 fps refresh ceiling. While a
+    background thread continuously calls ``get_inference_frame`` (reusing the
+    running claim via a pure slot read), a subscribed viewer's observed frames must
+    keep flowing with no inter-frame gap exceeding 500 ms and at >= 90% of the
+    configured rate.
+    """
+    registry = ClaimRegistry()
+    broadcaster, created = _make_session_broadcaster(backend_kind, registry)
+
+    sub = broadcaster.subscribe(CAMERA)
+    assert sub.accepted and sub.viewer_id is not None
+    viewer_id = sub.viewer_id
+
+    inference_calls = 0
+    inference_frames = 0
+    stop_inference = threading.Event()
+
+    def hammer_inference() -> None:
+        nonlocal inference_calls, inference_frames
+        while not stop_inference.is_set():
+            frame = broadcaster.get_inference_frame(CAMERA)
+            inference_calls += 1
+            if frame is not None:
+                inference_frames += 1
+            # Tight but not a busy-spin; many calls land inside the window.
+            time.sleep(0.002)
+
+    inference_thread = threading.Thread(target=hammer_inference, daemon=True)
+    try:
+        # Single claim is open for the live session.
+        assert registry.open_count(CAMERA) == 1
+
+        _wait_for_first_frame(broadcaster, viewer_id)
+
+        inference_thread.start()
+        stamps = _sample_viewer_cadence(broadcaster, viewer_id, MEASURE_WINDOW_S)
+    finally:
+        stop_inference.set()
+        inference_thread.join(timeout=2.0)
+        broadcaster.unsubscribe(CAMERA, viewer_id)
+
+    # The inference path actually ran concurrently and reused the claim (it
+    # returned frames from the shared slot) without ever opening a second claim.
+    assert inference_calls > 0, "inference thread did not run during the window"
+    assert inference_frames > 0, "inference reads returned no frame from the slot"
+    assert len(created) == 1, "inference must reuse the session claim, not build a backend"
+    assert registry.max_concurrent.get(CAMERA) == 1
+    assert not registry.overlap_detected
+
+    # Enough distinct frames to measure a meaningful cadence over ~1.2 s @ 5 fps.
+    assert len(stamps) >= 3, (
+        f"too few frames observed to assess cadence: {len(stamps)}"
+    )
+
+    gaps = [b - a for a, b in zip(stamps, stamps[1:])]
+
+    # Req 6.2: no single inter-frame gap exceeds 500 ms.
+    worst_gap = max(gaps)
+    assert worst_gap <= MAX_GAP_S, (
+        f"inter-frame gap {worst_gap*1000:.0f} ms exceeded the 500 ms bound "
+        f"(gaps_ms={[round(g*1000) for g in gaps]})"
+    )
+
+    # Req 6.2: delivered rate stays >= 90% of the configured rate. Measured from
+    # the producer's own acquired-at stamps across the observed frames.
+    span = stamps[-1] - stamps[0]
+    assert span > 0.0
+    delivered_fps = (len(stamps) - 1) / span
+    assert delivered_fps >= MIN_RATE_FRACTION * CONFIGURED_FPS, (
+        f"delivered {delivered_fps:.2f} fps < 90% of configured {CONFIGURED_FPS} fps "
+        f"(gaps_ms={[round(g*1000) for g in gaps]})"
+    )
+
+    # Session cleanly torn down; claim released.
+    assert registry.open_count(CAMERA) == 0
+
+
+@pytest.mark.parametrize("backend_kind", BACKEND_KINDS)
+def test_dedicated_claim_inference_returns_within_2s(backend_kind):
+    """Req 6.3 (timing): a no-session inference grab returns a frame within 2000 ms.
+
+    With no active session, ``get_inference_frame`` takes the dedicated-claim
+    fallback (open -> start_stream -> grab -> stop_stream -> close). We time the
+    call end-to-end and assert it returns a frame within the 2 s bound and leaves
+    no lingering claim.
+    """
+    registry = ClaimRegistry()
+    created: List[MockCameraBackend] = []
+
+    def backend_factory(camera_id, config) -> MockCameraBackend:
+        backend = make_backend(
+            backend_kind,
+            camera_id,
+            claim_registry=registry,
+            # One scripted frame for the single dedicated grab to return.
+            frames=[make_raw_frame(seq=1, width=8, height=8)],
+        )
+        created.append(backend)
+        return backend
+
+    broadcaster = StreamBroadcaster(
+        stream_config=StreamConfig(min_refresh_fps=CONFIGURED_FPS),
+        backend_factory=backend_factory,
+    )
+
+    # Precondition: no session, no open claim.
+    assert broadcaster.viewer_count(CAMERA) == 0
+    assert registry.open_count(CAMERA) == 0
+
+    start = time.monotonic()
+    frame = broadcaster.get_inference_frame(CAMERA, config={"width": 8})
+    elapsed = time.monotonic() - start
+
+    # Returned an actual frame in the legacy dict shape, within the 2 s bound.
+    assert isinstance(frame, dict)
+    assert set(frame.keys()) == {"data", "height", "width"}
+    assert elapsed <= DEDICATED_DEADLINE_S, (
+        f"dedicated-claim inference took {elapsed*1000:.0f} ms (> 2000 ms bound)"
+    )
+
+    # Exactly one dedicated claim opened and released; nothing lingers.
+    assert len(created) == 1
+    dedicated = created[0]
+    assert dedicated.open_count == 1
+    assert dedicated.close_count == 1
+    assert dedicated.grab_count == 1
+    assert registry.open_count(CAMERA) == 0
+    assert registry.max_concurrent.get(CAMERA) == 1
+    assert not registry.overlap_detected
+    assert broadcaster.viewer_count(CAMERA) == 0

--- a/test/backend-test/utils/streaming/integration/test_latency_bounds.py
+++ b/test/backend-test/utils/streaming/integration/test_latency_bounds.py
@@ -1,0 +1,331 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""First-frame availability and latest-frame read latency-bound integration tests.
+
+Feature: concurrent-camera-stream-viewing, task 12.1.
+
+These are **timing / integration** tests (not property tests). They wire the real
+``StreamBroadcaster`` + ``StreamSession`` + ``AcquisitionWorker`` together against
+the hardware-free mock ``CameraBackend`` and assert the wall-clock latency bounds
+from the acceptance criteria:
+
+* **Req 3.10 — first frame within 10 s.** A new ``StreamSession`` makes its first
+  ``Latest_Frame`` available to viewers within 10 seconds of starting. We subscribe
+  through the broadcaster (which opens the backend claim and starts a *real* worker
+  thread) against a mock that delivers frames immediately, and assert a frame becomes
+  readable well within the 10 s bound.
+
+* **Req 2.3 — latest-frame read < 100 ms.** A viewer's request for the current
+  preview frame returns the ``Latest_Frame`` within 100 ms. Because the read is a
+  pure in-memory latest-frame-slot copy (no device grab), we measure the wall-clock
+  time around ``broadcaster.get_frame`` after a frame has been published and assert it
+  is comfortably under 100 ms.
+
+* **Req 4.1 — available frame returned < 500 ms.** Same read path, asserted against
+  the looser 500 ms bound for an available frame.
+
+* **Req 4.2 — no-frame response < 500 ms.** When no ``Latest_Frame`` is available yet
+  (session started, first frame not produced), a ``NO_FRAME`` response is returned
+  within 500 ms. Measured around both ``broadcaster.get_frame`` (startup phase) and
+  ``session.read_latest``.
+
+* **Req 4.7 — stale response < 500 ms.** When the latest frame is older than the
+  freshness ceiling, a ``STALE`` response is returned within 500 ms. Freshness is a
+  pure function of the injected ``now`` vs the frame's ``acquired_at``, so we publish a
+  frame and read it with an advanced ``now`` and measure the wall-clock time of the
+  ``read_latest`` call.
+
+All reads are pure in-memory operations, so the measured latencies are orders of
+magnitude below the requirement bounds; the tests pin that this stays true. They are
+fast and deterministic — the only real sleeps are tiny poll intervals while waiting
+for the worker thread to publish the first frame.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from mock_camera_backend import (
+    MOCK_BACKEND_CLASSES,
+    ClaimRegistry,
+    make_raw_frame,
+)
+from utils.streaming.broadcaster import StreamBroadcaster
+from utils.streaming.models import FrameStatus, SessionState, StreamConfig
+from utils.streaming.session import StreamSession
+
+CAMERA_ID = "Fake_1"
+
+# Acceptance-criteria latency bounds (seconds).
+FIRST_FRAME_BOUND_S = 10.0   # Req 3.10
+READ_100MS_BOUND_S = 0.100   # Req 2.3
+READ_500MS_BOUND_S = 0.500   # Req 4.1, 4.2, 4.7
+
+# How many times to sample a read latency; we assert the worst-case sample.
+_LATENCY_SAMPLES = 50
+
+
+def _make_broadcaster(backend_kind, *, frames=None, default_grab=None,
+                      stream_config=None, claim_registry=None):
+    """Build a real ``StreamBroadcaster`` backed by a scripted mock backend.
+
+    The injected ``backend_factory`` hands the broadcaster a mock backend of the
+    requested family (``aravis`` / ``gstreamer``) so subscribe/start opens a real
+    (in-memory) claim and the broadcaster spins up a *real* ``AcquisitionWorker``
+    thread driving ``grab -> publish`` against the scripted frames.
+    """
+    backend_cls = MOCK_BACKEND_CLASSES[backend_kind]
+    cfg = stream_config or StreamConfig()
+
+    def factory(camera_id, config):
+        return backend_cls(
+            camera_id,
+            frames=list(frames) if frames else None,
+            default_grab=default_grab,
+            claim_registry=claim_registry,
+        )
+
+    return StreamBroadcaster(stream_config=cfg, backend_factory=factory)
+
+
+def _wait_for_status(broadcaster, camera_id, viewer_id, target_status, deadline_s):
+    """Poll ``get_frame`` until it reports ``target_status`` or the deadline passes.
+
+    Returns ``(elapsed_seconds, result)``. ``elapsed_seconds`` is the wall-clock time
+    from the start of polling until the target status was first observed; if the
+    deadline elapses first, ``result`` carries the last (non-matching) result so the
+    caller can assert/diagnose.
+    """
+    start = time.perf_counter()
+    last = None
+    while True:
+        last = broadcaster.get_frame(camera_id, viewer_id)
+        if last.status == target_status:
+            return time.perf_counter() - start, last
+        if time.perf_counter() - start >= deadline_s:
+            return time.perf_counter() - start, last
+        time.sleep(0.005)
+
+
+def _max_read_latency(read_callable, samples=_LATENCY_SAMPLES):
+    """Return the worst-case wall-clock duration (seconds) of ``read_callable``."""
+    worst = 0.0
+    for _ in range(samples):
+        start = time.perf_counter()
+        read_callable()
+        worst = max(worst, time.perf_counter() - start)
+    return worst
+
+
+# --------------------------------------------------------------------------- #
+# Req 3.10 — first frame available within 10 s of session start
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("backend_kind", list(MOCK_BACKEND_CLASSES))
+def test_first_frame_available_within_10s(backend_kind):
+    """A new session makes the first frame available well within the 10 s bound.
+
+    Feature: concurrent-camera-stream-viewing, task 12.1
+    Validates: Requirements 3.10
+    """
+    registry = ClaimRegistry()
+    # default_grab is a real frame so the worker keeps publishing fresh frames and
+    # the stream never disconnects for the duration of the test.
+    broadcaster = _make_broadcaster(
+        backend_kind,
+        frames=[make_raw_frame(seq=i) for i in range(3)],
+        default_grab=make_raw_frame(seq=99),
+        claim_registry=registry,
+    )
+
+    result = broadcaster.subscribe(CAMERA_ID, config={"type": "Camera"})
+    assert result.accepted, f"subscribe rejected: {result.reason}"
+    viewer_id = result.viewer_id
+    try:
+        elapsed, frame_result = _wait_for_status(
+            broadcaster, CAMERA_ID, viewer_id,
+            FrameStatus.OK, deadline_s=FIRST_FRAME_BOUND_S + 2.0,
+        )
+        assert frame_result.status == FrameStatus.OK, (
+            f"first frame never became available (last status={frame_result.status})"
+        )
+        assert frame_result.frame is not None
+        # The hard acceptance bound (Req 3.10); in practice this is a few ms.
+        assert elapsed < FIRST_FRAME_BOUND_S, (
+            f"first frame took {elapsed:.3f}s, exceeding the {FIRST_FRAME_BOUND_S}s bound"
+        )
+    finally:
+        broadcaster.unsubscribe(CAMERA_ID, viewer_id)
+
+    # The single device claim was released on stop-on-last (sanity on teardown).
+    registry.assert_single_claim()
+    assert registry.total_open() == 0
+
+
+# --------------------------------------------------------------------------- #
+# Req 2.3 / 4.1 — latest-frame read latency for an available frame
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("backend_kind", list(MOCK_BACKEND_CLASSES))
+def test_available_frame_read_under_100ms(backend_kind):
+    """Reading an available latest frame returns within 100 ms (and 500 ms).
+
+    Feature: concurrent-camera-stream-viewing, task 12.1
+    Validates: Requirements 2.3, 4.1
+    """
+    broadcaster = _make_broadcaster(
+        backend_kind,
+        frames=[make_raw_frame(seq=i) for i in range(3)],
+        default_grab=make_raw_frame(seq=99),
+    )
+    result = broadcaster.subscribe(CAMERA_ID, config={"type": "Camera"})
+    assert result.accepted
+    viewer_id = result.viewer_id
+    try:
+        # Ensure a frame is actually available before timing the read path.
+        _, ok = _wait_for_status(
+            broadcaster, CAMERA_ID, viewer_id, FrameStatus.OK, deadline_s=FIRST_FRAME_BOUND_S
+        )
+        assert ok.status == FrameStatus.OK
+
+        def read_ok():
+            res = broadcaster.get_frame(CAMERA_ID, viewer_id)
+            # Stays OK because the worker keeps republishing fresh frames.
+            assert res.status == FrameStatus.OK
+            return res
+
+        worst = _max_read_latency(read_ok)
+        assert worst < READ_100MS_BOUND_S, (
+            f"worst available-frame read was {worst * 1000:.3f}ms, "
+            f"exceeding the 100ms bound (Req 2.3)"
+        )
+        # The looser Req 4.1 bound is satisfied a fortiori.
+        assert worst < READ_500MS_BOUND_S
+    finally:
+        broadcaster.unsubscribe(CAMERA_ID, viewer_id)
+
+
+# --------------------------------------------------------------------------- #
+# Req 4.2 — no-frame response within 500 ms
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("backend_kind", list(MOCK_BACKEND_CLASSES))
+def test_no_frame_response_under_500ms(backend_kind):
+    """A session with no frame yet returns NO_FRAME within 500 ms.
+
+    The mock backend yields only grab timeouts (``None``), so the worker stays in its
+    start-up phase tolerating failed grabs (no frame is published) and the session
+    remains active — exactly the "started, no Latest_Frame available" condition.
+
+    Feature: concurrent-camera-stream-viewing, task 12.1
+    Validates: Requirements 4.2
+    """
+    # default_grab is None -> the worker never publishes a frame during the brief
+    # window we measure (well before the 10 s first-frame timeout).
+    broadcaster = _make_broadcaster(backend_kind, frames=None, default_grab=None)
+    result = broadcaster.subscribe(CAMERA_ID, config={"type": "Camera"})
+    assert result.accepted
+    viewer_id = result.viewer_id
+    try:
+        def read_no_frame():
+            res = broadcaster.get_frame(CAMERA_ID, viewer_id)
+            assert res.status == FrameStatus.NO_FRAME, (
+                f"expected NO_FRAME during start-up, got {res.status}"
+            )
+            assert res.frame is None
+            return res
+
+        worst = _max_read_latency(read_no_frame)
+        assert worst < READ_500MS_BOUND_S, (
+            f"worst no-frame response was {worst * 1000:.3f}ms, exceeding the 500ms bound"
+        )
+    finally:
+        broadcaster.unsubscribe(CAMERA_ID, viewer_id)
+
+
+def test_no_frame_session_read_under_500ms():
+    """``StreamSession.read_latest`` returns NO_FRAME within 500 ms before any publish.
+
+    Feature: concurrent-camera-stream-viewing, task 12.1
+    Validates: Requirements 4.2
+    """
+    session = StreamSession(
+        CAMERA_ID, backend=None, stream_config=StreamConfig(), state=SessionState.STARTING
+    )
+
+    def read():
+        res = session.read_latest(now=time.time())
+        assert res.status == FrameStatus.NO_FRAME
+        return res
+
+    worst = _max_read_latency(read)
+    assert worst < READ_500MS_BOUND_S, (
+        f"worst no-frame read was {worst * 1000:.3f}ms, exceeding the 500ms bound"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Req 4.7 — stale response within 500 ms
+# --------------------------------------------------------------------------- #
+def test_stale_response_under_500ms():
+    """A frame older than the freshness ceiling reads STALE within 500 ms.
+
+    Freshness is a pure function of ``now - acquired_at`` vs ``stale_after_s``, so we
+    publish a frame at ``t0`` and read it with an advanced ``now`` (past the ceiling).
+    The wall-clock duration of the ``read_latest`` call itself is what Req 4.7 bounds.
+
+    Feature: concurrent-camera-stream-viewing, task 12.1
+    Validates: Requirements 4.7
+    """
+    cfg = StreamConfig(stale_after_s=2.0)
+    session = StreamSession(
+        CAMERA_ID, backend=None, stream_config=cfg, state=SessionState.RUNNING
+    )
+    # Publish a frame stamped at t0; later reads use an injected now well past the
+    # 2 s freshness ceiling so the slot classifies STALE.
+    session.publish(make_raw_frame(seq=1), now=1000.0)
+    stale_now = 1000.0 + cfg.stale_after_s + 5.0
+
+    def read_stale():
+        res = session.read_latest(now=stale_now)
+        assert res.status == FrameStatus.STALE, f"expected STALE, got {res.status}"
+        # The stale frame is still returned (last-good payload), but flagged stale.
+        assert res.frame is not None
+        return res
+
+    worst = _max_read_latency(read_stale)
+    assert worst < READ_500MS_BOUND_S, (
+        f"worst stale response was {worst * 1000:.3f}ms, exceeding the 500ms bound"
+    )
+
+
+def test_ok_session_read_under_100ms():
+    """A fresh frame reads OK within 100 ms via ``StreamSession.read_latest``.
+
+    Feature: concurrent-camera-stream-viewing, task 12.1
+    Validates: Requirements 2.3
+    """
+    cfg = StreamConfig(stale_after_s=2.0)
+    session = StreamSession(
+        CAMERA_ID, backend=None, stream_config=cfg, state=SessionState.RUNNING
+    )
+    session.publish(make_raw_frame(seq=1), now=1000.0)
+
+    def read_ok():
+        res = session.read_latest(now=1000.0 + 0.1)  # within the freshness ceiling
+        assert res.status == FrameStatus.OK
+        return res
+
+    worst = _max_read_latency(read_ok)
+    assert worst < READ_100MS_BOUND_S, (
+        f"worst OK read was {worst * 1000:.3f}ms, exceeding the 100ms bound"
+    )

--- a/test/backend-test/utils/streaming/integration/test_refresh_rate.py
+++ b/test/backend-test/utils/streaming/integration/test_refresh_rate.py
@@ -1,0 +1,290 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Wall-clock refresh-rate and viewer-independence performance tests (task 12.2).
+
+These are *integration / performance* tests, not property tests: they drive the
+**real** :class:`AcquisitionWorker` on its own thread against a real
+:class:`StreamSession` and a mock :class:`CameraBackend` whose ``grab()`` cadence
+we control, then measure the actual publish cadence with the real
+``time.monotonic`` wall clock over a small bounded window (~1-2 s). They cover the
+wall-clock side of the design's refresh-rate acceptance criteria:
+
+* **Req 4.3** — a stream refreshes at >= 5 fps when the source can deliver >= 5 fps.
+  The worker caps the producer at ``StreamConfig.min_refresh_fps`` (5 fps by
+  default), so a source that can grab arbitrarily fast is published at ~5 fps.
+* **Req 4.4** — when the device is slower than the 5 fps ceiling, the refresh rate
+  tracks the device's own cadence (no artificial delay is added below the ceiling).
+  We model a slow source with a ``grab()`` that sleeps, and assert the measured
+  cadence matches the device rate rather than being pinned to 5 fps or stalling.
+* **Req 4.5 (wall-clock side)** — the producer cadence is independent of the number
+  of viewers. We run the identical fast source with 1 reader vs ``max_viewers`` (8)
+  readers polling the latest-frame slot concurrently and assert the publish cadence
+  is essentially unchanged (drop-to-latest: reads never slow or block the producer).
+
+Timing tests are inherently sensitive to scheduler jitter, so each assertion uses a
+generous tolerance band around the expected cadence rather than an exact equality,
+and the cadence is measured between the first and last publish (independent of where
+the measurement window happens to start/stop) to keep the estimate robust.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+import uuid
+
+import pytest
+
+# --- import bootstrap -------------------------------------------------------
+# This test lives one directory below the other streaming tests, so make the
+# sibling ``mock_camera_backend`` module and the ``src/backend`` source root
+# importable with the same bare import style the sibling tests use, regardless of
+# pytest's rootdir / invocation directory.
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_STREAMING_DIR = os.path.dirname(_THIS_DIR)
+_BACKEND_SRC = os.path.abspath(
+    os.path.join(_THIS_DIR, "..", "..", "..", "..", "..", "src", "backend")
+)
+for _p in (_STREAMING_DIR, _BACKEND_SRC):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from mock_camera_backend import make_backend, make_raw_frame  # noqa: E402
+from utils.streaming.models import StreamConfig, Viewer  # noqa: E402
+from utils.streaming.session import StreamSession  # noqa: E402
+from utils.streaming.worker import AcquisitionWorker  # noqa: E402
+
+CAMERA_ID = "Fake_1"
+
+# Default refresh ceiling the worker enforces for a fast-enough source (Req 4.3).
+CEILING_FPS = StreamConfig().min_refresh_fps           # 5.0
+CEILING_INTERVAL_S = 1.0 / CEILING_FPS                 # 0.2 s
+MAX_VIEWERS = StreamConfig().max_viewers               # 8
+
+# A deliberately slow device cadence, comfortably below the 5 fps ceiling, used to
+# exercise the "track the device, don't add delay" path (Req 4.4).
+SLOW_GRAB_S = 0.4                                       # -> ~2.5 fps device cadence
+SLOW_DEVICE_FPS = 1.0 / SLOW_GRAB_S                     # 2.5
+
+# Measurement windows (wall-clock seconds). Kept small but long enough to capture
+# several publishes so the cadence estimate is meaningful.
+FAST_WINDOW_S = 1.5
+SLOW_WINDOW_S = 2.0
+
+
+def _make_viewer(now: float) -> Viewer:
+    """Build a Viewer with a unique id for registration in a session."""
+    return Viewer(
+        viewer_id=str(uuid.uuid4()),
+        camera_id=CAMERA_ID,
+        subscribed_at=now,
+        last_active=now,
+    )
+
+
+def _fast_grab():
+    """A source that can deliver frames arbitrarily fast (near-instant grab)."""
+    return make_raw_frame(seq=0, width=8, height=8)
+
+
+def _slow_grab():
+    """A source slower than the refresh ceiling: each grab takes ``SLOW_GRAB_S``."""
+    time.sleep(SLOW_GRAB_S)
+    return make_raw_frame(seq=0, width=8, height=8)
+
+
+def _run_worker_window(grab_fn, *, window_s, num_readers=0, stream_config=None):
+    """Run the real worker thread for ``window_s`` and record publish timestamps.
+
+    Drives the real :class:`AcquisitionWorker` (real ``time.monotonic`` clock and
+    ``time.sleep``) against a mock backend whose ``grab()`` is ``grab_fn`` (reused
+    indefinitely via ``default_grab``). ``num_readers`` viewer threads poll
+    ``read_latest`` concurrently to model fan-out reads. The worker is signalled to
+    stop after ``window_s`` and joined.
+
+    Returns ``(publish_monotonic_times, elapsed_s)`` where ``publish_monotonic_times``
+    is the wall-clock (monotonic) instant of every publish in order.
+    """
+    config = stream_config or StreamConfig()
+
+    # default_grab is reused once the (empty) scripted queue drains, so the backend
+    # serves frames forever at whatever cadence grab_fn imposes; the worker therefore
+    # runs until we stop it rather than hitting a disconnect on an exhausted queue.
+    backend = make_backend("aravis", camera_id=CAMERA_ID, default_grab=grab_fn)
+    # The broadcaster owns open/start_stream in production; the worker only
+    # grab->publishes. Acquire the claim and start acquisition before running.
+    backend.open()
+    backend.start_stream()
+
+    session = StreamSession(CAMERA_ID, backend=backend, stream_config=config)
+
+    for _ in range(num_readers):
+        session.add_viewer(_make_viewer(time.time()))
+    assert session.viewer_count() == num_readers
+
+    publish_times: list[float] = []
+    record_lock = threading.Lock()
+    real_publish = session.publish
+
+    def recording_publish(frame, width=None, height=None, now=0.0):
+        result = real_publish(frame, width=width, height=height, now=now)
+        with record_lock:
+            publish_times.append(time.monotonic())
+        return result
+
+    session.publish = recording_publish
+
+    # Concurrent fan-out readers: poll the latest-frame slot in a tight-but-not-spin
+    # loop, mirroring real viewers. Pure slot reads must never slow the producer.
+    stop_readers = threading.Event()
+
+    def reader_loop():
+        while not stop_readers.is_set():
+            session.read_latest(time.time())
+            time.sleep(0.005)
+
+    reader_threads = [
+        threading.Thread(target=reader_loop, name=f"reader-{i}", daemon=True)
+        for i in range(num_readers)
+    ]
+    for t in reader_threads:
+        t.start()
+
+    worker = AcquisitionWorker(session, stream_config=config)
+
+    start = time.monotonic()
+    worker.start()
+    time.sleep(window_s)
+    worker.stop()
+    worker.join(timeout=SLOW_GRAB_S + 2.0)
+    elapsed = time.monotonic() - start
+
+    stop_readers.set()
+    for t in reader_threads:
+        t.join(timeout=1.0)
+
+    return publish_times, elapsed
+
+
+def _cadence_fps(publish_times):
+    """Estimate the publish cadence (fps) from recorded publish timestamps.
+
+    Measured between the first and last publish so the estimate reflects the actual
+    inter-publish interval and is independent of exactly where the measurement window
+    opened or closed. Requires at least two publishes.
+    """
+    assert len(publish_times) >= 2, (
+        f"need >= 2 publishes to estimate cadence, got {len(publish_times)}"
+    )
+    span = publish_times[-1] - publish_times[0]
+    assert span > 0.0, "publish timestamps did not advance"
+    return (len(publish_times) - 1) / span
+
+
+# --------------------------------------------------------------------------- #
+# Req 4.3: a >= 5 fps source refreshes at >= 5 fps
+# --------------------------------------------------------------------------- #
+def test_refresh_meets_5fps_for_fast_source():
+    """A source that can grab >= 5 fps is published at ~>= 5 fps (Req 4.3).
+
+    The worker caps the producer at the 5 fps refresh ceiling, so a near-instant
+    grab source is published at approximately 5 fps. We allow a tolerance below 5
+    fps for scheduler jitter (the ``time.sleep`` that paces the ceiling may overrun
+    slightly), and a modest tolerance above to confirm the ceiling is roughly
+    respected rather than free-running far faster.
+    """
+    publish_times, elapsed = _run_worker_window(_fast_grab, window_s=FAST_WINDOW_S)
+
+    fps = _cadence_fps(publish_times)
+    # Lower bound: ~5 fps with a 10% jitter allowance (Req 4.3, "at least 5 fps").
+    assert fps >= CEILING_FPS * 0.9, (
+        f"refresh {fps:.2f} fps below the >= 5 fps requirement for a fast source "
+        f"({len(publish_times)} publishes in {elapsed:.2f}s)"
+    )
+    # Upper sanity bound: the producer is paced by the ceiling, not free-running.
+    assert fps <= CEILING_FPS * 1.5, (
+        f"refresh {fps:.2f} fps far exceeds the ~5 fps ceiling; pacing may be broken"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Req 4.4: a source slower than the ceiling tracks the device cadence
+# --------------------------------------------------------------------------- #
+def test_refresh_tracks_device_rate_below_ceiling():
+    """A sub-5-fps source refreshes at the device cadence, not the ceiling (Req 4.4).
+
+    With a ``grab()`` that takes 0.4 s (~2.5 fps), the per-iteration grab already
+    overruns the 0.2 s ceiling interval, so the worker adds no extra delay and the
+    publish cadence tracks the device. We assert the measured cadence is close to the
+    device's ~2.5 fps (within a tolerance band) and clearly below the 5 fps ceiling —
+    i.e. the worker neither pins it to 5 fps nor stalls it well under the device rate.
+    """
+    publish_times, elapsed = _run_worker_window(_slow_grab, window_s=SLOW_WINDOW_S)
+
+    fps = _cadence_fps(publish_times)
+    # Tracks the device: comfortably below the 5 fps ceiling.
+    assert fps < CEILING_FPS * 0.9, (
+        f"slow-source refresh {fps:.2f} fps is not below the 5 fps ceiling; the worker "
+        f"may be adding/forcing cadence ({len(publish_times)} publishes in {elapsed:.2f}s)"
+    )
+    # Tracks the device: no artificial delay below the device's own ~2.5 fps cadence.
+    # Generous band to absorb grab + scheduling overhead on either side.
+    assert SLOW_DEVICE_FPS * 0.7 <= fps <= SLOW_DEVICE_FPS * 1.25, (
+        f"slow-source refresh {fps:.2f} fps does not track the ~{SLOW_DEVICE_FPS:.1f} fps "
+        f"device cadence ({len(publish_times)} publishes in {elapsed:.2f}s)"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Req 4.5 (wall-clock side): refresh rate is independent of viewer count
+# --------------------------------------------------------------------------- #
+def test_refresh_rate_independent_of_viewer_count():
+    """Publish cadence is essentially unchanged from 1 to 8 concurrent viewers (Req 4.5).
+
+    Drop-to-latest means viewer reads are pure, non-blocking slot copies that never
+    apply backpressure to the producer. We run the identical fast source twice — once
+    with a single reader, once with ``max_viewers`` (8) readers all polling
+    concurrently — and assert the measured publish cadence is essentially the same and
+    still meets the ~5 fps ceiling in both cases.
+    """
+    single_times, single_elapsed = _run_worker_window(
+        _fast_grab, window_s=FAST_WINDOW_S, num_readers=1
+    )
+    multi_times, multi_elapsed = _run_worker_window(
+        _fast_grab, window_s=FAST_WINDOW_S, num_readers=MAX_VIEWERS
+    )
+
+    fps_single = _cadence_fps(single_times)
+    fps_multi = _cadence_fps(multi_times)
+
+    # Both viewer counts still hit the ~5 fps ceiling (10% jitter allowance).
+    assert fps_single >= CEILING_FPS * 0.9, (
+        f"1-viewer refresh {fps_single:.2f} fps below the 5 fps ceiling"
+    )
+    assert fps_multi >= CEILING_FPS * 0.9, (
+        f"{MAX_VIEWERS}-viewer refresh {fps_multi:.2f} fps below the 5 fps ceiling; "
+        f"concurrent reads appear to be slowing the producer"
+    )
+
+    # Viewer-independence: 8 concurrent readers must not measurably slow the producer
+    # relative to a single reader (allow a 20% band for wall-clock jitter).
+    assert fps_multi >= fps_single * 0.8, (
+        f"refresh dropped from {fps_single:.2f} fps (1 viewer) to {fps_multi:.2f} fps "
+        f"({MAX_VIEWERS} viewers); reads are applying backpressure to the producer"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience for manual runs
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/backend-test/utils/streaming/integration/test_subscriber_and_settings_timing.py
+++ b/test/backend-test/utils/streaming/integration/test_subscriber_and_settings_timing.py
@@ -1,0 +1,378 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration / timing tests: new-subscriber latency and applied-setting visibility.
+
+Feature: concurrent-camera-stream-viewing (task 12.3). These are wall-clock
+**integration / timing** tests, *not* Hypothesis property tests, so they do not
+update PBT status. They drive the real :class:`StreamBroadcaster` +
+:class:`AcquisitionWorker` (a live producer thread) against the hardware-free
+:class:`MockCameraBackend`, exercising the genuine subscribe / get_frame /
+apply_settings code paths end-to-end.
+
+Requirements under test
+-----------------------
+* **Req 1.4 — a new subscriber starts receiving frames quickly with no disruption
+  to existing viewers.** With a session already running and existing viewers
+  reading frames, a freshly-subscribed viewer must obtain an ``OK`` frame well
+  within 2000 ms of subscribing, while the existing viewers keep receiving fresh
+  frames (their sequence numbers keep advancing and they never observe
+  ``DISCONNECTED``) and the single device claim is reused (never re-opened).
+
+* **Req 5.2 — an applied setting becomes visible within 5 frames.** After
+  ``apply_settings`` is applied to a running session, a published frame that
+  reflects the applied control values must appear within 5 subsequent published
+  frames.
+
+Modelling "visible within N frames" with the mock
+--------------------------------------------------
+The real device has no notion of "the frame carries the current settings", so the
+mock is scripted to *tag* every frame it produces with the controls currently in
+effect. The acquisition worker is the single caller of ``grab()``; each frame the
+mock returns from ``grab()`` encodes ``backend.last_applied_features`` — exactly the
+device-accepted control set recorded by ``apply_features`` — into its ``data``
+payload (``seq=<n>|settings=<tag>``). Because ``StreamBroadcaster.apply_settings``
+calls ``backend.apply_features`` synchronously, every frame grabbed *after* the apply
+carries the new tag.
+
+A "published frame" is one acquisition interval, identified by the session's
+monotonic ``seq``. Modelling "the applied setting is visible in frame K" therefore
+means: a viewer's ``get_frame`` returns a frame whose tag reflects the applied
+values. The test records the latest ``seq`` visible at the moment ``apply_settings``
+returns (the baseline), then counts how many *new* distinct published frames
+(``seq`` greater than the baseline) appear before one reflects the applied tag, and
+asserts that count is ``<= 5`` (Req 5.2). The worker's refresh ceiling is slowed for
+these tests (``min_refresh_fps`` small) so the poll loop reliably observes every
+new ``seq`` rather than skipping past them.
+
+No production code is modified. Only the public test double's existing
+``default_grab`` hook (a per-grab callable, already supported) is used to script the
+tagged frames; the broadcaster / worker / session run completely unchanged.
+
+Run note
+--------
+This file imports only the import-safe streaming stack (no ``gi`` / device stack),
+so it is intended to be run bypassing the backend-wide ``conftest.py``::
+
+    PYTHONPATH=src/backend python3.9 -m pytest \
+        test/backend-test/utils/streaming/integration/test_subscriber_and_settings_timing.py \
+        --noconftest -p no:cacheprovider
+"""
+from __future__ import annotations
+
+import itertools
+import os
+import sys
+import time
+from typing import Callable, List, Optional, Set
+
+import pytest
+
+# The shared test double (``mock_camera_backend``) lives in the parent
+# ``streaming`` directory. Sibling tests in that directory import it directly
+# because pytest puts the test's own directory on ``sys.path``; this file lives in
+# the ``integration`` subdirectory, so we add the parent directory explicitly to
+# replicate the sibling import (``from mock_camera_backend import ...``).
+_STREAMING_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _STREAMING_DIR not in sys.path:
+    sys.path.insert(0, _STREAMING_DIR)
+
+from mock_camera_backend import (  # noqa: E402  (import after sys.path shim)
+    BACKEND_KINDS,
+    ClaimRegistry,
+    MockCameraBackend,
+    make_backend,
+    make_raw_frame,
+)
+from utils.streaming.broadcaster import StreamBroadcaster  # noqa: E402
+from utils.streaming.models import FrameStatus, SessionState, StreamConfig  # noqa: E402
+
+# A single physical camera is enough for these timing tests.
+CAMERA = "Fake_timing_1"
+
+# Generous max_viewers so we can add a new subscriber on top of existing ones.
+# A small, positive refresh ceiling deliberately *slows* the producer so the
+# polling loops below reliably observe every published frame (every seq) without
+# skipping — important for the "within 5 frames" count to be meaningful. At 20 fps
+# the cadence is ~50 ms; five frames take ~250 ms, far inside the test budget.
+_REFRESH_FPS = 20.0
+_STREAM_CONFIG = StreamConfig(
+    max_viewers=8,
+    min_refresh_fps=_REFRESH_FPS,
+    # Keep frames classified OK between polls: the freshness ceiling is far larger
+    # than the inter-frame cadence so a just-published frame never reads STALE.
+    stale_after_s=5.0,
+    first_frame_timeout_s=10,
+)
+
+# The new-subscriber acceptance bound (Req 1.4). The assertion uses the full bound;
+# in practice the latency is sub-cadence (tens of ms) because the session already
+# has a published latest frame the moment the new viewer subscribes.
+_NEW_SUBSCRIBER_BUDGET_S = 2.0
+
+# Upper bound on published frames for the applied setting to become visible (Req 5.2).
+_MAX_FRAMES_TO_VISIBLE = 5
+
+
+def _settings_tag(applied: Optional[dict]) -> str:
+    """Render a device-accepted control set into a stable, comparable tag string.
+
+    ``None`` / empty (no apply yet) renders as ``"none"``; otherwise the controls
+    are rendered in sorted-key order so the tag is deterministic regardless of dict
+    ordering.
+    """
+    if not applied:
+        return "none"
+    return ",".join(f"{key}={applied[key]}" for key in sorted(applied))
+
+
+def _tagging_grab_factory(backend: MockCameraBackend) -> Callable[[], object]:
+    """Return a zero-arg ``grab`` producer that tags each frame with live settings.
+
+    The acquisition worker is the single caller of ``grab()``. Each produced
+    :class:`RawFrame` carries a monotonic local counter and the controls currently
+    in effect on the backend (``last_applied_features``, set by ``apply_features``)
+    encoded into its ``data`` as ``seq=<n>|settings=<tag>``. This is how we model
+    "the published frame reflects the applied setting" with a hardware-free double.
+    """
+    counter = itertools.count(1)
+
+    def produce() -> object:
+        n = next(counter)
+        tag = _settings_tag(backend.last_applied_features)
+        data = f"seq={n}|settings={tag}".encode("utf-8")
+        return make_raw_frame(seq=n, width=8, height=8, data=data)
+
+    return produce
+
+
+def _make_broadcaster(
+    backend_kind: str, registry: ClaimRegistry, created: List[MockCameraBackend]
+) -> StreamBroadcaster:
+    """Build a broadcaster whose factory yields tagging mock backends.
+
+    Every backend shares one :class:`ClaimRegistry` (so the test reads the true
+    per-camera open-claim count) and records itself into ``created`` (so the test
+    can assert no second claim/backend was built). ``time_fn`` is the real wall
+    clock so freshness and the measured latencies use real time — these are
+    wall-clock timing tests.
+    """
+
+    def backend_factory(camera_id: str, config: Optional[dict]) -> MockCameraBackend:
+        backend = make_backend(backend_kind, camera_id, claim_registry=registry)
+        # Script an unbounded supply of settings-tagged frames for the worker loop.
+        backend.default_grab = _tagging_grab_factory(backend)
+        created.append(backend)
+        return backend
+
+    return StreamBroadcaster(
+        stream_config=_STREAM_CONFIG,
+        backend_factory=backend_factory,
+        time_fn=time.time,
+    )
+
+
+def _wait_for_ok_frame(
+    broadcaster: StreamBroadcaster,
+    camera: str,
+    viewer_id: str,
+    *,
+    timeout_s: float,
+    poll_s: float = 0.005,
+):
+    """Poll ``get_frame`` until it returns an ``OK`` frame or the timeout elapses.
+
+    Returns ``(frame, elapsed_seconds)`` on success, or ``(None, elapsed_seconds)``
+    if no OK frame arrived within ``timeout_s``.
+    """
+    start = time.time()
+    deadline = start + timeout_s
+    while time.time() < deadline:
+        result = broadcaster.get_frame(camera, viewer_id)
+        if result.status == FrameStatus.OK and result.frame is not None:
+            return result.frame, time.time() - start
+        time.sleep(poll_s)
+    return None, time.time() - start
+
+
+@pytest.mark.parametrize("backend_kind", BACKEND_KINDS)
+def test_new_subscriber_starts_receiving_without_disrupting_existing_viewers(backend_kind):
+    """A new subscriber gets frames < 2000 ms with no disruption to existing viewers.
+
+    Feature: concurrent-camera-stream-viewing (task 12.3).
+    Validates: Requirement 1.4.
+    """
+    registry = ClaimRegistry()
+    created: List[MockCameraBackend] = []
+    broadcaster = _make_broadcaster(backend_kind, registry, created)
+
+    existing_viewers: List[str] = []
+    new_viewer: Optional[str] = None
+    try:
+        # --- a running session with two existing viewers already reading frames ---
+        for _ in range(2):
+            result = broadcaster.subscribe(CAMERA, {"type": "Camera"})
+            assert result.accepted, "subscribe within max_viewers must be accepted"
+            existing_viewers.append(result.viewer_id)
+
+        assert registry.open_count(CAMERA) == 1, "exactly one device claim for the camera"
+        assert len(created) == 1, "first subscribe builds exactly one backend"
+
+        # Wait until the existing viewers are actually receiving frames (the worker
+        # has published its first frame and the session is RUNNING).
+        first_frame, _ = _wait_for_ok_frame(
+            broadcaster, CAMERA, existing_viewers[0], timeout_s=_STREAM_CONFIG.first_frame_timeout_s
+        )
+        assert first_frame is not None, "existing viewers should be receiving frames before we add one"
+        assert broadcaster._sessions[CAMERA].state == SessionState.RUNNING
+
+        # Snapshot what an existing viewer currently sees so we can prove its stream
+        # keeps advancing (no disruption) across the new subscription.
+        before = broadcaster.get_frame(CAMERA, existing_viewers[0])
+        assert before.status == FrameStatus.OK and before.frame is not None
+        existing_seq_before = before.frame.seq
+
+        opens_before = created[0].open_count
+
+        # --- the operation under test: subscribe a brand-new viewer ---
+        t0 = time.time()
+        new_result = broadcaster.subscribe(CAMERA, {"type": "Camera"})
+        assert new_result.accepted, "the new viewer must be accepted onto the running session"
+        new_viewer = new_result.viewer_id
+        assert new_viewer not in existing_viewers
+        # The new subscriber must start receiving frames well within 2000 ms.
+        new_frame, latency_s = _wait_for_ok_frame(
+            broadcaster, CAMERA, new_viewer, timeout_s=_NEW_SUBSCRIBER_BUDGET_S
+        )
+        total_since_subscribe = time.time() - t0
+        assert new_frame is not None, (
+            f"new subscriber did not receive a frame within {_NEW_SUBSCRIBER_BUDGET_S * 1000:.0f} ms"
+        )
+        assert total_since_subscribe < _NEW_SUBSCRIBER_BUDGET_S, (
+            f"new subscriber latency {total_since_subscribe * 1000:.1f} ms exceeded the "
+            f"{_NEW_SUBSCRIBER_BUDGET_S * 1000:.0f} ms bound (Req 1.4)"
+        )
+
+        # --- no disruption to existing viewers ---
+        # The new subscription reused the single claim (no second open / backend).
+        assert registry.open_count(CAMERA) == 1, "the single claim must be reused, not duplicated"
+        assert not registry.overlap_detected
+        assert len(created) == 1, "no second backend may be built for the new subscriber"
+        assert created[0].open_count == opens_before, "claim must not be re-opened for a new viewer"
+
+        # The existing viewer keeps getting fresh frames: its sequence advances and it
+        # never observes DISCONNECTED while the new viewer is being added.
+        after, _ = _wait_for_ok_frame(
+            broadcaster, CAMERA, existing_viewers[0], timeout_s=_NEW_SUBSCRIBER_BUDGET_S
+        )
+        assert after is not None, "existing viewer must keep receiving frames (no disruption)"
+        assert after.seq >= existing_seq_before, "existing viewer's stream must keep advancing"
+
+        # Sample the existing viewer a few times: it must remain OK throughout.
+        for _ in range(5):
+            sample = broadcaster.get_frame(CAMERA, existing_viewers[1])
+            assert sample.status in (FrameStatus.OK, FrameStatus.NO_FRAME), (
+                f"existing viewer disrupted: status={sample.status}"
+            )
+            assert sample.status != FrameStatus.DISCONNECTED
+            time.sleep(0.01)
+
+        assert broadcaster.viewer_count(CAMERA) == 3
+    finally:
+        # Tear down all viewers so the worker stops and the claim is released.
+        for viewer_id in existing_viewers:
+            broadcaster.unsubscribe(CAMERA, viewer_id)
+        if new_viewer is not None:
+            broadcaster.unsubscribe(CAMERA, new_viewer)
+        assert registry.open_count(CAMERA) == 0, "claim must be released once all viewers leave"
+
+
+@pytest.mark.parametrize("backend_kind", BACKEND_KINDS)
+def test_applied_setting_becomes_visible_within_five_frames(backend_kind):
+    """An applied setting is reflected in a published frame within 5 frames.
+
+    Feature: concurrent-camera-stream-viewing (task 12.3).
+    Validates: Requirement 5.2.
+
+    See the module docstring for how "visible within N frames" is modelled with the
+    settings-tagging mock: each grabbed frame encodes the controls in effect, so a
+    frame reflecting the applied values must appear within 5 published frames (seqs)
+    after ``apply_settings`` returns.
+    """
+    registry = ClaimRegistry()
+    created: List[MockCameraBackend] = []
+    broadcaster = _make_broadcaster(backend_kind, registry, created)
+
+    viewer_id = None
+    try:
+        result = broadcaster.subscribe(CAMERA, {"type": "Camera"})
+        assert result.accepted
+        viewer_id = result.viewer_id
+
+        # Ensure the session is running and producing (settings-untagged) frames.
+        first_frame, _ = _wait_for_ok_frame(
+            broadcaster, CAMERA, viewer_id, timeout_s=_STREAM_CONFIG.first_frame_timeout_s
+        )
+        assert first_frame is not None
+        # Before any apply, frames carry the "none" tag.
+        assert "settings=none" in first_frame.data.decode("utf-8")
+
+        # The valid control values to apply live. A distinctive gain value keeps the
+        # resulting tag unambiguous in the frame payload.
+        features = {"gain": 37.0, "exposure": 1250.0}
+        expected_tag = _settings_tag(MockCameraBackend._normalize_features(features))
+
+        # --- the operation under test: apply settings to the live session ---
+        accepted = broadcaster.apply_settings(CAMERA, features)
+        assert accepted == MockCameraBackend._normalize_features(features)
+
+        # Baseline: the latest published seq visible at the moment the apply returned.
+        baseline = broadcaster.get_frame(CAMERA, viewer_id)
+        assert baseline.status == FrameStatus.OK and baseline.frame is not None
+        baseline_seq = baseline.frame.seq
+
+        # Poll faster than the producer cadence so every new published frame (seq) is
+        # observed. Count distinct *new* seqs until one reflects the applied tag.
+        new_seqs: Set[int] = set()
+        visible_seq: Optional[int] = None
+        deadline = time.time() + 2.0  # ample: 5 frames at ~50 ms cadence is ~250 ms
+        while time.time() < deadline:
+            res = broadcaster.get_frame(CAMERA, viewer_id)
+            if res.status == FrameStatus.OK and res.frame is not None:
+                frame = res.frame
+                if frame.seq > baseline_seq:
+                    new_seqs.add(frame.seq)
+                    if expected_tag in frame.data.decode("utf-8"):
+                        visible_seq = frame.seq
+                        break
+            time.sleep(0.005)
+
+        assert visible_seq is not None, (
+            f"applied setting tag {expected_tag!r} never became visible within the budget"
+        )
+
+        # Number of published frames from baseline until the setting was visible: the
+        # count of new distinct seqs up to and including the one that reflected it.
+        frames_until_visible = len({s for s in new_seqs if s <= visible_seq})
+        assert frames_until_visible <= _MAX_FRAMES_TO_VISIBLE, (
+            f"applied setting took {frames_until_visible} published frames to become "
+            f"visible; Req 5.2 allows at most {_MAX_FRAMES_TO_VISIBLE}"
+        )
+
+        # The session stayed intact throughout the live apply (Req 5.2 context).
+        assert broadcaster._sessions[CAMERA].state == SessionState.RUNNING
+        assert registry.open_count(CAMERA) == 1
+    finally:
+        if viewer_id is not None:
+            broadcaster.unsubscribe(CAMERA, viewer_id)
+        assert registry.open_count(CAMERA) == 0

--- a/test/backend-test/utils/streaming/mock_camera_backend.py
+++ b/test/backend-test/utils/streaming/mock_camera_backend.py
@@ -1,0 +1,572 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared test double for the ``CameraBackend`` protocol.
+
+This module provides the in-memory, hardware-free backend used by the
+property-based and unit tests for the concurrent-camera-stream stack
+(tasks 3.x / 4.x / 5.x / 7.x / 8.x). It lets those tests exercise the
+``StreamSession`` / ``StreamBroadcaster`` / acquisition-worker logic
+deterministically, without real Aravis or GStreamer devices.
+
+The double:
+
+* satisfies the :class:`utils.streaming.backends.CameraBackend` Protocol
+  (``open`` / ``start_stream`` / ``grab`` / ``apply_features`` /
+  ``stop_stream`` / ``close``);
+* records the count **and order** of every lifecycle call so tests can assert
+  on the exact interaction sequence;
+* can simulate an ``open()`` failure (raise), a ``grab()`` timeout/failure
+  (return ``None``), a ``stop_stream()`` failure (raise), and — for the
+  disconnect/settings properties — ``close()`` / ``apply_features()`` failures;
+* serves a scripted / queued sequence of frames (or ``None``/exceptions) from
+  ``grab()``;
+* tracks whether a ``Device_Claim`` is currently open, optionally registering
+  with a shared :class:`ClaimRegistry` so tests can assert the single-claim
+  invariant (claim count is 0/1, never overlapping) across many cameras;
+* comes in mock **Aravis** and **GStreamer** variants (a ``backend_kind`` flag
+  plus :class:`MockAravisBackend` / :class:`MockGStreamerBackend` subclasses) so
+  backend-parity property tests can parametrize over both (Req 2.8).
+
+It also ships a controllable :class:`MockClock` so timing-dependent logic
+(staleness, freshness, first-frame timeout, stale sweep) is deterministic in
+session / broadcaster tests.
+
+The module imports only ``RawFrame`` from ``utils.streaming.backends`` (and
+``StreamConfig`` is intentionally not required), which is import-safe on hosts
+without the ``gi`` / GenICam / GStreamer stack because those backends keep their
+``gi`` imports lazy.
+
+Importing this raises nothing requiring native libraries:
+
+    >>> from mock_camera_backend import MockCameraBackend, MockClock
+"""
+from __future__ import annotations
+
+from collections import deque
+from typing import Callable, Deque, Iterable, List, Optional, Union
+
+from utils.streaming.backends import CameraBackend, RawFrame
+
+__all__ = [
+    "MockClock",
+    "ClaimRegistry",
+    "MockBackendError",
+    "MockOpenError",
+    "MockStopError",
+    "MockCloseError",
+    "MockApplyError",
+    "MockGrabError",
+    "MockCameraBackend",
+    "MockAravisBackend",
+    "MockGStreamerBackend",
+    "BACKEND_KINDS",
+    "MOCK_BACKEND_CLASSES",
+    "make_backend",
+    "make_raw_frame",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Injectable clock
+# --------------------------------------------------------------------------- #
+class MockClock:
+    """A controllable, monotonic time source for deterministic timing tests.
+
+    Replaces ``time.time`` / ``time.monotonic`` / ``time.sleep`` in the
+    session and broadcaster so freshness (``stale_after_s``), staleness
+    (``stale_timeout_s``), first-frame, and sweep windows can be advanced
+    explicitly rather than by waiting on a wall clock.
+
+    The clock never goes backwards. ``sleep`` advances the clock by the given
+    number of seconds instead of blocking, so worker/loop code under test runs
+    instantly while still observing the passage of (virtual) time.
+    """
+
+    def __init__(self, start: float = 0.0) -> None:
+        """Create a clock positioned at ``start`` (epoch seconds)."""
+        self._now = float(start)
+
+    def time(self) -> float:
+        """Return the current virtual time in seconds (epoch-style)."""
+        return self._now
+
+    # Alias so the clock can stand in for either ``time.time`` or
+    # ``time.monotonic`` wherever the code under test expects a callable.
+    def monotonic(self) -> float:
+        """Return the current virtual time; alias of :meth:`time`."""
+        return self._now
+
+    def __call__(self) -> float:
+        """Allow the clock instance itself to be used as a ``now()`` callable."""
+        return self._now
+
+    def advance(self, seconds: float) -> float:
+        """Advance the clock by ``seconds`` (must be non-negative). Returns now."""
+        if seconds < 0:
+            raise ValueError("MockClock cannot move backwards")
+        self._now += float(seconds)
+        return self._now
+
+    def set(self, value: float) -> float:
+        """Jump the clock to ``value`` seconds (must not move backwards)."""
+        value = float(value)
+        if value < self._now:
+            raise ValueError("MockClock cannot move backwards")
+        self._now = value
+        return self._now
+
+    def sleep(self, seconds: float) -> None:
+        """Stand-in for ``time.sleep`` that advances virtual time instead of blocking."""
+        self.advance(seconds)
+
+
+# --------------------------------------------------------------------------- #
+# Shared single-claim registry
+# --------------------------------------------------------------------------- #
+class ClaimRegistry:
+    """Tracks open ``Device_Claim``s per camera across backend instances.
+
+    Pass the same registry to every backend a test creates so the test can
+    assert the single-claim invariant (Property 1): at most one open claim per
+    camera at any time, never overlapping (a new claim is never opened before
+    the prior claim for the same camera is released).
+
+    The registry records, per ``camera_id``, the current number of open claims
+    and the maximum ever observed, and flags ``overlap_detected`` if a second
+    claim is ever acquired while one is still open.
+    """
+
+    def __init__(self) -> None:
+        self.open_claims: dict = {}        # camera_id -> current open count
+        self.max_concurrent: dict = {}     # camera_id -> max ever observed
+        self.overlap_detected: bool = False
+        self.released_without_open: bool = False
+
+    def acquire(self, camera_id: str) -> None:
+        """Record that a claim was opened for ``camera_id``."""
+        count = self.open_claims.get(camera_id, 0) + 1
+        self.open_claims[camera_id] = count
+        if count > 1:
+            self.overlap_detected = True
+        self.max_concurrent[camera_id] = max(self.max_concurrent.get(camera_id, 0), count)
+
+    def release(self, camera_id: str) -> None:
+        """Record that a claim was released for ``camera_id``."""
+        count = self.open_claims.get(camera_id, 0)
+        if count <= 0:
+            self.released_without_open = True
+            return
+        self.open_claims[camera_id] = count - 1
+
+    def open_count(self, camera_id: str) -> int:
+        """Return the number of claims currently open for ``camera_id``."""
+        return self.open_claims.get(camera_id, 0)
+
+    def total_open(self) -> int:
+        """Return the total number of open claims across all cameras."""
+        return sum(self.open_claims.values())
+
+    @property
+    def single_claim_ok(self) -> bool:
+        """True iff no overlap was ever seen and no claim is doubly open now."""
+        return (
+            not self.overlap_detected
+            and not self.released_without_open
+            and all(count <= 1 for count in self.open_claims.values())
+        )
+
+    def assert_single_claim(self) -> None:
+        """Assert the single-claim invariant held throughout (test convenience)."""
+        assert not self.overlap_detected, (
+            f"overlapping Device_Claim detected: {self.max_concurrent}"
+        )
+        assert not self.released_without_open, "claim released without a matching open"
+        for camera_id, count in self.open_claims.items():
+            assert count <= 1, f"camera {camera_id} has {count} concurrent claims"
+
+
+# --------------------------------------------------------------------------- #
+# Mock backend errors (import-safe; no gi / native dependency)
+# --------------------------------------------------------------------------- #
+class MockBackendError(Exception):
+    """Base error raised by :class:`MockCameraBackend` failure simulations."""
+
+
+class MockOpenError(MockBackendError):
+    """Raised by ``open()`` when an open failure is simulated (Req 7.6)."""
+
+
+class MockStopError(MockBackendError):
+    """Raised by ``stop_stream()`` when a stop failure is simulated (Req 3.5)."""
+
+
+class MockCloseError(MockBackendError):
+    """Raised by ``close()`` when a claim-release failure is simulated."""
+
+
+class MockApplyError(MockBackendError):
+    """Raised by ``apply_features()`` when a control-apply failure is simulated (Req 5.5)."""
+
+
+class MockGrabError(MockBackendError):
+    """A grab failure that surfaces as an exception (vs. a ``None`` timeout)."""
+
+
+# A scripted grab result: a frame, ``None`` (timeout/failure), a callable
+# producing one of those, or an exception instance/class to raise.
+GrabScriptItem = Union[
+    RawFrame,
+    None,
+    BaseException,
+    "type[BaseException]",
+    Callable[[], Optional[RawFrame]],
+]
+
+
+def make_raw_frame(seq: int = 0, width: int = 4, height: int = 4, data: Optional[bytes] = None) -> RawFrame:
+    """Build a deterministic :class:`RawFrame` for scripting ``grab()`` results.
+
+    When ``data`` is omitted, a unique, reproducible byte payload derived from
+    ``seq`` is generated so different scripted frames are byte-distinguishable
+    (useful for fan-out / latest-frame assertions).
+    """
+    if data is None:
+        data = f"frame-{seq}".encode("utf-8")
+    return RawFrame(data=data, width=width, height=height)
+
+
+# --------------------------------------------------------------------------- #
+# The mock backend
+# --------------------------------------------------------------------------- #
+class MockCameraBackend:
+    """In-memory :class:`CameraBackend` double for hardware-free tests.
+
+    Drives the same lifecycle the broadcaster/worker expect — ``open`` ->
+    ``start_stream`` -> repeated ``grab`` -> ``stop_stream`` -> ``close`` — while
+    recording every call and serving scripted frames. See the module docstring
+    for the full capability list.
+
+    Failure simulation knobs (all default to "no failure"):
+
+    * ``open_failures``: number of leading ``open()`` calls that raise before a
+      subsequent call succeeds (models the ``<= max_open_attempts`` retry budget).
+    * ``fail_open``: when True, **every** ``open()`` raises.
+    * ``fail_stop`` / ``fail_close`` / ``fail_apply``: when True the
+      corresponding call raises.
+
+    Frame scripting:
+
+    * ``frames``: an initial iterable of scripted ``grab()`` results.
+    * ``queue_frame`` / ``queue_frames`` / ``queue_timeout`` / ``queue_error``:
+      append results at runtime.
+    * ``default_grab``: result returned once the scripted queue is exhausted
+      (defaults to ``None``, i.e. a timeout, which the worker treats as a
+      disconnect signal).
+    """
+
+    #: Identifies which real backend family this double stands in for.
+    backend_kind: str = "generic"
+
+    def __init__(
+        self,
+        camera_id: str = "Fake_1",
+        *,
+        frames: Optional[Iterable[GrabScriptItem]] = None,
+        default_grab: GrabScriptItem = None,
+        open_failures: int = 0,
+        fail_open: bool = False,
+        fail_stop: bool = False,
+        fail_close: bool = False,
+        fail_apply: bool = False,
+        claim_registry: Optional[ClaimRegistry] = None,
+        clock: Optional[MockClock] = None,
+        open_error: Callable[[], BaseException] = None,
+        stop_error: Callable[[], BaseException] = None,
+        close_error: Callable[[], BaseException] = None,
+        apply_error: Callable[[], BaseException] = None,
+    ) -> None:
+        self.camera_id = camera_id
+
+        # --- call accounting ---------------------------------------------- #
+        self.call_log: List[str] = []
+        self.open_count = 0
+        self.open_failure_count = 0
+        self.close_count = 0
+        self.start_stream_count = 0
+        self.stop_stream_count = 0
+        self.grab_count = 0
+        self.apply_features_count = 0
+
+        # --- lifecycle state ---------------------------------------------- #
+        self.is_open = False
+        self.is_streaming = False
+        self.last_grab_timeout_ms: Optional[int] = None
+
+        # --- failure simulation ------------------------------------------- #
+        self._pending_open_failures = int(open_failures)
+        self.fail_open = bool(fail_open)
+        self.fail_stop = bool(fail_stop)
+        self.fail_close = bool(fail_close)
+        self.fail_apply = bool(fail_apply)
+        self._open_error = open_error or (lambda: MockOpenError(f"open failed for {camera_id}"))
+        self._stop_error = stop_error or (lambda: MockStopError(f"stop failed for {camera_id}"))
+        self._close_error = close_error or (lambda: MockCloseError(f"close failed for {camera_id}"))
+        self._apply_error = apply_error or (lambda: MockApplyError(f"apply failed for {camera_id}"))
+
+        # --- frame scripting ---------------------------------------------- #
+        self._grab_queue: Deque[GrabScriptItem] = deque(frames or [])
+        self.default_grab: GrabScriptItem = default_grab
+
+        # --- single-claim tracking + clock -------------------------------- #
+        self._claim_registry = claim_registry
+        self.clock = clock
+
+        # --- applied-feature history (for settings properties) ------------ #
+        self.applied_features: List[dict] = []
+        self.last_applied_features: Optional[dict] = None
+
+    # ----- CameraBackend protocol ----------------------------------------- #
+    def open(self) -> None:
+        """Acquire the single ``Device_Claim``; may raise to simulate failure.
+
+        Honors ``open_failures`` (raise N times then succeed) and ``fail_open``
+        (always raise). On success marks the claim open and registers with the
+        shared :class:`ClaimRegistry` if one was provided.
+        """
+        self._record("open")
+        self.open_count += 1
+
+        if self.fail_open or self._pending_open_failures > 0:
+            if self._pending_open_failures > 0:
+                self._pending_open_failures -= 1
+            self.open_failure_count += 1
+            raise self._open_error()
+
+        # A correct caller never re-opens an already-open claim; surface it so a
+        # bug in the code under test is caught rather than silently masked.
+        if self.is_open:
+            raise MockBackendError(
+                f"open() called on {self.camera_id} while a claim is already open"
+            )
+
+        self.is_open = True
+        if self._claim_registry is not None:
+            self._claim_registry.acquire(self.camera_id)
+
+    def start_stream(self) -> None:
+        """Begin continuous acquisition; requires an open claim."""
+        self._record("start_stream")
+        self.start_stream_count += 1
+        self._require_open()
+        self.is_streaming = True
+
+    def grab(self, timeout_ms: int) -> Optional[RawFrame]:
+        """Return the next scripted frame, ``None`` (timeout/failure), or raise.
+
+        Records the requested ``timeout_ms`` (so timeout-clamping behaviour can
+        be asserted). Pops the next scripted item; once the queue is drained the
+        ``default_grab`` result is used. A queued exception (class or instance)
+        is raised; a callable item is invoked to produce the result.
+        """
+        self._record("grab")
+        self.grab_count += 1
+        self.last_grab_timeout_ms = timeout_ms
+
+        if not self.is_open:
+            # No claim -> behaves like a failed grab (None), matching the real
+            # adapters which return None when the device handle is absent.
+            return None
+
+        item: GrabScriptItem = self._grab_queue.popleft() if self._grab_queue else self.default_grab
+        return self._resolve_grab_item(item)
+
+    def apply_features(self, features: dict) -> dict:
+        """Apply control values to the live stream; echoes accepted values.
+
+        Records each request. When ``fail_apply`` is set the call raises
+        (Property 19). Otherwise the supplied feature mapping is normalized to a
+        plain dict, stored, and returned as the device-accepted set.
+        """
+        self._record("apply_features")
+        self.apply_features_count += 1
+        self.applied_features.append(features)
+
+        if self.fail_apply:
+            raise self._apply_error()
+
+        accepted = self._normalize_features(features)
+        self.last_applied_features = accepted
+        return accepted
+
+    def stop_stream(self) -> None:
+        """Stop acquisition without releasing the claim; may raise (Req 3.5)."""
+        self._record("stop_stream")
+        self.stop_stream_count += 1
+        if self.fail_stop:
+            raise self._stop_error()
+        self.is_streaming = False
+
+    def close(self) -> None:
+        """Release the single ``Device_Claim``.
+
+        Even when a close failure is simulated the claim is treated as released
+        (state cleared and the registry decremented) *before* the error is
+        raised, mirroring the design's "force claim release on stop/close
+        failure" handling so the single-claim invariant is preserved.
+        """
+        self._record("close")
+        self.close_count += 1
+
+        was_open = self.is_open
+        self.is_open = False
+        self.is_streaming = False
+        if was_open and self._claim_registry is not None:
+            self._claim_registry.release(self.camera_id)
+
+        if self.fail_close:
+            raise self._close_error()
+
+    # ----- frame-scripting helpers ---------------------------------------- #
+    def queue_frame(self, frame: GrabScriptItem) -> "MockCameraBackend":
+        """Append a single scripted ``grab()`` result. Returns self for chaining."""
+        self._grab_queue.append(frame)
+        return self
+
+    def queue_frames(self, frames: Iterable[GrabScriptItem]) -> "MockCameraBackend":
+        """Append several scripted ``grab()`` results. Returns self for chaining."""
+        self._grab_queue.extend(frames)
+        return self
+
+    def queue_timeout(self, count: int = 1) -> "MockCameraBackend":
+        """Append ``count`` grab timeouts (``None`` results). Returns self."""
+        self._grab_queue.extend([None] * count)
+        return self
+
+    def queue_error(self, error: GrabScriptItem = MockGrabError) -> "MockCameraBackend":
+        """Append a grab that raises ``error``. Returns self for chaining."""
+        self._grab_queue.append(error)
+        return self
+
+    def script_sequence(self, count: int, *, start_seq: int = 0,
+                         width: int = 4, height: int = 4) -> List[RawFrame]:
+        """Queue ``count`` distinct frames and return the list that was queued.
+
+        Convenience for fan-out / cadence tests that need a known, ordered,
+        byte-distinguishable sequence of frames to verify against.
+        """
+        frames = [
+            make_raw_frame(seq=start_seq + i, width=width, height=height)
+            for i in range(count)
+        ]
+        self.queue_frames(frames)
+        return frames
+
+    @property
+    def remaining_frames(self) -> int:
+        """Number of scripted grab results not yet consumed."""
+        return len(self._grab_queue)
+
+    # ----- internal helpers ----------------------------------------------- #
+    def _record(self, name: str) -> None:
+        """Append ``name`` to the ordered call log."""
+        self.call_log.append(name)
+
+    def _require_open(self) -> None:
+        """Raise if the claim has not been acquired via :meth:`open`."""
+        if not self.is_open:
+            raise MockBackendError(
+                f"{self.camera_id} is not open; call open() before this operation"
+            )
+
+    @staticmethod
+    def _resolve_grab_item(item: GrabScriptItem) -> Optional[RawFrame]:
+        """Turn a scripted grab item into a concrete ``RawFrame`` / ``None`` / raise."""
+        if isinstance(item, type) and issubclass(item, BaseException):
+            raise item()
+        if isinstance(item, BaseException):
+            raise item
+        if callable(item) and not isinstance(item, RawFrame):
+            item = item()
+        if item is None or isinstance(item, RawFrame):
+            return item
+        raise TypeError(f"Unsupported scripted grab item: {item!r}")
+
+    @staticmethod
+    def _normalize_features(features) -> dict:
+        """Normalize an ``apply_features`` argument into a plain accepted dict."""
+        if features is None:
+            return {}
+        if isinstance(features, dict):
+            return dict(features)
+        if isinstance(features, list):
+            accepted: dict = {}
+            for entry in features:
+                if not isinstance(entry, dict):
+                    continue
+                name = entry.get("feature")
+                if name is not None:
+                    accepted[name] = entry.get("value")
+            return accepted
+        # Fall back to a best-effort wrapper for unexpected shapes.
+        return {"value": features}
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return (
+            f"{type(self).__name__}(camera_id={self.camera_id!r}, kind={self.backend_kind!r}, "
+            f"open={self.is_open}, streaming={self.is_streaming}, "
+            f"opens={self.open_count}, grabs={self.grab_count}, closes={self.close_count})"
+        )
+
+
+class MockAravisBackend(MockCameraBackend):
+    """Mock standing in for the Aravis (GenICam / USB3Vision) backend (Req 2.8)."""
+
+    backend_kind = "aravis"
+
+
+class MockGStreamerBackend(MockCameraBackend):
+    """Mock standing in for the GStreamer (NVIDIA CSI / ICAM) backend (Req 2.8)."""
+
+    backend_kind = "gstreamer"
+
+
+# Parametrization helpers so backend-parity property tests can run over both
+# families (e.g. ``@pytest.mark.parametrize("backend_cls", MOCK_BACKEND_CLASSES.values())``).
+BACKEND_KINDS = ("aravis", "gstreamer")
+MOCK_BACKEND_CLASSES = {
+    "aravis": MockAravisBackend,
+    "gstreamer": MockGStreamerBackend,
+}
+
+
+def make_backend(kind: str = "aravis", camera_id: str = "Fake_1", **kwargs) -> MockCameraBackend:
+    """Construct a mock backend of the requested ``kind`` ("aravis"|"gstreamer").
+
+    Any additional keyword arguments are forwarded to
+    :class:`MockCameraBackend` (e.g. ``claim_registry``, ``frames``,
+    ``open_failures``, ``fail_stop``).
+    """
+    try:
+        cls = MOCK_BACKEND_CLASSES[kind]
+    except KeyError:
+        raise ValueError(f"unknown backend kind {kind!r}; expected one of {BACKEND_KINDS}")
+    return cls(camera_id, **kwargs)
+
+
+# Runtime sanity: the mock must satisfy the runtime-checkable CameraBackend
+# Protocol. Performed at import so a drift in the protocol surface is caught by
+# any test that imports this module.
+assert isinstance(
+    MockCameraBackend("__protocol_check__"), CameraBackend
+), "MockCameraBackend does not satisfy the CameraBackend protocol"

--- a/test/backend-test/utils/streaming/test_backend_adapters.py
+++ b/test/backend-test/utils/streaming/test_backend_adapters.py
@@ -1,0 +1,523 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Example/unit tests for the concrete ``CameraBackend`` adapters (Task 2.5).
+
+Feature: concurrent-camera-stream-viewing.
+
+These exercise the real :class:`~utils.streaming.backends.AravisBackend` and
+:class:`~utils.streaming.backends.GStreamerBackend` adapter *logic* —
+``open() -> start_stream() -> grab() -> stop_stream() -> close()`` — without any
+real hardware or the native ``gi`` / Aravis / GStreamer stack (Req 2.8).
+
+Both adapters defer all native imports to module-level helpers
+(``backends._load_aravis_runtime`` / ``backends._load_gstreamer_runtime``), each
+returning a ``SimpleNamespace`` of the runtime symbols the adapter uses. The
+tests inject a hand-built namespace of fakes in place of those helpers via
+``monkeypatch``, so the adapter runs against scripted fakes (fake ``Camera`` /
+fake ``Gst`` + appsink). This keeps ``backends.py`` import-safe on a bare
+checkout and lets the happy path, the bounded open-retry budget (<= 3 attempts,
+Req 7.6), and the open-failure-raises path (so the broadcaster can reject the
+subscribe) all be asserted deterministically.
+
+These are example/unit tests (not property-based tests).
+"""
+from __future__ import annotations
+
+import sys
+import threading
+from collections import deque
+from types import SimpleNamespace
+
+import pytest
+
+# ``backends`` is import-safe without the native stack because its gi imports
+# are lazy (see _load_aravis_runtime / _load_gstreamer_runtime).
+from utils.streaming import backends
+from utils.streaming.backends import AravisBackend, GStreamerBackend, RawFrame
+from utils.streaming.models import StreamConfig
+
+
+# --------------------------------------------------------------------------- #
+# Shared helpers
+# --------------------------------------------------------------------------- #
+class _FakeTimer:
+    """Stand-in for ``metrics.collector.Timer`` (a no-op context manager)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.metric_name = kwargs.get("metric_name")
+
+    def __enter__(self) -> "_FakeTimer":
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        return False
+
+
+# --------------------------------------------------------------------------- #
+# Aravis fakes
+# --------------------------------------------------------------------------- #
+class _FakeArvBuffer:
+    """A scripted Aravis buffer returned by ``stream.timeout_pop_buffer``."""
+
+    def __init__(self, data: bytes, width: int, height: int, status) -> None:
+        self._data = data
+        self._width = width
+        self._height = height
+        self._status = status
+
+    def get_status(self):
+        return self._status
+
+    def get_data(self) -> bytes:
+        return self._data
+
+    def get_image_width(self) -> int:
+        return self._width
+
+    def get_image_height(self) -> int:
+        return self._height
+
+
+class _FakeArvStream:
+    """Fake Aravis stream serving a scripted queue of buffers (``None`` = timeout)."""
+
+    def __init__(self, buffers) -> None:
+        self._buffers = deque(buffers)
+        self.last_timeout_us = None
+        self.pop_count = 0
+
+    def timeout_pop_buffer(self, timeout_us):
+        self.last_timeout_us = timeout_us
+        self.pop_count += 1
+        return self._buffers.popleft() if self._buffers else None
+
+
+class _FakeAravisCamera:
+    """Fake of ``utils.camera_manager.Camera`` for driving ``AravisBackend``.
+
+    Records the lifecycle calls the adapter makes (trigger / set_buffer /
+    acquisition start-stop / disconnect / feature apply) so tests can assert the
+    exact device interaction sequence.
+    """
+
+    def __init__(self, camera_id, *, connected, enums, success_status, buffers) -> None:
+        self.camera_id = camera_id
+        self._connected = connected
+        self._enums = enums
+        self.trigger_count = 0
+        self.set_buffer_count = 0
+        self.status_log = []
+        self.acq_started = False
+        self.acq_stopped = False
+        self.disconnected = False
+        self.last_config = None
+        self.applied_features = []
+        # The native device handle only exists once connected; ``grab`` guards on
+        # ``cam.camera is None`` so an unopened camera yields no frame.
+        self.camera = SimpleNamespace(software_trigger=self._software_trigger) if connected else None
+        self.stream = _FakeArvStream(buffers)
+        self._lock = threading.Lock()
+
+    def _software_trigger(self) -> None:
+        self.trigger_count += 1
+
+    def get_status(self):
+        if self._connected:
+            return SimpleNamespace(status=self._enums.CONNECTED, error=None)
+        return SimpleNamespace(status=self._enums.DISCONNECTED, error="camera not connected")
+
+    def set_buffer(self) -> None:
+        self.set_buffer_count += 1
+
+    def update_camera_status(self, status, message=None) -> None:
+        self.status_log.append((status, message))
+
+    def start_acquisition(self, config) -> None:
+        self.acq_started = True
+        self.last_config = config
+
+    def stop_acquisition(self) -> None:
+        self.acq_stopped = True
+
+    def disconnect(self) -> None:
+        self.disconnected = True
+
+    def apply_device_features(self, feature_list) -> dict:
+        self.applied_features.append(feature_list)
+        return {entry.get("feature"): entry.get("value") for entry in feature_list}
+
+
+def _build_aravis_runtime(*, connect_after=1, buffers=None):
+    """Build a fake Aravis runtime namespace for ``backends._load_aravis_runtime``.
+
+    Args:
+        connect_after: 1-based attempt number on which a freshly constructed
+            ``Camera`` first reports CONNECTED (so ``connect_after=3`` models two
+            failed opens followed by success; a large value never connects).
+        buffers: scripted ``grab()`` buffers served by the camera's stream.
+    """
+    buffer_status = SimpleNamespace(SUCCESS="SUCCESS", ERROR="ERROR")
+    aravis = SimpleNamespace(BufferStatus=buffer_status)
+    enums = SimpleNamespace(CONNECTED="CONNECTED", DISCONNECTED="DISCONNECTED")
+
+    class AravisCameraException(Exception):
+        pass
+
+    state = {"construct_count": 0}
+    cameras = []
+
+    def camera_factory(camera_id):
+        state["construct_count"] += 1
+        connected = state["construct_count"] >= connect_after
+        cam = _FakeAravisCamera(
+            camera_id,
+            connected=connected,
+            enums=enums,
+            success_status=buffer_status.SUCCESS,
+            buffers=list(buffers) if (buffers and connected) else [],
+        )
+        cameras.append(cam)
+        return cam
+
+    rt = SimpleNamespace(
+        Aravis=aravis,
+        Camera=camera_factory,
+        CONFIG_FEATURE_MAP={},
+        CameraStatusEnum=enums,
+        Timer=_FakeTimer,
+        AravisCameraException=AravisCameraException,
+    )
+    rt._state = state
+    rt._cameras = cameras
+    return rt
+
+
+# --------------------------------------------------------------------------- #
+# GStreamer fakes
+# --------------------------------------------------------------------------- #
+class _FakeGstStructure:
+    def __init__(self, width, height) -> None:
+        self._width = width
+        self._height = height
+
+    def get_int(self, name):
+        if name == "width":
+            return (True, self._width)
+        if name == "height":
+            return (True, self._height)
+        return (False, 0)
+
+
+class _FakeGstCaps:
+    def __init__(self, width, height) -> None:
+        self._structure = _FakeGstStructure(width, height)
+
+    def get_size(self) -> int:
+        return 1
+
+    def get_structure(self, index):
+        return self._structure
+
+
+class _FakeGstBuffer:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+        self.unmap_count = 0
+
+    def map(self, flags):
+        return (True, SimpleNamespace(data=self._data))
+
+    def unmap(self, map_info) -> None:
+        self.unmap_count += 1
+
+
+class _FakeGstSample:
+    """A scripted appsink sample (frame)."""
+
+    def __init__(self, data: bytes, width: int, height: int) -> None:
+        self._buffer = _FakeGstBuffer(data)
+        self._caps = _FakeGstCaps(width, height)
+
+    def get_buffer(self):
+        return self._buffer
+
+    def get_caps(self):
+        return self._caps
+
+
+class _FakeAppsink:
+    """Fake appsink serving a scripted queue of samples (``None`` = timeout)."""
+
+    def __init__(self, samples) -> None:
+        self._samples = deque(samples)
+        self.props = {}
+        self.last_timeout_ns = None
+        self.pull_count = 0
+
+    def set_property(self, key, value) -> None:
+        self.props[key] = value
+
+    def try_pull_sample(self, timeout_ns):
+        self.last_timeout_ns = timeout_ns
+        self.pull_count += 1
+        return self._samples.popleft() if self._samples else None
+
+
+class _FakeGstPipeline:
+    """Fake GStreamer pipeline; ``ok=False`` makes the PAUSED preroll fail."""
+
+    def __init__(self, *, ok, samples, state, state_change_return) -> None:
+        self._ok = ok
+        self._state = state
+        self._scr = state_change_return
+        self._appsink = _FakeAppsink(samples)
+        self.state_calls = []
+
+    def get_by_name(self, name):
+        return self._appsink if name == "appsink" else None
+
+    def set_state(self, state):
+        self.state_calls.append(state)
+        if not self._ok and state == self._state.PAUSED:
+            return self._scr.FAILURE
+        return self._scr.SUCCESS
+
+    def get_state(self, timeout_ns):
+        if not self._ok:
+            return (self._scr.FAILURE, self._state.NULL, self._state.PAUSED)
+        return (self._scr.SUCCESS, self._state.PAUSED, self._state.PAUSED)
+
+
+def _build_gstreamer_runtime(*, fail_until=0, samples=None):
+    """Build a fake GStreamer runtime namespace for ``_load_gstreamer_runtime``.
+
+    Args:
+        fail_until: number of leading ``parse_launch`` pipelines whose PAUSED
+            preroll fails (so ``fail_until=2`` models two failed opens then a
+            success; a large value never opens).
+        samples: scripted ``grab()`` samples served by the appsink.
+    """
+    state_change_return = SimpleNamespace(
+        FAILURE="FAILURE", SUCCESS="SUCCESS", NO_PREROLL="NO_PREROLL", ASYNC="ASYNC"
+    )
+    gst_state = SimpleNamespace(NULL="NULL", READY="READY", PAUSED="PAUSED", PLAYING="PLAYING")
+    map_flags = SimpleNamespace(READ="READ")
+
+    class PipelineExecutionException(Exception):
+        pass
+
+    state = {"launch_count": 0}
+    pipelines = []
+
+    def parse_launch(pipeline_str):
+        state["launch_count"] += 1
+        ok = state["launch_count"] > fail_until
+        pipeline = _FakeGstPipeline(
+            ok=ok,
+            samples=list(samples) if (samples and ok) else [],
+            state=gst_state,
+            state_change_return=state_change_return,
+        )
+        pipelines.append(pipeline)
+        return pipeline
+
+    gst = SimpleNamespace(
+        State=gst_state,
+        StateChangeReturn=state_change_return,
+        MapFlags=map_flags,
+        SECOND=1_000_000_000,
+        init=lambda *a, **k: None,
+        parse_launch=parse_launch,
+    )
+    utils_ns = SimpleNamespace(get_gst_plugins_path=lambda: "/tmp/fake/gst/plugins")
+
+    rt = SimpleNamespace(
+        Gst=gst,
+        GstApp=SimpleNamespace(),
+        GLib=SimpleNamespace(),
+        GstPipelineBuilder=object,
+        Timer=_FakeTimer,
+        PipelineExecutionException=PipelineExecutionException,
+        utils=utils_ns,
+    )
+    rt._state = state
+    rt._pipelines = pipelines
+    return rt
+
+
+# --------------------------------------------------------------------------- #
+# AravisBackend tests
+# --------------------------------------------------------------------------- #
+def test_aravis_backend_subscribe_grab_close_happy_path(monkeypatch):
+    """open -> start_stream -> grab -> stop_stream -> close drives the device and yields a RawFrame."""
+    payload = b"aravis-frame-bytes"
+    buffer = _FakeArvBuffer(payload, width=64, height=48, status="SUCCESS")
+    rt = _build_aravis_runtime(connect_after=1, buffers=[buffer])
+    monkeypatch.setattr(backends, "_load_aravis_runtime", lambda: rt)
+
+    backend = AravisBackend("Fake_1", image_source_config={"gain": 1.0})
+
+    backend.open()
+    assert rt._state["construct_count"] == 1
+    cam = rt._cameras[-1]
+
+    backend.start_stream()
+    assert cam.acq_started is True
+    assert cam.last_config == {"gain": 1.0}
+
+    frame = backend.grab(timeout_ms=2000)
+    assert isinstance(frame, RawFrame)
+    assert frame.data == payload
+    assert frame.width == 64
+    assert frame.height == 48
+    # timeout is converted ms -> us, the camera is software-triggered, and the
+    # stream is re-armed with a fresh buffer for the next grab.
+    assert cam.stream.last_timeout_us == 2000 * 1000
+    assert cam.trigger_count == 1
+    assert cam.set_buffer_count == 1
+    assert ("CONNECTED", None) in cam.status_log
+
+    backend.stop_stream()
+    assert cam.acq_stopped is True
+
+    backend.close()
+    assert cam.disconnected is True
+    assert backend._camera is None
+
+
+def test_aravis_grab_timeout_returns_none_and_marks_disconnected(monkeypatch):
+    """A grab that pops no buffer returns None (disconnect signal) and flags DISCONNECTED."""
+    rt = _build_aravis_runtime(connect_after=1, buffers=[])  # empty -> pop returns None
+    monkeypatch.setattr(backends, "_load_aravis_runtime", lambda: rt)
+
+    backend = AravisBackend("Fake_1")
+    backend.open()
+    backend.start_stream()
+
+    assert backend.grab(timeout_ms=1000) is None
+    cam = rt._cameras[-1]
+    assert any(status == "DISCONNECTED" for status, _ in cam.status_log)
+
+
+def test_aravis_open_retries_then_succeeds_within_budget(monkeypatch):
+    """open retries the connect (<= max_open_attempts) and succeeds on the 3rd try (Req 7.6)."""
+    rt = _build_aravis_runtime(connect_after=3, buffers=[])
+    monkeypatch.setattr(backends, "_load_aravis_runtime", lambda: rt)
+
+    backend = AravisBackend("Fake_1", stream_config=StreamConfig(max_open_attempts=3))
+    backend.open()
+
+    # Exactly three Camera constructions: two not-connected then one connected.
+    assert rt._state["construct_count"] == 3
+    assert backend._camera is not None
+
+
+def test_aravis_open_failure_raises_after_max_attempts(monkeypatch):
+    """When the camera never connects, open raises after <= 3 attempts so subscribe can be rejected."""
+    rt = _build_aravis_runtime(connect_after=999, buffers=[])
+    monkeypatch.setattr(backends, "_load_aravis_runtime", lambda: rt)
+
+    backend = AravisBackend("Fake_1", stream_config=StreamConfig(max_open_attempts=3))
+
+    with pytest.raises(rt.AravisCameraException):
+        backend.open()
+
+    assert rt._state["construct_count"] == 3
+    assert backend._camera is None
+
+
+# --------------------------------------------------------------------------- #
+# GStreamerBackend tests
+# --------------------------------------------------------------------------- #
+def test_gstreamer_backend_subscribe_grab_close_happy_path(monkeypatch):
+    """open -> start_stream -> grab -> stop_stream -> close drives the pipeline and yields a RawFrame."""
+    payload = b"gstreamer-frame-bytes"
+    sample = _FakeGstSample(payload, width=128, height=72)
+    rt = _build_gstreamer_runtime(fail_until=0, samples=[sample])
+    monkeypatch.setattr(backends, "_load_gstreamer_runtime", lambda: rt)
+
+    backend = GStreamerBackend("Fake_2", pipeline_description="videotestsrc")
+
+    backend.open()
+    assert rt._state["launch_count"] == 1
+    pipeline = rt._pipelines[-1]
+    # appsink is configured for drop-to-latest, pull-based acquisition.
+    assert pipeline._appsink.props == {
+        "sync": False,
+        "max-buffers": 1,
+        "drop": True,
+        "emit-signals": False,
+    }
+
+    backend.start_stream()
+    assert "PLAYING" in pipeline.state_calls
+
+    frame = backend.grab(timeout_ms=1000)
+    assert isinstance(frame, RawFrame)
+    assert frame.data == payload
+    assert frame.width == 128
+    assert frame.height == 72
+    # timeout converted ms -> ns for the bounded appsink pull.
+    assert pipeline._appsink.last_timeout_ns == 1000 * 1_000_000
+
+    backend.stop_stream()
+    assert pipeline.state_calls.count("PAUSED") >= 1
+
+    backend.close()
+    assert "NULL" in pipeline.state_calls
+    assert backend._pipeline is None
+    assert backend._appsink is None
+
+
+def test_gstreamer_grab_timeout_returns_none(monkeypatch):
+    """A pull that yields no sample returns None so the worker can treat it as a disconnect."""
+    rt = _build_gstreamer_runtime(fail_until=0, samples=[])  # no samples -> pull returns None
+    monkeypatch.setattr(backends, "_load_gstreamer_runtime", lambda: rt)
+
+    backend = GStreamerBackend("Fake_2", pipeline_description="videotestsrc")
+    backend.open()
+    backend.start_stream()
+
+    assert backend.grab(timeout_ms=1000) is None
+
+
+def test_gstreamer_open_retries_then_succeeds_within_budget(monkeypatch):
+    """open retries the preroll (<= max_open_attempts) and succeeds on the 3rd try (Req 7.6)."""
+    sample = _FakeGstSample(b"x", width=8, height=8)
+    rt = _build_gstreamer_runtime(fail_until=2, samples=[sample])
+    monkeypatch.setattr(backends, "_load_gstreamer_runtime", lambda: rt)
+
+    backend = GStreamerBackend(
+        "Fake_2", pipeline_description="videotestsrc", stream_config=StreamConfig(max_open_attempts=3)
+    )
+    backend.open()
+
+    assert rt._state["launch_count"] == 3
+    assert backend._pipeline is not None
+
+
+def test_gstreamer_open_failure_raises_after_max_attempts(monkeypatch):
+    """When the preroll always fails, open raises after <= 3 attempts so subscribe can be rejected."""
+    rt = _build_gstreamer_runtime(fail_until=999, samples=[])
+    monkeypatch.setattr(backends, "_load_gstreamer_runtime", lambda: rt)
+
+    backend = GStreamerBackend(
+        "Fake_2", pipeline_description="videotestsrc", stream_config=StreamConfig(max_open_attempts=3)
+    )
+
+    with pytest.raises(rt.PipelineExecutionException):
+        backend.open()
+
+    assert rt._state["launch_count"] == 3
+    assert backend._pipeline is None

--- a/test/backend-test/utils/streaming/test_broadcaster_claim.py
+++ b/test/backend-test/utils/streaming/test_broadcaster_claim.py
@@ -1,0 +1,298 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Stateful property-based test for the single device-claim invariant.
+
+Feature: concurrent-camera-stream-viewing, Property 1: Single device-claim
+invariant — for any interleaving of subscribe / unsubscribe / stale-sweep /
+disconnect operations across one or more cameras, the number of open
+``Device_Claim``s for a camera is:
+
+* exactly **1** while that camera has at least one active viewer (a running
+  session),
+* **0** when it has none,
+* **never greater than 1**, and
+* never *overlapping* — a new claim is never opened for a camera before the
+  prior claim for that same camera has been released.
+
+Validates: Requirements 1.2, 2.1, 3.4, 7.7.
+
+How the machine exercises the broadcaster
+-----------------------------------------
+A :class:`hypothesis.stateful.RuleBasedStateMachine` drives a real
+:class:`StreamBroadcaster` over a randomized sequence of rules:
+
+* ``subscribe(camera)`` — register a viewer (start-on-first-viewer opens the
+  single claim).
+* ``unsubscribe(viewer)`` — drop a previously-issued viewer (stop-on-last-viewer
+  releases the claim).
+* ``advance_clock`` — move the injected clock forward so stale-sweep windows can
+  elapse deterministically.
+* ``sweep_stale_viewers`` — run the broadcaster's stale-viewer sweep at the
+  current clock time (emptied sessions stop and release their claim).
+* ``disconnect(camera)`` — simulate a device drop by marking the session ERROR
+  (exactly what the acquisition worker does on a failed/timed-out grab) and then
+  calling ``get_frame`` to trigger the disconnection cascade, which stops the
+  session and releases the claim before reporting DISCONNECTED.
+
+The broadcaster is wired with an injected ``backend_factory`` that builds the
+shared :class:`MockCameraBackend` registered against one shared
+:class:`ClaimRegistry`, so the machine can read the true open-claim count per
+camera, and an injected :class:`MockClock` so the stale-sweep is deterministic.
+
+Test-only technique (no production code changed)
+------------------------------------------------
+In production the broadcaster starts a real :class:`AcquisitionWorker` on a
+daemon thread when a session starts (``grab -> publish`` loop). That thread is
+irrelevant to the claim invariant and would make per-rule claim counting racy
+(and would burn real wall-clock time on its rate-ceiling sleeps). For
+determinism this test patches the ``AcquisitionWorker`` symbol *in the
+broadcaster module* with a no-op stub for the duration of each machine run (see
+:class:`_StubAcquisitionWorker`). This is a pure test seam: the broadcaster's
+subscribe / unsubscribe / sweep / disconnect-cascade logic — and therefore every
+``open()`` / ``close()`` that moves the device claim — runs completely unchanged.
+The stub marks the session RUNNING on start (mirroring the worker after its
+first frame) so claim/viewer assertions reflect a live session. Disconnects are
+modelled by setting ``SessionState.ERROR`` directly, which is exactly the state
+transition the real worker performs on a disconnect before the broadcaster
+cascade tears the session down.
+"""
+from __future__ import annotations
+
+import unittest.mock as mock
+from typing import Optional
+
+from hypothesis import settings
+from hypothesis import strategies as st
+from hypothesis.stateful import (
+    Bundle,
+    RuleBasedStateMachine,
+    consumes,
+    invariant,
+    multiple,
+    rule,
+)
+
+import utils.streaming.broadcaster as broadcaster_module
+from mock_camera_backend import ClaimRegistry, MockClock, make_backend
+from utils.streaming.broadcaster import StreamBroadcaster
+from utils.streaming.models import SessionState, StreamConfig
+
+# The small fixed set of physical cameras the machine quantifies over. Using
+# more than one camera exercises that the single-claim invariant holds
+# *per camera* and that operations on one camera never disturb another.
+CAMERAS = ("cam_a", "cam_b", "cam_c")
+
+# Keep max_viewers small so the viewer-limit branch is reached within a run
+# (the limit path must also preserve the single-claim invariant). stale window
+# kept modest so advance_clock can cross it.
+_STREAM_CONFIG = StreamConfig(max_viewers=4, stale_timeout_s=30)
+
+
+class _StubAcquisitionWorker:
+    """No-op stand-in for ``AcquisitionWorker`` (test-only; see module docstring).
+
+    Matches the construction/usage contract the broadcaster relies on
+    (``AcquisitionWorker(session, stream_config=..., time_fn=...)`` then
+    ``start()`` / ``stop()`` / ``join()``) but runs no thread and performs no
+    grabs, so claim counting is deterministic. ``start()`` marks the session
+    RUNNING to mirror the real worker after its first published frame.
+    """
+
+    def __init__(self, session, *, stream_config=None, time_fn=None, **kwargs) -> None:
+        self.session = session
+
+    def start(self):
+        # Mirror the real worker transitioning the session to RUNNING once the
+        # first frame is published; no device interaction occurs in the stub.
+        self.session.state = SessionState.RUNNING
+        return None
+
+    def stop(self) -> None:
+        return None
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        return None
+
+
+class SingleClaimMachine(RuleBasedStateMachine):
+    """Drives a real broadcaster and asserts the single-claim invariant.
+
+    Concrete per-backend subclasses set :attr:`backend_kind` so the property is
+    checked for both the mock Aravis and mock GStreamer backends (Req 2.8 parity).
+    """
+
+    #: Overridden by the concrete subclasses below ("aravis" | "gstreamer").
+    backend_kind = "aravis"
+
+    # Bundle of issued viewers: each entry is a (camera_id, viewer_id) pair that
+    # the broadcaster accepted. Entries may become stale (their session was
+    # swept or disconnected); unsubscribing a stale viewer is a harmless no-op.
+    viewers = Bundle("viewers")
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Patch the worker symbol the broadcaster module resolves at session
+        # start, for the lifetime of this machine run only.
+        self._worker_patch = mock.patch.object(
+            broadcaster_module, "AcquisitionWorker", _StubAcquisitionWorker
+        )
+        self._worker_patch.start()
+
+        self.clock = MockClock(start=1_000.0)
+        self.registry = ClaimRegistry()
+
+        def backend_factory(camera_id, config):
+            # Every backend shares the one registry + clock so the machine can
+            # read the true per-camera open-claim count and stale-sweep is
+            # deterministic. Backends open successfully (open-failure handling is
+            # Property 7, out of scope here).
+            return make_backend(
+                self.backend_kind,
+                camera_id,
+                claim_registry=self.registry,
+                clock=self.clock,
+            )
+
+        self.broadcaster = StreamBroadcaster(
+            stream_config=_STREAM_CONFIG,
+            backend_factory=backend_factory,
+            time_fn=self.clock.time,
+        )
+
+    # --- rules ------------------------------------------------------------
+
+    @rule(target=viewers, camera=st.sampled_from(CAMERAS))
+    def subscribe(self, camera):
+        """Subscribe a viewer; record accepted viewers, ignore limit rejections."""
+        result = self.broadcaster.subscribe(camera)
+        if result.accepted:
+            return (camera, result.viewer_id)
+        # Rejected (viewer_limit at the cap): nothing enters the bundle. The
+        # rejection must not have created/opened a claim — checked by @invariant.
+        return multiple()
+
+    @rule(entry=consumes(viewers))
+    def unsubscribe(self, entry):
+        """Unsubscribe a previously-issued viewer (stop-on-last releases claim)."""
+        camera, viewer_id = entry
+        self.broadcaster.unsubscribe(camera, viewer_id)
+
+    @rule(seconds=st.floats(min_value=0.0, max_value=60.0, allow_nan=False, allow_infinity=False))
+    def advance_clock(self, seconds):
+        """Advance the injected clock so stale windows can elapse deterministically."""
+        self.clock.advance(seconds)
+
+    @rule()
+    def sweep_stale_viewers(self):
+        """Sweep stale viewers at the current clock time; emptied sessions stop."""
+        self.broadcaster.sweep_stale_viewers(self.clock.time())
+
+    @rule(camera=st.sampled_from(CAMERAS))
+    def disconnect(self, camera):
+        """Simulate a device disconnect and trigger the broadcaster cascade.
+
+        Mark the (running) session ERROR — exactly the transition the real
+        acquisition worker performs on a failed/timed-out grab — then call
+        ``get_frame`` so the broadcaster cascade stops the session and releases
+        the single claim before returning DISCONNECTED.
+        """
+        session = self.broadcaster._sessions.get(camera)
+        if session is None:
+            return
+        session.state = SessionState.ERROR
+        # Any viewer id works: the ERROR/DISCONNECTED branch is evaluated before
+        # the per-viewer heartbeat lookup.
+        self.broadcaster.get_frame(camera, "disconnect-probe")
+
+    # --- invariant --------------------------------------------------------
+
+    @invariant()
+    def single_claim_invariant(self):
+        """After every rule: per-camera claim is 0/1, ==1 iff a viewer is active,
+        never > 1, and no overlapping claims were ever observed.
+        """
+        for camera in CAMERAS:
+            claim_count = self.registry.open_count(camera)
+            viewer_count = self.broadcaster.viewer_count(camera)
+
+            # Never more than one open claim per camera.
+            assert claim_count <= 1, (
+                f"camera {camera}: {claim_count} concurrent Device_Claims (> 1)"
+            )
+            assert claim_count in (0, 1), (
+                f"camera {camera}: unexpected claim count {claim_count}"
+            )
+
+            # Exactly one claim iff the camera currently has >= 1 active viewer
+            # (i.e. a live session); zero claims when it has none.
+            if viewer_count >= 1:
+                assert claim_count == 1, (
+                    f"camera {camera}: {viewer_count} viewer(s) but {claim_count} claim(s) "
+                    f"(expected exactly 1 open claim for an active camera)"
+                )
+            else:
+                assert claim_count == 0, (
+                    f"camera {camera}: no viewers but {claim_count} claim(s) "
+                    f"(expected the claim to be released)"
+                )
+
+        # Global, history-aware checks: a second claim was never acquired while
+        # one was still open (no overlap), and no claim was released without a
+        # matching open. This is the "no overlapping claims" guarantee (Req 7.7).
+        assert not self.registry.overlap_detected, (
+            f"overlapping Device_Claim observed at some point: {self.registry.max_concurrent}"
+        )
+        assert not self.registry.released_without_open, (
+            "a claim was released without a matching open"
+        )
+        assert self.registry.single_claim_ok
+        assert all(
+            peak <= 1 for peak in self.registry.max_concurrent.values()
+        ), f"a camera reached > 1 concurrent claims at some point: {self.registry.max_concurrent}"
+
+    def teardown(self) -> None:
+        """Release any remaining sessions and remove the worker patch."""
+        try:
+            for camera in CAMERAS:
+                session = self.broadcaster._sessions.get(camera)
+                if session is not None:
+                    # Drain viewers so the broadcaster stops the session and
+                    # releases the claim through its normal stop-on-last path.
+                    for viewer_id in list(session.viewers.keys()):
+                        self.broadcaster.unsubscribe(camera, viewer_id)
+        finally:
+            self._worker_patch.stop()
+
+
+class SingleClaimMachineAravis(SingleClaimMachine):
+    """Single-claim invariant over the mock Aravis backend (Req 2.8 parity)."""
+
+    backend_kind = "aravis"
+
+
+class SingleClaimMachineGStreamer(SingleClaimMachine):
+    """Single-claim invariant over the mock GStreamer backend (Req 2.8 parity)."""
+
+    backend_kind = "gstreamer"
+
+
+# Feature: concurrent-camera-stream-viewing, Property 1: Single device-claim invariant
+# Validates: Requirements 1.2, 2.1, 3.4, 7.7
+_MACHINE_SETTINGS = settings(max_examples=120, stateful_step_count=40, deadline=None)
+
+TestSingleClaimInvariantAravis = SingleClaimMachineAravis.TestCase
+TestSingleClaimInvariantAravis.settings = _MACHINE_SETTINGS
+
+TestSingleClaimInvariantGStreamer = SingleClaimMachineGStreamer.TestCase
+TestSingleClaimInvariantGStreamer.settings = _MACHINE_SETTINGS

--- a/test/backend-test/utils/streaming/test_broadcaster_disconnect.py
+++ b/test/backend-test/utils/streaming/test_broadcaster_disconnect.py
@@ -1,0 +1,226 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based test for the disconnection cascade.
+
+Feature: concurrent-camera-stream-viewing, Property 14: Disconnection cascade —
+for any session with any set of subscribed viewers, when a grab times out / fails
+such that the camera is marked disconnected, the session is stopped with the
+backend ``close()`` (claim release) invoked **before** stop completion is
+reported, and every subscribed viewer's subsequent ``get_frame`` returns
+``DISCONNECTED`` with no frame payload (never a previously cached frame).
+
+Validates: Requirements 3.5, 3.11, 7.1, 7.2, 7.3, 7.4, 7.5.
+
+How the cascade is exercised
+----------------------------
+A real :class:`StreamBroadcaster` is wired with an injected ``backend_factory``
+(building the shared :class:`MockCameraBackend` registered against one shared
+:class:`ClaimRegistry`) and an injected :class:`MockClock`, exactly like the
+single-claim stateful test. For each example we:
+
+1. Subscribe a generated number of viewers to a single camera (start-on-first
+   opens the one device claim; the rest reuse it).
+2. Optionally publish a frame into the session's latest-frame slot first, so
+   there *is* a cached frame the cascade must refuse to serve.
+3. Simulate the disconnect by setting ``session.state = SessionState.ERROR`` —
+   exactly the transition the real acquisition worker performs on a failed /
+   timed-out grab (``WorkerStopReason.DISCONNECTED`` / ``FIRST_FRAME_TIMEOUT``).
+4. Call ``get_frame`` for one viewer to trigger the broadcaster's disconnection
+   cascade.
+
+We then assert:
+
+* the cascade stopped the session and the backend ``close()`` (claim release)
+  was invoked, releasing the single claim (``registry.open_count == 0``), and
+  that the ``close()`` happened **before** the ``DISCONNECTED`` result was
+  returned (the call log records ``close`` during the ``get_frame`` call);
+* every subscribed viewer's subsequent ``get_frame`` returns
+  ``FrameStatus.DISCONNECTED`` with ``frame is None`` — never the cached frame;
+* the session was removed from the registry, so a later ``get_frame`` still
+  returns ``DISCONNECTED``.
+
+Test-only technique (no production code changed)
+------------------------------------------------
+Like ``test_broadcaster_claim.py``, this patches the ``AcquisitionWorker`` symbol
+in the broadcaster module with a no-op stub for the duration of each example so
+no real daemon thread / wall-clock grab loop runs. The stub marks the session
+RUNNING on ``start()`` (mirroring the real worker after its first published
+frame). The disconnect itself is modelled by setting ``SessionState.ERROR``
+directly, which is the precise state the real worker leaves behind before the
+broadcaster cascade tears the session down. Production code is untouched.
+"""
+from __future__ import annotations
+
+import unittest.mock as mock
+from typing import Optional
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from mock_camera_backend import (
+    MOCK_BACKEND_CLASSES,
+    ClaimRegistry,
+    MockClock,
+    make_raw_frame,
+)
+from utils.streaming import broadcaster as broadcaster_module
+from utils.streaming.broadcaster import StreamBroadcaster
+from utils.streaming.models import FrameStatus, SessionState, StreamConfig
+
+# Keep max_viewers comfortably above the generated viewer count so the cascade —
+# not the viewer-limit branch (Property 6) — is what we exercise.
+_CONFIG = StreamConfig(max_viewers=8, stale_after_s=2.0)
+_CAMERA = "Fake_disconnect_1"
+
+
+class _StubAcquisitionWorker:
+    """No-op stand-in for ``AcquisitionWorker`` (test-only; see module docstring).
+
+    Matches the broadcaster's construction/usage contract
+    (``AcquisitionWorker(session, stream_config=..., time_fn=...)`` then
+    ``start()`` / ``stop()`` / ``join()``) but runs no thread and performs no
+    grabs, so the cascade runs deterministically. ``start()`` marks the session
+    RUNNING to mirror the real worker after its first published frame.
+    """
+
+    def __init__(self, session, *, stream_config=None, time_fn=None, **kwargs) -> None:
+        self.session = session
+
+    def start(self):
+        self.session.state = SessionState.RUNNING
+        return None
+
+    def stop(self) -> None:
+        return None
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        return None
+
+
+# Feature: concurrent-camera-stream-viewing, Property 14: Disconnection cascade
+# Validates: Requirements 3.5, 3.11, 7.1, 7.2, 7.3, 7.4, 7.5
+@pytest.mark.parametrize(
+    "backend_cls", MOCK_BACKEND_CLASSES.values(), ids=list(MOCK_BACKEND_CLASSES)
+)
+@settings(max_examples=150, deadline=None)
+@given(
+    num_viewers=st.integers(min_value=1, max_value=_CONFIG.max_viewers),
+    publish_cached_frame=st.booleans(),
+    cached_seq=st.integers(min_value=1, max_value=10_000),
+    clock_advance=st.floats(min_value=0.0, max_value=120.0, allow_nan=False, allow_infinity=False),
+    probe_offset=st.integers(min_value=0, max_value=_CONFIG.max_viewers - 1),
+)
+def test_property_14_disconnection_cascade(
+    backend_cls, num_viewers, publish_cached_frame, cached_seq, clock_advance, probe_offset
+):
+    """A disconnect stops the session, releases the claim before reporting
+    completion, and makes every viewer's get_frame return DISCONNECTED with no
+    cached payload; the session is removed so later reads stay DISCONNECTED.
+
+    Feature: concurrent-camera-stream-viewing, Property 14: Disconnection cascade
+    Validates: Requirements 3.5, 3.11, 7.1, 7.2, 7.3, 7.4, 7.5
+    """
+    registry = ClaimRegistry()
+    clock = MockClock(start=1000.0)
+    created: dict[str, object] = {}
+
+    def backend_factory(camera_id, config):
+        backend = backend_cls(
+            camera_id,
+            claim_registry=registry,
+            clock=clock,
+        )
+        created[camera_id] = backend
+        return backend
+
+    broadcaster = StreamBroadcaster(
+        stream_config=_CONFIG,
+        backend_factory=backend_factory,
+        time_fn=clock.time,
+    )
+
+    with mock.patch.object(broadcaster_module, "AcquisitionWorker", _StubAcquisitionWorker):
+        # 1. Subscribe the generated number of viewers to the one camera.
+        viewer_ids = []
+        for _ in range(num_viewers):
+            result = broadcaster.subscribe(_CAMERA)
+            assert result.accepted is True
+            viewer_ids.append(result.viewer_id)
+
+        # Sanity: the single claim is open while the session has viewers.
+        assert broadcaster.viewer_count(_CAMERA) == num_viewers
+        assert registry.open_count(_CAMERA) == 1
+
+        session = broadcaster._sessions[_CAMERA]
+        backend = created[_CAMERA]
+
+        # 2. Optionally publish a frame so a cached frame exists to prove it is
+        #    NOT served once the camera is disconnected. A generated seq makes the
+        #    cached frame byte-distinguishable across examples.
+        cached_frame = None
+        if publish_cached_frame:
+            cached_frame = session.publish(make_raw_frame(seq=cached_seq), now=clock.time())
+            # The slot is genuinely populated and would read OK pre-disconnect.
+            assert session.latest is cached_frame
+
+        # Advancing the clock varies how "old" the cached frame is (fresh vs
+        # stale) at disconnect time; the cascade must report DISCONNECTED either
+        # way, never OK/STALE with the cached payload.
+        clock.advance(clock_advance)
+
+        # 3. Simulate the disconnect: ERROR is exactly what the worker leaves on a
+        #    failed/timed-out grab (Req 3.11, 7.2). Record the close-call count so
+        #    we can prove close() happens DURING the cascade get_frame below.
+        session.state = SessionState.ERROR
+        closes_before = backend.close_count
+        assert closes_before == 0  # claim still held; nothing released yet
+
+        # 4. Trigger the cascade via a viewer's get_frame (any viewer works).
+        probe_viewer = viewer_ids[probe_offset % num_viewers]
+        result = broadcaster.get_frame(_CAMERA, probe_viewer)
+
+    # --- assertions on the cascade ---------------------------------------
+
+    # The triggering get_frame reports DISCONNECTED with no payload (Req 7.5).
+    assert result.status == FrameStatus.DISCONNECTED
+    assert result.frame is None
+
+    # close() (claim release) was invoked as part of the cascade, BEFORE the
+    # DISCONNECTED result was returned. Because get_frame is synchronous, the
+    # close recorded during the call necessarily completed before the return
+    # value we are now holding (Req 7.3, 7.4). The shared registry confirms the
+    # single device claim was actually released.
+    assert backend.close_count == closes_before + 1
+    assert "close" in backend.call_log
+    assert registry.open_count(_CAMERA) == 0
+    assert registry.total_open() == 0
+
+    # The session was stopped and removed from the registry (Req 3.5, 3.7).
+    assert _CAMERA not in broadcaster._sessions
+    assert broadcaster.viewer_count(_CAMERA) == 0
+    assert session.state == SessionState.STOPPED
+
+    # Every subscribed viewer's subsequent get_frame returns DISCONNECTED with no
+    # frame — never the previously cached frame (Req 7.5, 3.11).
+    for viewer_id in viewer_ids:
+        res = broadcaster.get_frame(_CAMERA, viewer_id)
+        assert res.status == FrameStatus.DISCONNECTED
+        assert res.frame is None
+        if cached_frame is not None:
+            assert res.frame is not cached_frame
+
+    # The single-claim invariant held throughout (no overlap, no release without
+    # a matching open).
+    registry.assert_single_claim()

--- a/test/backend-test/utils/streaming/test_broadcaster_lifecycle.py
+++ b/test/backend-test/utils/streaming/test_broadcaster_lifecycle.py
@@ -1,0 +1,307 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Stateful property-based test for stream-session lifecycle.
+
+Feature: concurrent-camera-stream-viewing, Property 2: Session lifecycle (start
+on first, stop and release on last) — the first viewer to subscribe to a camera
+that has no session creates *exactly one* session (one backend ``open()`` /
+device claim), and whenever a camera's active viewer count returns to 0 the
+session is stopped and the backend ``close()`` (claim release) is invoked. A
+brand-new subscribe after a teardown starts a *fresh* session/claim rather than
+resurrecting the closed one (Req 3.1, 3.3, 3.7, 8.7).
+
+The property is exercised as a Hypothesis ``RuleBasedStateMachine`` over a real
+:class:`StreamBroadcaster` whose ``backend_factory`` builds the hardware-free
+:class:`MockCameraBackend` and whose clock is a deterministic :class:`MockClock`.
+The machine interleaves three kinds of rules:
+
+* ``subscribe(camera)`` — register a new viewer (start-on-first-viewer),
+* ``unsubscribe(viewer)`` — remove a known viewer (stop-on-last-viewer), and
+* ``advance_and_sweep()`` — push the clock past the stale window and run
+  ``sweep_stale_viewers`` so sessions can also be emptied (and torn down) via
+  staleness, not only explicit unsubscribes.
+
+After every rule the machine re-checks the full lifecycle invariant against a
+shadow model of the expected viewers per camera (see :meth:`_check_invariant`).
+
+Test-only worker stub
+---------------------
+In production :meth:`StreamBroadcaster._start_session` starts a real
+``AcquisitionWorker`` on a daemon thread (the grab→publish producer). That
+background thread is irrelevant to the *lifecycle* invariant (it never opens or
+closes the device claim — only the broadcaster does) but it would introduce
+non-determinism into the assertions and could transition sessions to ``ERROR``
+concurrently. To keep the state machine deterministic we patch the
+``AcquisitionWorker`` symbol *in the broadcaster module* with a no-op
+:class:`_StubWorker` for the duration of each run. This is a test-only seam: no
+production code is modified, and the broadcaster's own start/stop/close
+orchestration (the code under test) runs exactly as in production.
+"""
+from __future__ import annotations
+
+from unittest import mock
+
+from hypothesis import settings
+from hypothesis import strategies as st
+from hypothesis.stateful import (
+    Bundle,
+    RuleBasedStateMachine,
+    consumes,
+    invariant,
+    rule,
+)
+
+from mock_camera_backend import ClaimRegistry, MockClock, make_raw_frame
+from utils.streaming.broadcaster import StreamBroadcaster
+from utils.streaming.models import StreamConfig
+
+# A small fixed pool of cameras so the machine repeatedly drives the same camera
+# through full start→stop→restart cycles (rather than always touching a fresh id).
+CAMERAS = ("Fake_1", "Fake_2", "Fake_3")
+
+# Stale window used by the model; advancing the clock past it makes every
+# currently-subscribed viewer eligible for the sweep. A large max_viewers keeps
+# this test focused purely on lifecycle (viewer-limit rejection is Property 6,
+# task 5.7), so every subscribe is accepted and drives real lifecycle.
+STALE_TIMEOUT_S = 30
+MAX_VIEWERS = 1000
+
+
+def _build_mock_backend(camera_id, claims, clock):
+    """Build a fresh mock backend wired to the shared claim registry and clock.
+
+    Each new session gets a brand-new backend instance so the test can assert
+    that every start-on-first-viewer opens a *fresh* claim (not a resurrected
+    one) and that each torn-down session's backend had ``close()`` invoked.
+    """
+    from mock_camera_backend import MockAravisBackend
+
+    # default_grab keeps the backend representative of a healthy camera; the
+    # stub worker never calls grab(), so no frames are actually consumed.
+    return MockAravisBackend(
+        camera_id,
+        claim_registry=claims,
+        clock=clock,
+        default_grab=make_raw_frame(seq=0),
+    )
+
+
+class _StubWorker:
+    """No-op stand-in for ``AcquisitionWorker`` (test-only; see module docstring).
+
+    Implements just the surface the broadcaster touches — construction plus
+    ``start`` / ``stop`` / ``join`` — without spawning any thread or touching the
+    backend, so the broadcaster's session start/stop/close orchestration runs
+    deterministically and the lifecycle assertions are race-free.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def start(self):
+        return None
+
+    def stop(self) -> None:
+        return None
+
+    def join(self, timeout=None) -> None:
+        return None
+
+
+class SessionLifecycleMachine(RuleBasedStateMachine):
+    """Drives subscribe / unsubscribe / sweep against a real broadcaster.
+
+    Maintains a shadow model:
+
+    * ``model[camera]`` — set of viewer ids the *test* believes are active, with
+      each viewer's ``last_active`` time (for predicting the stale sweep), and
+    * ``backends[camera]`` — every mock backend the factory has built for that
+      camera, in creation order (so we can assert each torn-down session's
+      backend had ``close()`` invoked and each new session uses a fresh backend),
+    * ``sessions_created[camera]`` — how many sessions the test expects to have
+      been started for the camera (incremented on every 0→≥1 transition).
+    """
+
+    viewers = Bundle("viewers")
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.clock = MockClock(start=1000.0)
+        self.claims = ClaimRegistry()
+        self.config = StreamConfig(
+            max_viewers=MAX_VIEWERS,
+            stale_timeout_s=STALE_TIMEOUT_S,
+        )
+        # Every backend ever built, per camera, in creation order.
+        self.backends: dict[str, list] = {c: [] for c in CAMERAS}
+        # Expected number of sessions started per camera (0→≥1 transitions).
+        self.sessions_created: dict[str, int] = {c: 0 for c in CAMERAS}
+        # Shadow of active viewers: camera -> {viewer_id: last_active}.
+        self.model: dict[str, dict] = {c: {} for c in CAMERAS}
+
+        def backend_factory(camera_id, config):
+            backend = _build_mock_backend(camera_id, self.claims, self.clock)
+            self.backends[camera_id].append(backend)
+            return backend
+
+        # Patch the worker symbol the broadcaster constructs (test-only seam).
+        self._worker_patcher = mock.patch(
+            "utils.streaming.broadcaster.AcquisitionWorker", _StubWorker
+        )
+        self._worker_patcher.start()
+
+        self.broadcaster = StreamBroadcaster(
+            stream_config=self.config,
+            backend_factory=backend_factory,
+            time_fn=self.clock,
+        )
+
+    def teardown(self) -> None:
+        """Stop the worker patch at the end of each generated run."""
+        self._worker_patcher.stop()
+
+    # --- helpers ----------------------------------------------------------
+
+    def _camera_active(self, camera: str) -> bool:
+        return len(self.model[camera]) > 0
+
+    # --- rules ------------------------------------------------------------
+
+    @rule(target=viewers, camera=st.sampled_from(CAMERAS))
+    def subscribe(self, camera):
+        """Register a new viewer; the first one for a camera starts a session."""
+        was_active = self._camera_active(camera)
+        now = self.clock.time()
+        result = self.broadcaster.subscribe(camera)
+
+        # max_viewers is huge, the mock open never fails: subscribe is accepted.
+        assert result.accepted, f"unexpected rejection: {result.reason}"
+        assert result.viewer_id is not None
+
+        if not was_active:
+            # 0→≥1 transition: exactly one new session/claim was started.
+            self.sessions_created[camera] += 1
+
+        self.model[camera][result.viewer_id] = now
+        return (camera, result.viewer_id)
+
+    @rule(viewer=consumes(viewers))
+    def unsubscribe(self, viewer):
+        """Remove a known viewer; the last one tears the session down."""
+        camera, viewer_id = viewer
+        # The viewer may already have been swept away by advance_and_sweep; in
+        # that case it is gone from the model and unsubscribe is a no-op.
+        existed = viewer_id in self.model[camera]
+        self.broadcaster.unsubscribe(camera, viewer_id)
+        self.model[camera].pop(viewer_id, None)
+        # Nothing else to assert here; _check_invariant covers the outcome.
+        _ = existed
+
+    @rule(seconds=st.integers(min_value=STALE_TIMEOUT_S + 1, max_value=STALE_TIMEOUT_S + 600))
+    def advance_and_sweep(self, seconds):
+        """Advance the clock past the stale window and sweep stale viewers.
+
+        Every viewer subscribed before this advance becomes stale
+        (``now - last_active > stale_timeout_s``) and is removed; any camera that
+        empties as a result is torn down (claim released), exactly like the
+        last-viewer unsubscribe path.
+        """
+        now = self.clock.advance(seconds)
+        self.broadcaster.sweep_stale_viewers(now)
+        # Mirror the sweep in the model: drop every viewer past the stale window.
+        for camera in CAMERAS:
+            stale = [
+                vid
+                for vid, last_active in self.model[camera].items()
+                if (now - last_active) > STALE_TIMEOUT_S
+            ]
+            for vid in stale:
+                self.model[camera].pop(vid, None)
+
+    # --- invariant --------------------------------------------------------
+
+    @invariant()
+    def _check_invariant(self):
+        """Assert the start-on-first / stop-and-release-on-last lifecycle."""
+        for camera in CAMERAS:
+            expected_count = len(self.model[camera])
+            built = self.backends[camera]
+
+            # Reported viewer count tracks the model exactly.
+            assert self.broadcaster.viewer_count(camera) == expected_count, (
+                f"{camera}: broadcaster count "
+                f"{self.broadcaster.viewer_count(camera)} != model {expected_count}"
+            )
+
+            # The number of sessions ever started equals the number of backends
+            # the factory built — each 0→≥1 transition creates exactly one
+            # session, hence exactly one backend (Req 3.1).
+            assert len(built) == self.sessions_created[camera], (
+                f"{camera}: built {len(built)} backends but expected "
+                f"{self.sessions_created[camera]} sessions"
+            )
+
+            if expected_count >= 1:
+                # Active camera: exactly one open session/claim — the latest
+                # backend is open with a single acquired claim, not yet closed.
+                assert camera in self.broadcaster._sessions, (
+                    f"{camera}: active ({expected_count} viewers) but no session"
+                )
+                current = built[-1]
+                assert current.is_open, f"{camera}: current backend not open"
+                assert current.open_count == 1, (
+                    f"{camera}: current backend open_count={current.open_count}"
+                )
+                assert current.close_count == 0, (
+                    f"{camera}: active session's backend was closed"
+                )
+                assert self.claims.open_count(camera) == 1, (
+                    f"{camera}: expected exactly 1 open claim, got "
+                    f"{self.claims.open_count(camera)}"
+                )
+            else:
+                # Empty camera: no session, claim released.
+                assert camera not in self.broadcaster._sessions, (
+                    f"{camera}: empty but session still registered"
+                )
+                assert self.claims.open_count(camera) == 0, (
+                    f"{camera}: empty but {self.claims.open_count(camera)} open claims"
+                )
+                if built:
+                    # The most recent session was stopped: close() was invoked
+                    # exactly once (claim released, Req 3.3, 3.7, 8.7).
+                    last = built[-1]
+                    assert last.close_count == 1, (
+                        f"{camera}: torn-down backend close_count={last.close_count}"
+                    )
+                    assert not last.is_open
+
+            # Every non-current backend belongs to a finished session and must
+            # have been closed exactly once (no leaked claim across restarts),
+            # and a restart always used a brand-new backend instance.
+            for old in built[:-1]:
+                assert old.close_count == 1, (
+                    f"{camera}: a previous session backend was not closed once "
+                    f"(close_count={old.close_count})"
+                )
+                assert not old.is_open
+
+        # Global single-claim invariant: never overlapping, never released twice.
+        self.claims.assert_single_claim()
+
+
+# Feature: concurrent-camera-stream-viewing, Property 2: Session lifecycle (start on first, stop and release on last)
+# Validates: Requirements 3.1, 3.3, 3.7, 8.7
+TestSessionLifecycle = SessionLifecycleMachine.TestCase
+TestSessionLifecycle.settings = settings(max_examples=150, stateful_step_count=40, deadline=None)

--- a/test/backend-test/utils/streaming/test_broadcaster_openfail.py
+++ b/test/backend-test/utils/streaming/test_broadcaster_openfail.py
@@ -1,0 +1,219 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based test for open-failure handling.
+
+Feature: concurrent-camera-stream-viewing, Property 7: Open-failure handling —
+for any camera whose backend ``open()`` fails, a subscribe makes at most
+``max_open_attempts`` (3) attempts and is then rejected with reason
+``"camera_unavailable"``, leaving no session and zero open device claims for that
+camera, while subscriptions to any other healthy camera still succeed
+(Req 1.7, 3.2, 7.6).
+
+Design notes / test seams
+-------------------------
+* The :class:`StreamBroadcaster` is driven with an injected ``backend_factory``
+  that returns a *failing* mock backend (``fail_open=True``, so every ``open()``
+  raises) for a designated set of "bad" cameras and a *healthy* mock for every
+  other camera. All mocks share a single :class:`ClaimRegistry`, so the test can
+  assert the zero-claims invariant for the bad camera and the single open claim
+  for healthy cameras across the whole interleaving.
+
+* ``max_open_attempts`` semantics: in production the *backend adapter* retries
+  ``open()`` up to ``max_open_attempts`` internally (the real Aravis/GStreamer
+  adapters do ``<= 3``); the broadcaster calls ``backend.open()`` once and
+  surfaces the resulting failure as a ``camera_unavailable`` rejection. We
+  therefore assert the broadcaster-level rejection + zero-claims invariant, and
+  additionally assert the mock's recorded open-failure count never exceeds
+  ``max_open_attempts`` (it is exactly 1 per subscribe at the broadcaster seam).
+
+* Worker threads: a subscribe that *succeeds* would normally spawn a real
+  acquisition-worker daemon thread. To keep the property deterministic and
+  thread-free we replace the ``AcquisitionWorker`` symbol in the broadcaster
+  module with a tiny test-only no-op subclass (``_NoopWorker``) for the duration
+  of each example. This is a TEST-ONLY stub installed via ``mock.patch`` on the
+  broadcaster module's name binding — **production code is not modified**; the
+  broadcaster still constructs and tracks a "worker" and drives the real
+  open/start_stream claim lifecycle, only the thread spin-up is stubbed out.
+"""
+from __future__ import annotations
+
+import unittest.mock as mock
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from mock_camera_backend import (
+    MOCK_BACKEND_CLASSES,
+    ClaimRegistry,
+    MockClock,
+    make_raw_frame,
+)
+from utils.streaming import broadcaster as broadcaster_module
+from utils.streaming.broadcaster import StreamBroadcaster
+from utils.streaming.models import StreamConfig
+from utils.streaming.worker import AcquisitionWorker
+
+MAX_OPEN_ATTEMPTS = StreamConfig().max_open_attempts  # 3
+_CONFIG = StreamConfig()
+
+
+class _NoopWorker(AcquisitionWorker):
+    """Test-only :class:`AcquisitionWorker` that never spawns a real thread.
+
+    The broadcaster starts one acquisition worker per healthy session. For this
+    property we only care about the open/claim lifecycle, not frame production,
+    so ``start``/``stop``/``join`` are no-ops and no background thread (or wall
+    clock) is involved. Subclassing keeps the constructor contract identical, so
+    the broadcaster wires it exactly as it would the real worker.
+    """
+
+    def start(self):  # noqa: D401 - simple stub
+        """Do not spawn a thread; record that a (stub) worker was started."""
+        self._thread = None
+        return None
+
+    def stop(self) -> None:
+        """No-op stop for the stub worker."""
+        self.stop_event.set()
+
+    def join(self, timeout=None) -> None:
+        """No-op join for the stub worker."""
+        return None
+
+
+# Distinct, non-overlapping camera-id pools for healthy vs. bad cameras.
+_healthy_ids = st.lists(
+    st.from_regex(r"Healthy_[0-9]{1,3}", fullmatch=True),
+    min_size=1,
+    max_size=4,
+    unique=True,
+)
+_bad_ids = st.lists(
+    st.from_regex(r"Bad_[0-9]{1,3}", fullmatch=True),
+    min_size=1,
+    max_size=4,
+    unique=True,
+)
+
+
+# Feature: concurrent-camera-stream-viewing, Property 7: Open-failure handling
+# Validates: Requirements 1.7, 3.2, 7.6
+@pytest.mark.parametrize(
+    "backend_cls", MOCK_BACKEND_CLASSES.values(), ids=list(MOCK_BACKEND_CLASSES)
+)
+@settings(max_examples=150, deadline=None)
+@given(
+    healthy_ids=_healthy_ids,
+    bad_ids=_bad_ids,
+    seed=st.randoms(use_true_random=False),
+)
+def test_property_7_open_failure_handling(backend_cls, healthy_ids, bad_ids, seed):
+    """Bad-camera subscribes reject with ``camera_unavailable`` and zero claims;
+    healthy cameras still subscribe and hold exactly one claim.
+
+    Feature: concurrent-camera-stream-viewing, Property 7: Open-failure handling
+    Validates: Requirements 1.7, 3.2, 7.6
+    """
+    registry = ClaimRegistry()
+    clock = MockClock(start=1000.0)
+    created: dict[str, object] = {}
+
+    def backend_factory(camera_id, config):
+        """Return a failing mock for bad cameras, a healthy mock otherwise.
+
+        All backends share the single ``registry`` so the open-claim count per
+        camera can be asserted across the whole interleaving.
+        """
+        if camera_id in bad_set:
+            backend = backend_cls(
+                camera_id,
+                fail_open=True,           # every open() raises -> camera_unavailable
+                claim_registry=registry,
+                clock=clock,
+            )
+        else:
+            backend = backend_cls(
+                camera_id,
+                frames=[make_raw_frame(seq=0)],
+                claim_registry=registry,
+                clock=clock,
+            )
+        created[camera_id] = backend
+        return backend
+
+    bad_set = set(bad_ids)
+    # Ensure the two pools are disjoint (regex prefixes already guarantee this,
+    # but be explicit so a future generator tweak cannot silently overlap them).
+    assert bad_set.isdisjoint(set(healthy_ids))
+
+    broadcaster = StreamBroadcaster(
+        stream_config=_CONFIG,
+        backend_factory=backend_factory,
+        time_fn=clock.time,
+    )
+
+    # Interleave the healthy and bad subscribes in an arbitrary order so the
+    # property holds regardless of sequencing.
+    order = [("healthy", cid) for cid in healthy_ids] + [("bad", cid) for cid in bad_ids]
+    seed.shuffle(order)
+
+    subscribed_healthy: set[str] = set()
+
+    # Stub worker thread creation for the duration of the scenario (test-only).
+    with mock.patch.object(broadcaster_module, "AcquisitionWorker", _NoopWorker):
+        for kind, camera_id in order:
+            result = broadcaster.subscribe(camera_id)
+
+            if kind == "bad":
+                # Rejected as camera_unavailable, viewer_count 0, no viewer id.
+                assert result.accepted is False
+                assert result.reason == "camera_unavailable"
+                assert result.viewer_count == 0
+                assert result.viewer_id is None
+
+                # No session left behind for the bad camera.
+                assert camera_id not in broadcaster._sessions
+                assert broadcaster.viewer_count(camera_id) == 0
+
+                # Zero OPEN claims for the bad camera (open failed -> never acquired).
+                assert registry.open_count(camera_id) == 0
+
+                # At most max_open_attempts open attempts were made (Req 7.6). At the
+                # broadcaster seam this is exactly 1 failed open per subscribe.
+                assert created[camera_id].open_failure_count <= MAX_OPEN_ATTEMPTS
+            else:
+                # Healthy subscribe still succeeds even alongside failing cameras.
+                assert result.accepted is True
+                assert result.reason is None
+                assert result.viewer_id is not None
+                assert result.viewer_count >= 1
+
+                # Exactly one open device claim is held for a healthy camera.
+                assert registry.open_count(camera_id) == 1
+                assert broadcaster.viewer_count(camera_id) == result.viewer_count
+                subscribed_healthy.add(camera_id)
+
+    # Final invariants over the whole run:
+    # - Every healthy camera holds exactly one claim; no bad camera holds any.
+    for camera_id in subscribed_healthy:
+        assert registry.open_count(camera_id) == 1
+    for camera_id in bad_set:
+        assert registry.open_count(camera_id) == 0
+        assert camera_id not in broadcaster._sessions
+
+    # - The single-claim invariant never overlapped for any camera.
+    registry.assert_single_claim()
+    # - Total open claims equals the number of distinct healthy cameras started.
+    assert registry.total_open() == len(subscribed_healthy)

--- a/test/backend-test/utils/streaming/test_broadcaster_sweep.py
+++ b/test/backend-test/utils/streaming/test_broadcaster_sweep.py
@@ -1,0 +1,231 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based test for the stale-viewer sweep.
+
+Feature: concurrent-camera-stream-viewing, Property 10: Stale sweep deregisters,
+heartbeats keep alive — for any set of viewers with arbitrary last-active
+timestamps, a stale-sweep at time ``now`` removes exactly those viewers with
+``now - last_active > stale_timeout_s`` (decrementing the active count and
+treating them as unsubscribed), while any viewer that has sent a heartbeat
+within ``stale_timeout_s`` of ``now`` is retained (Req 3.8, 8.2, 8.6).
+
+Validates: Requirements 3.8, 8.2, 8.6
+
+Design notes / test seams
+-------------------------
+* The :class:`StreamBroadcaster` is driven with an injected ``backend_factory``
+  that builds the hardware-free :class:`MockCameraBackend` and an injected
+  :class:`MockClock`, so subscribe/heartbeat/sweep timing is fully
+  deterministic. All mocks share one :class:`ClaimRegistry` so the single-claim
+  invariant can be checked across the whole run.
+
+* A real subscribe would spawn an acquisition-worker daemon thread. To keep the
+  property deterministic and thread-free we patch the ``AcquisitionWorker``
+  symbol in the broadcaster module with a no-op :class:`_StubWorker` for the
+  duration of each example (the worker-stub technique from
+  ``test_broadcaster_lifecycle.py``). This is a TEST-ONLY seam — production code
+  is not modified; the broadcaster's real subscribe/heartbeat/sweep/teardown
+  orchestration (the code under test) runs exactly as in production.
+
+* Driving the sweep through the *real* clock: viewers are subscribed at a base
+  time; a generated subset then heartbeats after the clock is advanced. The
+  sweep is invoked at the broadcaster's own clock value, and the expected
+  outcome is computed from each viewer's effective ``last_active`` (subscribe
+  time, or the later heartbeat time for the heartbeated subset).
+"""
+from __future__ import annotations
+
+import unittest.mock as mock
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from mock_camera_backend import (
+    MOCK_BACKEND_CLASSES,
+    ClaimRegistry,
+    MockClock,
+    make_raw_frame,
+)
+from utils.streaming import broadcaster as broadcaster_module
+from utils.streaming.broadcaster import StreamBroadcaster
+from utils.streaming.models import StreamConfig
+
+# Stale window the sweep compares against. A viewer is stale exactly when it has
+# been inactive strictly longer than this many seconds (Req 8.6).
+STALE_TIMEOUT_S = 30
+# Large viewer cap so this test focuses purely on the sweep (no viewer-limit
+# rejection, which is Property 6 / task 5.7) and every subscribe is accepted.
+MAX_VIEWERS = 1000
+# Single camera keeps the model small; the sweep logic is per-session and the
+# broadcaster sweeps every registered session uniformly.
+CAMERA_ID = "Fake_1"
+
+
+class _StubWorker:
+    """No-op stand-in for ``AcquisitionWorker`` (test-only; see module docstring).
+
+    Implements just the surface the broadcaster touches — construction plus
+    ``start`` / ``stop`` / ``join`` — without spawning any thread or touching the
+    backend, so the broadcaster's subscribe/sweep/teardown orchestration runs
+    deterministically and the sweep assertions are race-free.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def start(self):
+        return None
+
+    def stop(self) -> None:
+        return None
+
+    def join(self, timeout=None) -> None:
+        return None
+
+
+# A small population of viewers. Each is described by the offset (in seconds)
+# applied to the clock *before* it subscribes, so viewers end up with a spread of
+# subscribe times relative to one another.
+_subscribe_offsets = st.lists(
+    st.integers(min_value=0, max_value=120),
+    min_size=1,
+    max_size=12,
+)
+
+
+# Feature: concurrent-camera-stream-viewing, Property 10: Stale sweep deregisters, heartbeats keep alive
+# Validates: Requirements 3.8, 8.2, 8.6
+@pytest.mark.parametrize(
+    "backend_cls", MOCK_BACKEND_CLASSES.values(), ids=list(MOCK_BACKEND_CLASSES)
+)
+@settings(max_examples=150, deadline=None)
+@given(
+    subscribe_offsets=_subscribe_offsets,
+    data=st.data(),
+)
+def test_property_10_stale_sweep_deregisters_heartbeats_keep_alive(
+    backend_cls, subscribe_offsets, data
+):
+    """Sweep removes exactly viewers stale past the window; heartbeated ones stay.
+
+    Subscribe a generated set of viewers at a spread of times, heartbeat a
+    generated subset at later (generated) times, then sweep at the broadcaster's
+    current clock value and assert exactly the viewers whose effective
+    ``last_active`` is older than ``stale_timeout_s`` were removed.
+
+    Feature: concurrent-camera-stream-viewing, Property 10: Stale sweep deregisters, heartbeats keep alive
+    Validates: Requirements 3.8, 8.2, 8.6
+    """
+    registry = ClaimRegistry()
+    clock = MockClock(start=1000.0)
+    config = StreamConfig(max_viewers=MAX_VIEWERS, stale_timeout_s=STALE_TIMEOUT_S)
+
+    def backend_factory(camera_id, cfg):
+        return backend_cls(
+            camera_id,
+            frames=[make_raw_frame(seq=0)],
+            claim_registry=registry,
+            clock=clock,
+            default_grab=make_raw_frame(seq=0),
+        )
+
+    broadcaster = StreamBroadcaster(
+        stream_config=config,
+        backend_factory=backend_factory,
+        time_fn=clock.time,
+    )
+
+    # Shadow model: viewer_id -> effective last_active time the test expects.
+    expected_last_active: dict[str, float] = {}
+
+    with mock.patch.object(broadcaster_module, "AcquisitionWorker", _StubWorker):
+        # --- Phase 1: subscribe every viewer at a spread of (monotonic) times.
+        viewer_ids: list[str] = []
+        prev_offset = 0
+        for offset in subscribe_offsets:
+            # MockClock cannot move backwards; advance by the non-negative delta
+            # so subscribe times are monotonic but still spread out.
+            delta = max(0, offset - prev_offset)
+            clock.advance(delta)
+            prev_offset = offset
+
+            result = broadcaster.subscribe(CAMERA_ID)
+            assert result.accepted, f"unexpected rejection: {result.reason}"
+            assert result.viewer_id is not None
+            viewer_ids.append(result.viewer_id)
+            expected_last_active[result.viewer_id] = clock.time()
+
+        assert broadcaster.viewer_count(CAMERA_ID) == len(viewer_ids)
+
+        # --- Phase 2: heartbeat a generated subset at later, generated times.
+        heartbeat_subset = data.draw(
+            st.lists(
+                st.sampled_from(viewer_ids),
+                unique=True,
+                max_size=len(viewer_ids),
+            ),
+            label="heartbeat_subset",
+        )
+        for viewer_id in heartbeat_subset:
+            # Advance the clock by a generated non-negative amount before each
+            # heartbeat so heartbeated viewers get a fresher last_active.
+            bump = data.draw(st.integers(min_value=0, max_value=100), label="hb_bump")
+            clock.advance(bump)
+            refreshed = broadcaster.heartbeat(CAMERA_ID, viewer_id)
+            assert refreshed is True
+            expected_last_active[viewer_id] = clock.time()
+
+        # --- Phase 3: advance to an arbitrary sweep time and sweep.
+        sweep_bump = data.draw(st.integers(min_value=0, max_value=200), label="sweep_bump")
+        clock.advance(sweep_bump)
+        now = clock.time()
+
+        # Predict the exact outcome from the model: a viewer is removed iff it has
+        # been inactive strictly longer than the stale window (Req 8.6).
+        expected_removed = {
+            vid
+            for vid, last_active in expected_last_active.items()
+            if (now - last_active) > STALE_TIMEOUT_S
+        }
+        expected_retained = set(expected_last_active) - expected_removed
+
+        broadcaster.sweep_stale_viewers(now)
+
+        # --- Assertions: exactly the stale viewers were removed; the rest stay.
+        session = broadcaster._sessions.get(CAMERA_ID)
+        if expected_retained:
+            assert session is not None, "session torn down while viewers remain"
+            surviving = set(session.viewers.keys())
+            assert surviving == expected_retained, (
+                f"survivors {surviving} != expected retained {expected_retained}"
+            )
+            # No retained viewer is stale; no removed viewer survived.
+            for vid in surviving:
+                assert (now - expected_last_active[vid]) <= STALE_TIMEOUT_S
+            assert surviving.isdisjoint(expected_removed)
+
+            # Active count tracks the retained set exactly (Req 8.2).
+            assert broadcaster.viewer_count(CAMERA_ID) == len(expected_retained)
+            # Session still holds its single device claim.
+            assert registry.open_count(CAMERA_ID) == 1
+        else:
+            # Every viewer was stale: the session is emptied and torn down, which
+            # releases the single device claim (stop-on-last, Req 8.7).
+            assert session is None, "session should be torn down when fully swept"
+            assert broadcaster.viewer_count(CAMERA_ID) == 0
+            assert registry.open_count(CAMERA_ID) == 0
+
+    # Single-claim invariant never overlapped throughout the run.
+    registry.assert_single_claim()

--- a/test/backend-test/utils/streaming/test_broadcaster_viewercount.py
+++ b/test/backend-test/utils/streaming/test_broadcaster_viewercount.py
@@ -1,0 +1,223 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Stateful property test for viewer-count correctness and duplicate subscriptions.
+
+Feature: concurrent-camera-stream-viewing, Property 8: Viewer-count correctness and
+duplicate subscriptions — the reported active viewer count for a camera is always a
+non-negative integer equal to the number of distinct registered viewers; subscribing
+K times to the same camera yields K distinct viewer ids that each count toward the
+total (a duplicate subscription is a *new* viewer, never a merge).
+
+Validates: Requirements 8.1, 8.4, 8.5, 8.8
+
+Approach
+--------
+A Hypothesis :class:`RuleBasedStateMachine` drives a real
+:class:`~utils.streaming.broadcaster.StreamBroadcaster` (constructed with an injected
+mock ``backend_factory`` and an injected :class:`MockClock`) through arbitrary
+interleavings of two rules:
+
+* ``subscribe(camera)`` — registers a new viewer for a camera and records the returned
+  ``viewer_id`` in a reference model (a ``{camera_id -> set[viewer_id]}`` map). Every
+  accepted subscription must return a globally-distinct ``viewer_id`` and bump the
+  camera's count by exactly one; a subscription rejected at the per-camera cap must be
+  a ``viewer_limit`` rejection that leaves the count untouched.
+* ``unsubscribe(viewer)`` — removes a previously-issued viewer and must drop that
+  camera's count by exactly one.
+
+After every step an invariant asserts, for every camera, that
+``broadcaster.viewer_count(camera)`` is a non-negative ``int`` equal to the number of
+distinct viewer ids the reference model expects for that camera.
+
+Worker stubbing (no production change)
+--------------------------------------
+``StreamBroadcaster._start_session`` constructs and ``start()``s an
+:class:`~utils.streaming.worker.AcquisitionWorker` on a real daemon thread. That thread
+is irrelevant to viewer-count bookkeeping but would spin a real grab/sleep loop per
+first-subscribed camera across hundreds of stateful steps. We therefore monkeypatch the
+``AcquisitionWorker`` symbol *in the broadcaster module* with a no-op
+:class:`_StubWorker` for the duration of this test module (autouse fixture below). This
+is a test-only seam: production code is untouched, and the broadcaster's real
+subscribe / unsubscribe / session start+stop / claim logic (including ``backend.open``
+/ ``start_stream`` / ``close``) still runs exactly as shipped — only the background
+acquisition thread is replaced by a no-op.
+
+This module is import-safe on hosts without the ``gi`` / GenICam / GStreamer stack:
+``broadcaster.py`` keeps its device imports lazy and the backend here is the in-memory
+mock double.
+"""
+from unittest.mock import patch
+
+import pytest
+from hypothesis import settings
+from hypothesis.stateful import (
+    Bundle,
+    RuleBasedStateMachine,
+    consumes,
+    invariant,
+    multiple,
+    rule,
+)
+from hypothesis import strategies as st
+
+from mock_camera_backend import ClaimRegistry, MockClock, MockCameraBackend
+from utils.streaming.models import StreamConfig
+
+import utils.streaming.broadcaster as broadcaster_module
+from utils.streaming.broadcaster import StreamBroadcaster
+
+# A small fixed set of cameras the machine quantifies over. Several cameras let the
+# machine interleave subscriptions across independent sessions while keeping the search
+# space tractable.
+CAMERAS = ["Fake_1", "Fake_2", "Fake_3"]
+_cameras = st.sampled_from(CAMERAS)
+
+# Per-camera viewer ceiling (StreamConfig default). Reaching it exercises the
+# viewer_limit rejection branch without merging duplicate subscriptions.
+MAX_VIEWERS = StreamConfig().max_viewers
+
+
+class _StubWorker:
+    """No-op stand-in for :class:`AcquisitionWorker` (no real acquisition thread).
+
+    Matches the constructor signature the broadcaster calls
+    (``AcquisitionWorker(session, stream_config=..., time_fn=...)``) and the
+    ``start`` / ``stop`` / ``join`` lifecycle the broadcaster drives, but does nothing —
+    so subscribe/unsubscribe bookkeeping is exercised without spinning a background
+    grab/sleep loop per session. Production worker code is unchanged; only the symbol
+    the broadcaster resolves is swapped for this double in tests.
+    """
+
+    def __init__(self, session, *args, **kwargs):
+        self.session = session
+
+    def start(self):
+        return None
+
+    def stop(self):
+        return None
+
+    def join(self, timeout=None):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _stub_acquisition_worker():
+    """Swap the broadcaster's ``AcquisitionWorker`` for the no-op stub during this module."""
+    with patch.object(broadcaster_module, "AcquisitionWorker", _StubWorker):
+        yield
+
+
+class ViewerCountMachine(RuleBasedStateMachine):
+    """Drives subscribe/unsubscribe and checks viewer-count == distinct viewers.
+
+    Feature: concurrent-camera-stream-viewing, Property 8: Viewer-count correctness and
+    duplicate subscriptions
+    Validates: Requirements 8.1, 8.4, 8.5, 8.8
+    """
+
+    # Each entry is a ``(camera_id, viewer_id)`` tuple for an active viewer; rules add
+    # to this on subscribe and consume from it on unsubscribe.
+    viewers = Bundle("viewers")
+
+    def __init__(self):
+        super().__init__()
+        self.clock = MockClock(start=1000.0)
+        self.registry = ClaimRegistry()
+        self.config = StreamConfig()
+        self.broadcaster = StreamBroadcaster(
+            stream_config=self.config,
+            backend_factory=self._make_backend,
+            time_fn=self.clock,
+        )
+        # Reference model: camera_id -> set of currently-registered viewer ids.
+        self.expected: dict[str, set] = {camera: set() for camera in CAMERAS}
+        # Every viewer id ever issued, to assert global distinctness (duplicate
+        # subscriptions to the same camera must mint a fresh id, never reuse one).
+        self.issued_ids: set = set()
+
+    def _make_backend(self, camera_id, config):
+        """Build an always-openable mock backend that shares the claim registry."""
+        return MockCameraBackend(
+            camera_id,
+            claim_registry=self.registry,
+            clock=self.clock,
+        )
+
+    # --- rules -----------------------------------------------------------
+
+    @rule(target=viewers, camera=_cameras)
+    def subscribe(self, camera):
+        """Subscribe a viewer; record its distinct id and assert the count bump."""
+        before = self.broadcaster.viewer_count(camera)
+        assert before == len(self.expected[camera])
+
+        result = self.broadcaster.subscribe(camera)
+
+        if result.accepted:
+            # A duplicate subscription to the same camera is a brand-new viewer: the
+            # id must be non-null and never seen before (Req 8.5, 8.8).
+            assert result.viewer_id is not None
+            assert result.viewer_id not in self.issued_ids, (
+                f"subscribe reused viewer id {result.viewer_id!r}"
+            )
+            self.issued_ids.add(result.viewer_id)
+            self.expected[camera].add(result.viewer_id)
+
+            # Each subscription adds exactly one to the active count (Req 8.1, 8.4).
+            after = self.broadcaster.viewer_count(camera)
+            assert after == before + 1
+            assert result.viewer_count == after
+            return (camera, result.viewer_id)
+
+        # The only rejection reachable here is hitting the per-camera cap; it must not
+        # disturb the count (existing viewers untouched).
+        assert result.reason == "viewer_limit"
+        assert result.viewer_id is None
+        assert before == MAX_VIEWERS
+        assert self.broadcaster.viewer_count(camera) == before
+        assert result.viewer_count == before
+        return multiple()
+
+    @rule(entry=consumes(viewers))
+    def unsubscribe(self, entry):
+        """Unsubscribe a known viewer; assert the count drops by exactly one."""
+        camera, viewer_id = entry
+        before = self.broadcaster.viewer_count(camera)
+        assert viewer_id in self.expected[camera]
+
+        self.broadcaster.unsubscribe(camera, viewer_id)
+        self.expected[camera].discard(viewer_id)
+
+        after = self.broadcaster.viewer_count(camera)
+        assert after == before - 1
+        assert after == len(self.expected[camera])
+
+    # --- invariant -------------------------------------------------------
+
+    @invariant()
+    def viewer_count_matches_distinct_viewers(self):
+        """Count is a non-negative int equal to the distinct registered viewers."""
+        for camera in CAMERAS:
+            count = self.broadcaster.viewer_count(camera)
+            # A genuine non-negative integer (reject bools, which are int subclasses).
+            assert isinstance(count, int) and not isinstance(count, bool)
+            assert count >= 0
+            assert count == len(self.expected[camera])
+
+
+# Feature: concurrent-camera-stream-viewing, Property 8: Viewer-count correctness and duplicate subscriptions
+# Validates: Requirements 8.1, 8.4, 8.5, 8.8
+TestViewerCount = ViewerCountMachine.TestCase
+TestViewerCount.settings = settings(max_examples=100, stateful_step_count=50, deadline=None)

--- a/test/backend-test/utils/streaming/test_broadcaster_viewerlimit.py
+++ b/test/backend-test/utils/streaming/test_broadcaster_viewerlimit.py
@@ -1,0 +1,238 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Stateful property-based test for viewer-limit enforcement.
+
+Feature: concurrent-camera-stream-viewing, Property 6: Viewer-limit enforcement
+— for any interleaving of subscribe / unsubscribe against a single camera with a
+small ``max_viewers``, a subscribe issued while the camera is already at
+``max_viewers`` active viewers is rejected with
+``SubscribeResult(accepted=False, reason="viewer_limit")`` and does NOT change
+the viewer set; the active viewer count never exceeds ``max_viewers``; and every
+previously-accepted viewer remains registered and can still read frames
+(``get_frame`` never errors and never reports ``DISCONNECTED`` for them)
+(Req 1.3, 1.6).
+
+Driven by a Hypothesis ``RuleBasedStateMachine`` (min 100 iterations) over the
+two operations that move the viewer set:
+
+* ``subscribe(camera)`` — attempt to add a viewer.
+* ``unsubscribe(viewer)`` — remove a previously-accepted viewer.
+
+After every step a set of invariants is checked: the broadcaster's reported
+viewer count equals the model's set size, never exceeds ``max_viewers``, and all
+modelled viewers read a frame successfully.
+
+Worker threads are stubbed: a test-only :class:`_NoThreadStreamBroadcaster`
+subclass replaces the real :class:`AcquisitionWorker` (which would spawn a
+producer thread grabbing from the backend and, on the default ``None`` grab,
+self-terminate the session into ``ERROR``) with an in-line
+:class:`_FakeAcquisitionWorker` that synchronously publishes one frame and marks
+the session ``RUNNING``. This keeps the test deterministic and focused on the
+broadcaster's registry / viewer-limit logic. **No production code is modified** —
+the subclass only swaps the worker class around the inherited ``_start_session``
+call.
+"""
+import utils.streaming.broadcaster as broadcaster_module
+from hypothesis import settings
+from hypothesis.stateful import (
+    Bundle,
+    RuleBasedStateMachine,
+    consumes,
+    initialize,
+    invariant,
+    multiple,
+    precondition,
+    rule,
+)
+from hypothesis import strategies as st
+
+from mock_camera_backend import (
+    MOCK_BACKEND_CLASSES,
+    ClaimRegistry,
+    MockClock,
+    make_raw_frame,
+)
+from utils.streaming.broadcaster import StreamBroadcaster
+from utils.streaming.models import FrameStatus, SessionState, StreamConfig
+
+CAMERA_ID = "Fake_1"
+# Freshness ceiling large enough that the single published frame never reads
+# STALE regardless of the (unadvanced) virtual clock — keeps the "existing
+# viewers can read frames" invariant about registration, not freshness.
+_NEVER_STALE_S = 1e9
+
+
+# --------------------------------------------------------------------------- #
+# Test-only worker stub + broadcaster subclass (no production code changes)
+# --------------------------------------------------------------------------- #
+class _FakeAcquisitionWorker:
+    """In-line stand-in for ``AcquisitionWorker`` that spawns no thread.
+
+    Mimics just enough of the real worker for the broadcaster's start-on-first
+    path: on :meth:`start` it synchronously publishes a single frame into the
+    session's latest-frame slot and transitions the session to ``RUNNING`` (as
+    the real worker does on its first frame), so existing viewers' ``get_frame``
+    returns ``OK`` rather than ``NO_FRAME`` — without a real producer thread that
+    would grab from the mock backend and disconnect on the default ``None`` grab.
+    """
+
+    def __init__(self, session, *, stream_config=None, time_fn=lambda: 0.0,
+                 sleep_fn=None, stop_event=None):
+        self._session = session
+        self._time = time_fn
+
+    def start(self):
+        self._session.publish(make_raw_frame(seq=1), now=self._time())
+        self._session.state = SessionState.RUNNING
+        return None
+
+    def stop(self):
+        pass
+
+    def join(self, timeout=None):
+        pass
+
+
+class _NoThreadStreamBroadcaster(StreamBroadcaster):
+    """``StreamBroadcaster`` whose sessions use the no-thread worker stub.
+
+    Overrides only :meth:`_start_session` to swap the module-level
+    ``AcquisitionWorker`` for :class:`_FakeAcquisitionWorker` around the inherited
+    implementation, so all of the production registry / open / start_stream /
+    rollback logic still runs unchanged — only the producer thread is stubbed.
+    """
+
+    def _start_session(self, camera_id, config):
+        real_worker_cls = broadcaster_module.AcquisitionWorker
+        broadcaster_module.AcquisitionWorker = _FakeAcquisitionWorker
+        try:
+            return super()._start_session(camera_id, config)
+        finally:
+            broadcaster_module.AcquisitionWorker = real_worker_cls
+
+
+# --------------------------------------------------------------------------- #
+# The stateful machine
+# --------------------------------------------------------------------------- #
+class ViewerLimitMachine(RuleBasedStateMachine):
+    """Subscribe/unsubscribe a single camera and assert the viewer-limit contract.
+
+    Feature: concurrent-camera-stream-viewing, Property 6: Viewer-limit enforcement
+    Validates: Requirements 1.3, 1.6
+    """
+
+    viewers = Bundle("viewers")
+
+    def __init__(self):
+        super().__init__()
+        self.broadcaster = None
+        self.max_viewers = None
+        # Model of currently-registered viewer ids (mirrors the broadcaster's set).
+        self.model_viewers: set[str] = set()
+
+    @initialize(
+        n=st.integers(min_value=1, max_value=4),
+        backend_cls=st.sampled_from(list(MOCK_BACKEND_CLASSES.values())),
+    )
+    def setup(self, n, backend_cls):
+        """Build a broadcaster with a small ``max_viewers`` to hit the boundary fast."""
+        self.max_viewers = n
+        clock = MockClock(start=1000.0)
+        registry = ClaimRegistry()
+
+        def backend_factory(camera_id, config, _cls=backend_cls, _clock=clock, _reg=registry):
+            return _cls(camera_id, clock=_clock, claim_registry=_reg)
+
+        self.broadcaster = _NoThreadStreamBroadcaster(
+            stream_config=StreamConfig(max_viewers=n, stale_after_s=_NEVER_STALE_S),
+            backend_factory=backend_factory,
+            time_fn=clock,
+        )
+
+    # --- rules ------------------------------------------------------------
+
+    @rule(target=viewers)
+    def subscribe(self):
+        """Attempt a subscribe; assert accept-below-limit vs reject-at-limit."""
+        at_limit = len(self.model_viewers) >= self.max_viewers
+        result = self.broadcaster.subscribe(CAMERA_ID)
+
+        if at_limit:
+            # Property 6: past max_viewers, reject with reason "viewer_limit" and
+            # leave the viewer set untouched (Req 1.3, 1.6).
+            assert result.accepted is False
+            assert result.reason == "viewer_limit"
+            assert result.viewer_id is None
+            assert result.viewer_count == self.max_viewers
+            assert self.broadcaster.viewer_count(CAMERA_ID) == len(self.model_viewers)
+            return multiple()  # nothing added to the bundle
+
+        # Below the limit: accept, register, and report the new count.
+        assert result.accepted is True, f"unexpected rejection: {result!r}"
+        assert result.reason is None
+        assert result.viewer_id is not None
+        self.model_viewers.add(result.viewer_id)
+        assert result.viewer_count == len(self.model_viewers)
+        return result.viewer_id
+
+    @precondition(lambda self: len(self.model_viewers) > 0)
+    @rule(viewer=consumes(viewers))
+    def unsubscribe(self, viewer):
+        """Remove a previously-accepted viewer; the set must shrink by one."""
+        if viewer not in self.model_viewers:
+            # The bundle may retain ids already removed by a prior step; skip them.
+            return
+        self.broadcaster.unsubscribe(CAMERA_ID, viewer)
+        self.model_viewers.discard(viewer)
+        assert self.broadcaster.viewer_count(CAMERA_ID) == len(self.model_viewers)
+
+    # --- invariants -------------------------------------------------------
+
+    @invariant()
+    def count_matches_model_and_within_limit(self):
+        """Reported count equals the model and never exceeds max_viewers."""
+        if self.broadcaster is None:
+            return
+        count = self.broadcaster.viewer_count(CAMERA_ID)
+        assert count == len(self.model_viewers)
+        assert count <= self.max_viewers
+
+    @invariant()
+    def existing_viewers_can_read(self):
+        """Every registered viewer still reads a frame (never errors/DISCONNECTED)."""
+        if self.broadcaster is None:
+            return
+        for viewer_id in self.model_viewers:
+            result = self.broadcaster.get_frame(CAMERA_ID, viewer_id)
+            assert result.status != FrameStatus.DISCONNECTED, (
+                f"existing viewer {viewer_id} unexpectedly DISCONNECTED"
+            )
+            # The stubbed worker published a fresh frame on session start, so a
+            # registered viewer reads OK (proves it remains a live viewer).
+            assert result.status == FrameStatus.OK, (
+                f"existing viewer {viewer_id} read {result.status} (expected OK)"
+            )
+            assert result.frame is not None
+
+
+# Min 100 iterations (examples), with enough steps per example to fill past the
+# small max_viewers boundary and exercise re-subscribe after unsubscribe.
+ViewerLimitMachine.TestCase.settings = settings(
+    max_examples=120,
+    stateful_step_count=24,
+    deadline=None,
+)
+
+# pytest collects this TestCase subclass and runs the stateful machine.
+TestViewerLimitEnforcement = ViewerLimitMachine.TestCase

--- a/test/backend-test/utils/streaming/test_capture_validation.py
+++ b/test/backend-test/utils/streaming/test_capture_validation.py
@@ -1,0 +1,181 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based tests for out-of-range per-capture config rejection (Task 7.6).
+
+Feature: concurrent-camera-stream-viewing, Property 21: Out-of-range capture
+configuration is rejected — for any per-capture image-source configuration
+containing at least one parameter value outside its accepted range, the request
+is rejected with an error identifying an offending parameter and the previously
+active image-source configuration is preserved unchanged.
+
+These target the pure validator added in task 7.3,
+:func:`utils.streaming.backends.validate_config_against_bounds`, which raises
+:class:`~utils.streaming.backends.CaptureConfigValidationError` (carrying the
+offending ``parameter``) when a supplied value falls outside its bounds. The
+validator is pure logic with no ``gi`` / hardware dependency, so this module is
+import-safe on a bare checkout.
+
+Validates: Requirements 6.5
+"""
+import copy
+
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+# ``backends`` is import-safe without the native stack: its gi imports are lazy
+# and ``validate_config_against_bounds`` is pure validation logic.
+from utils.streaming.backends import (
+    CaptureConfigValidationError,
+    validate_config_against_bounds,
+)
+
+# Advanced (non-top-level) control keys exercised by the bounds/config maps: one
+# enumeration control and one boolean control.
+ENUM_KEY = "balanceWhiteAuto"
+BOOL_KEY = "reverseX"
+
+# Top-level numeric controls range-checked by the validator.
+NUMERIC_KEYS = ("gain", "exposure")
+
+# Short lowercase identifiers used for enumeration option strings.
+_safe_text = st.text(alphabet="abcdefghijklmnopqrstuvwxyz", min_size=1, max_size=8)
+
+# Values that are NOT valid booleans (reject for a boolean control): excludes
+# bool, 0/1, and the "true"/"false"/"0"/"1" strings the validator accepts.
+_non_boolean_values = st.sampled_from(["maybe", "yes", "nope", "on", "off", 2, 3, 7, 3.5])
+
+
+@st.composite
+def _capture_case(draw):
+    """Build a (bounds, bad_config, offending_param, good_config) example.
+
+    ``bounds`` carries gain/exposure numeric ranges, an enumeration control, and
+    a boolean control. ``bad_config`` forces exactly one parameter
+    (``offending_param``) out of range while every other value stays in range, so
+    the validator deterministically rejects naming that parameter. ``good_config``
+    is an all-in-range counterpart used to assert the accepting path.
+    """
+    # Numeric bounds for gain / exposure (min < max).
+    def numeric_bounds():
+        lo = draw(st.integers(min_value=-1000, max_value=1000))
+        hi = draw(st.integers(min_value=lo + 1, max_value=lo + 2000))
+        return {"type": "float", "min": lo, "max": hi}
+
+    gain_b = numeric_bounds()
+    exp_b = numeric_bounds()
+    numeric_bounds_map = {"gain": gain_b, "exposure": exp_b}
+
+    options = draw(st.lists(_safe_text, min_size=1, max_size=5, unique=True))
+
+    bounds = {
+        "gain": gain_b,
+        "exposure": exp_b,
+        ENUM_KEY: {"type": "enumeration", "options": options},
+        BOOL_KEY: {"type": "boolean"},
+    }
+
+    offending = draw(st.sampled_from(["gain", "exposure", ENUM_KEY, BOOL_KEY]))
+
+    def in_range_numeric(b):
+        return draw(st.integers(min_value=b["min"], max_value=b["max"]))
+
+    def out_of_range_numeric(b):
+        return draw(
+            st.one_of(
+                st.integers(min_value=b["min"] - 1000, max_value=b["min"] - 1),
+                st.integers(min_value=b["max"] + 1, max_value=b["max"] + 1000),
+            )
+        )
+
+    def in_range_enum():
+        return draw(st.sampled_from(options))
+
+    def out_of_range_enum():
+        val = draw(_safe_text)
+        # Must not match any accepted option (validator compares str(value)).
+        assume(val not in options)
+        return val
+
+    def in_range_bool():
+        return draw(st.sampled_from([True, False, 0, 1, "true", "false", "0", "1"]))
+
+    def out_of_range_bool():
+        return draw(_non_boolean_values)
+
+    # bad_config: exactly the offending parameter is out of range.
+    bad_config = {
+        "gain": out_of_range_numeric(gain_b) if offending == "gain" else in_range_numeric(gain_b),
+        "exposure": out_of_range_numeric(exp_b)
+        if offending == "exposure"
+        else in_range_numeric(exp_b),
+        "advancedSettings": {
+            ENUM_KEY: out_of_range_enum() if offending == ENUM_KEY else in_range_enum(),
+            BOOL_KEY: out_of_range_bool() if offending == BOOL_KEY else in_range_bool(),
+        },
+    }
+
+    # good_config: every value is freshly drawn in range.
+    good_config = {
+        "gain": in_range_numeric(gain_b),
+        "exposure": in_range_numeric(exp_b),
+        "advancedSettings": {
+            ENUM_KEY: in_range_enum(),
+            BOOL_KEY: in_range_bool(),
+        },
+    }
+
+    return bounds, bad_config, offending, good_config
+
+
+# Feature: concurrent-camera-stream-viewing, Property 21: Out-of-range capture configuration is rejected
+# Validates: Requirements 6.5
+@settings(max_examples=200)
+@given(_capture_case())
+def test_property_21_out_of_range_capture_configuration_is_rejected(case):
+    """Out-of-range capture config is rejected naming an offending parameter;
+    the in-range config is accepted and validation never mutates the config.
+
+    Feature: concurrent-camera-stream-viewing, Property 21: Out-of-range capture configuration is rejected
+    Validates: Requirements 6.5
+    """
+    bounds, bad_config, offending, good_config = case
+
+    # The previously active configuration must be preserved unchanged across a
+    # rejected validation, so snapshot it for an equality check afterwards.
+    bad_snapshot = copy.deepcopy(bad_config)
+
+    # Rejection: the out-of-range config raises, naming an offending parameter.
+    try:
+        validate_config_against_bounds(bad_config, bounds)
+        raised = None
+    except CaptureConfigValidationError as err:
+        raised = err
+
+    assert raised is not None, (
+        f"expected CaptureConfigValidationError for out-of-range {offending}, got none"
+    )
+    # The error identifies an offending parameter, and (since exactly one value
+    # was forced out of range) it is precisely that parameter.
+    assert raised.parameter == offending
+    assert offending in ("gain", "exposure", ENUM_KEY, BOOL_KEY)
+
+    # Preservation: validation must not mutate the supplied config (the active
+    # image-source configuration is left unchanged on rejection).
+    assert bad_config == bad_snapshot
+
+    # Acceptance: an all-in-range config validates and returns None.
+    good_snapshot = copy.deepcopy(good_config)
+    assert validate_config_against_bounds(good_config, bounds) is None
+    # The accepting path likewise leaves the config untouched.
+    assert good_config == good_snapshot

--- a/test/backend-test/utils/streaming/test_inference_failure.py
+++ b/test/backend-test/utils/streaming/test_inference_failure.py
@@ -1,0 +1,241 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based test for inference-failure session integrity.
+
+Feature: concurrent-camera-stream-viewing, Property 17: Inference failure leaves
+the session intact — for any active session, if an inference frame request fails
+or the camera becomes unavailable for that request, an error / no-frame indication
+is returned to the caller while the session remains RUNNING with its claim
+retained.
+
+Validates: Requirements 6.6.
+
+How the property is exercised
+-----------------------------
+A real :class:`StreamBroadcaster` is wired with an injected ``backend_factory``
+(building the shared :class:`MockCameraBackend` registered against one shared
+:class:`ClaimRegistry`) and an injected :class:`MockClock`, exactly like the
+single-claim / disconnection-cascade property tests. For each example we:
+
+1. Subscribe a generated number of viewers to a single camera (start-on-first
+   opens the one device claim; the rest reuse it). The session is now ACTIVE
+   (RUNNING) holding exactly one claim.
+2. Make the inference frame *read* fail in one of two ways the active-session
+   path can encounter (per task 7.1 the active path is a pure latest-slot read
+   that opens no second claim and never stops the session):
+
+   * ``no_frame`` — leave the latest-frame slot empty (no publish). The session
+     read returns NO_FRAME, so ``get_inference_frame`` returns ``None`` (the
+     no-frame / error indication).
+   * ``read_error`` — script the session's slot read to raise (modelling a frame
+     read that errors / the camera becoming unavailable for that request). The
+     broadcaster's defensive branch swallows it and returns ``None`` while
+     leaving the live session untouched.
+
+3. Call ``get_inference_frame`` (optionally several times).
+
+We then assert, for every variation and viewer count, that the inference request
+returned ``None`` (the error / no-frame indication) WITHOUT disturbing the live
+session (Req 6.6):
+
+* the session still exists and its state is still ``RUNNING``;
+* the viewer count is unchanged;
+* the single device claim is still held (``registry.open_count == 1``) — no second
+  claim was opened (``backend.open_count == 1``) and the claim was **not** released
+  (``backend.close_count == 0``); and
+* the single-claim invariant held throughout (no overlap, no release without a
+  matching open).
+
+Test-only technique (no production code changed)
+------------------------------------------------
+Like ``test_broadcaster_claim.py`` / ``test_broadcaster_disconnect.py``, this
+patches the ``AcquisitionWorker`` symbol in the broadcaster module with a no-op
+stub for the duration of each example so no real daemon thread / wall-clock grab
+loop runs. The stub marks the session RUNNING on ``start()`` (mirroring the real
+worker after its first published frame), which is exactly the live state the
+property quantifies over. The ``read_error`` variation patches the *session
+instance's* ``read_latest`` for the single inference call to raise — a pure test
+seam that drives the broadcaster's existing defensive path; production code is
+untouched.
+"""
+from __future__ import annotations
+
+import unittest.mock as mock
+from typing import Optional
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from mock_camera_backend import (
+    MOCK_BACKEND_CLASSES,
+    ClaimRegistry,
+    MockClock,
+)
+from utils.streaming import broadcaster as broadcaster_module
+from utils.streaming.broadcaster import StreamBroadcaster
+from utils.streaming.models import SessionState, StreamConfig
+
+# Keep max_viewers comfortably above the generated viewer count so the active
+# session — not the viewer-limit branch (Property 6) — is what we exercise.
+_CONFIG = StreamConfig(max_viewers=8, stale_after_s=2.0)
+_CAMERA = "Fake_inference_fail_1"
+
+
+class _StubAcquisitionWorker:
+    """No-op stand-in for ``AcquisitionWorker`` (test-only; see module docstring).
+
+    Matches the broadcaster's construction/usage contract
+    (``AcquisitionWorker(session, stream_config=..., time_fn=...)`` then
+    ``start()`` / ``stop()`` / ``join()``) but runs no thread and performs no
+    grabs, so the session state is deterministic. ``start()`` marks the session
+    RUNNING to mirror the real worker after its first published frame.
+    """
+
+    def __init__(self, session, *, stream_config=None, time_fn=None, **kwargs) -> None:
+        self.session = session
+
+    def start(self):
+        self.session.state = SessionState.RUNNING
+        return None
+
+    def stop(self) -> None:
+        return None
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        return None
+
+
+# Feature: concurrent-camera-stream-viewing, Property 17: Inference failure leaves the session intact
+# Validates: Requirements 6.6
+@pytest.mark.parametrize(
+    "backend_cls", MOCK_BACKEND_CLASSES.values(), ids=list(MOCK_BACKEND_CLASSES)
+)
+@settings(max_examples=150, deadline=None)
+@given(
+    num_viewers=st.integers(min_value=1, max_value=_CONFIG.max_viewers),
+    failure_mode=st.sampled_from(["no_frame", "read_error"]),
+    num_requests=st.integers(min_value=1, max_value=4),
+    clock_advance=st.floats(
+        min_value=0.0, max_value=120.0, allow_nan=False, allow_infinity=False
+    ),
+)
+def test_property_17_inference_failure_leaves_session_intact(
+    backend_cls, num_viewers, failure_mode, num_requests, clock_advance
+):
+    """A failed/unavailable inference request returns None while the active
+    session stays RUNNING with its single claim retained and viewer set unchanged.
+
+    Feature: concurrent-camera-stream-viewing, Property 17: Inference failure leaves the session intact
+    Validates: Requirements 6.6
+    """
+    registry = ClaimRegistry()
+    clock = MockClock(start=1000.0)
+    created: dict[str, object] = {}
+
+    def backend_factory(camera_id, config):
+        backend = backend_cls(
+            camera_id,
+            claim_registry=registry,
+            clock=clock,
+        )
+        created[camera_id] = backend
+        return backend
+
+    broadcaster = StreamBroadcaster(
+        stream_config=_CONFIG,
+        backend_factory=backend_factory,
+        time_fn=clock.time,
+    )
+
+    with mock.patch.object(broadcaster_module, "AcquisitionWorker", _StubAcquisitionWorker):
+        # 1. Subscribe the generated number of viewers: start-on-first opens the
+        #    one claim, the rest reuse it. The session is now ACTIVE (RUNNING).
+        viewer_ids = []
+        for _ in range(num_viewers):
+            result = broadcaster.subscribe(_CAMERA)
+            assert result.accepted is True
+            viewer_ids.append(result.viewer_id)
+
+        # Sanity: a single claim is open while the session has viewers, and the
+        # session is live. No frame has been published yet (slot empty).
+        assert broadcaster.viewer_count(_CAMERA) == num_viewers
+        assert registry.open_count(_CAMERA) == 1
+
+        session = broadcaster._sessions[_CAMERA]
+        backend = created[_CAMERA]
+        assert session.state == SessionState.RUNNING
+        assert session.latest is None  # nothing published => active read fails (NO_FRAME)
+
+        # Record the device-call counts so we can prove the inference read reused
+        # the running claim: no new open(), no close() (the claim is retained).
+        opens_before = backend.open_count
+        closes_before = backend.close_count
+        grabs_before = backend.grab_count
+        assert opens_before == 1
+        assert closes_before == 0
+
+        # Advancing the clock varies the freshness context of the (empty) slot;
+        # the inference read must behave the same — None, session intact.
+        clock.advance(clock_advance)
+
+        # 2 + 3. Drive the failed inference request(s). In ``read_error`` mode the
+        #        session's slot read is scripted to raise for the duration of the
+        #        inference calls (models a frame read that errors / camera
+        #        unavailable for that request); the broadcaster's defensive branch
+        #        must swallow it and return None without disturbing the session.
+        for _ in range(num_requests):
+            if failure_mode == "read_error":
+                with mock.patch.object(
+                    session, "read_latest", side_effect=RuntimeError("inference read failed")
+                ):
+                    frame = broadcaster.get_inference_frame(_CAMERA)
+            else:  # "no_frame": empty slot => NO_FRAME => None
+                frame = broadcaster.get_inference_frame(_CAMERA)
+
+            # The caller gets the error / no-frame indication: None (Req 6.6).
+            assert frame is None
+
+    # --- assertions: the session is fully intact (Req 6.6) ---------------
+
+    # The session still exists and is still RUNNING (never torn down / errored).
+    assert _CAMERA in broadcaster._sessions
+    assert broadcaster._sessions[_CAMERA] is session
+    assert session.state == SessionState.RUNNING
+
+    # The viewer set is unchanged.
+    assert broadcaster.viewer_count(_CAMERA) == num_viewers
+    assert set(session.viewers.keys()) == set(viewer_ids)
+
+    # The single device claim is still held: no second claim opened, and the
+    # claim was NOT released by the failed inference request.
+    assert registry.open_count(_CAMERA) == 1
+    assert registry.total_open() == 1
+    assert backend.open_count == opens_before      # no new claim opened
+    assert backend.close_count == closes_before    # claim retained (not released)
+
+    # The active-session inference path reuses the running claim via a pure slot
+    # read: it performs no device grab of its own.
+    assert backend.grab_count == grabs_before
+
+    # The single-claim invariant held throughout (no overlap, no release without
+    # a matching open).
+    registry.assert_single_claim()
+
+    # Cleanup: drain viewers so the broadcaster stops the session and releases the
+    # claim through its normal stop-on-last path, returning the claim count to 0.
+    with mock.patch.object(broadcaster_module, "AcquisitionWorker", _StubAcquisitionWorker):
+        for viewer_id in list(session.viewers.keys()):
+            broadcaster.unsubscribe(_CAMERA, viewer_id)
+    assert registry.open_count(_CAMERA) == 0

--- a/test/backend-test/utils/streaming/test_inference_reuse.py
+++ b/test/backend-test/utils/streaming/test_inference_reuse.py
@@ -1,0 +1,267 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based test for inference claim reuse with dedicated-claim fallback.
+
+Feature: concurrent-camera-stream-viewing, Property 16: Inference reuses the
+session claim, falls back when none — for any camera, a frame request from the
+inference/capture path returns a frame WITHOUT opening a second claim when a
+session is active (the open-claim count stays exactly 1), and when no session
+exists it opens exactly one dedicated claim, returns a frame, and releases it
+(the open-claim count returns to 0).
+
+Validates: Requirements 6.1, 6.3, 6.4.
+
+How the property is exercised
+-----------------------------
+:meth:`StreamBroadcaster.get_inference_frame` is driven against an injected
+``backend_factory`` that builds the hardware-free :class:`MockCameraBackend`
+registered against one shared :class:`ClaimRegistry` (so the test can read the
+true per-camera open-claim count) plus an injected :class:`MockClock` (so frame
+freshness is deterministic). Every backend the factory builds is captured so the
+test can assert exactly how many backends were created and how many ``open()`` /
+``close()`` calls each saw — that is how "no second claim was opened" is proven.
+
+Hypothesis generates two independent scenarios per example (camera id + frame
+geometry):
+
+* **Active session** — subscribe first (the single claim is opened), publish a
+  frame into the live session, then call ``get_inference_frame``. The call must
+  return a ``{"data", "height", "width"}`` dict, the open-claim count must stay
+  exactly 1, and **no** second backend / second ``open()`` may occur (the running
+  claim is reused).
+* **No session** — call ``get_inference_frame`` on a camera with no session. The
+  call must open exactly one dedicated claim, return a frame dict, and release the
+  claim so the registry's open count returns to 0 (with the peak concurrency for
+  that camera being exactly 1).
+
+Worker-stub technique (test-only; mirrors ``test_broadcaster_claim.py``)
+------------------------------------------------------------------------
+In production a subscribe starts a real :class:`AcquisitionWorker` on a daemon
+thread (a ``grab -> publish`` loop). That thread is irrelevant to the claim-reuse
+property and would make the active-session frame non-deterministic. For the
+lifetime of each example the ``AcquisitionWorker`` symbol in the broadcaster
+module is patched with a no-op stub that simply marks the session RUNNING on
+``start()`` (mirroring the real worker after its first published frame). The
+active-session frame is then made deterministically available by publishing it
+through the session directly before reading. The broadcaster's
+subscribe / get_inference_frame logic — and therefore every ``open()`` /
+``close()`` that moves the device claim — runs completely unchanged. No
+production code is modified.
+"""
+from __future__ import annotations
+
+import unittest.mock as mock
+from typing import List, Optional
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+import utils.streaming.broadcaster as broadcaster_module
+from mock_camera_backend import (
+    BACKEND_KINDS,
+    ClaimRegistry,
+    MockCameraBackend,
+    MockClock,
+    make_backend,
+    make_raw_frame,
+)
+from utils.streaming.broadcaster import StreamBroadcaster
+from utils.streaming.models import SessionState, StreamConfig
+
+# A small fixed set of physical cameras the property quantifies over.
+CAMERAS = ("cam_a", "cam_b", "cam_c")
+
+_STREAM_CONFIG = StreamConfig(max_viewers=4, stale_timeout_s=30)
+
+# Hypothesis runs >= 100 iterations; the work per example is tiny and synchronous.
+_PROP_SETTINGS = settings(max_examples=100, deadline=None)
+
+
+class _StubAcquisitionWorker:
+    """No-op stand-in for ``AcquisitionWorker`` (test-only; see module docstring).
+
+    Matches the construction/usage contract the broadcaster relies on
+    (``AcquisitionWorker(session, stream_config=..., time_fn=...)`` then
+    ``start()`` / ``stop()`` / ``join()``) but runs no thread and performs no
+    grabs, so the open-claim count is deterministic. ``start()`` marks the session
+    RUNNING to mirror the real worker after its first published frame.
+    """
+
+    def __init__(self, session, *, stream_config=None, time_fn=None, **kwargs) -> None:
+        self.session = session
+
+    def start(self):
+        self.session.state = SessionState.RUNNING
+        return None
+
+    def stop(self) -> None:
+        return None
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        return None
+
+
+def _make_broadcaster(backend_kind, registry, clock, created):
+    """Build a broadcaster whose factory records every backend it creates.
+
+    Each backend shares the one ``registry`` + ``clock`` so the test reads the true
+    per-camera open-claim count, and is pre-loaded with a single scripted frame so
+    the no-session dedicated-claim path has a frame to grab. The ``created`` list
+    captures every backend instance so the test can assert exactly how many
+    backends / ``open()`` calls occurred.
+    """
+
+    def backend_factory(camera_id, config) -> MockCameraBackend:
+        backend = make_backend(
+            backend_kind,
+            camera_id,
+            claim_registry=registry,
+            clock=clock,
+            # A scripted frame so the dedicated-claim fallback's single grab
+            # returns a frame (the active-session path publishes its own frame and
+            # never grabs from this queue).
+            frames=[make_raw_frame(seq=1, width=8, height=8)],
+        )
+        created.append(backend)
+        return backend
+
+    return StreamBroadcaster(
+        stream_config=_STREAM_CONFIG,
+        backend_factory=backend_factory,
+        time_fn=clock.time,
+    )
+
+
+@pytest.mark.parametrize("backend_kind", BACKEND_KINDS)
+@given(
+    camera=st.sampled_from(CAMERAS),
+    width=st.integers(min_value=1, max_value=64),
+    height=st.integers(min_value=1, max_value=64),
+    seq=st.integers(min_value=1, max_value=1000),
+)
+@_PROP_SETTINGS
+def test_inference_reuses_active_session_claim(backend_kind, camera, width, height, seq):
+    """Active session: inference reuses the claim, opening no second claim (Req 6.1, 6.4).
+
+    Feature: concurrent-camera-stream-viewing, Property 16: Inference reuses the
+    session claim, falls back when none.
+    Validates: Requirements 6.1, 6.4.
+    """
+    registry = ClaimRegistry()
+    clock = MockClock(start=1_000.0)
+    created: List[MockCameraBackend] = []
+
+    with mock.patch.object(
+        broadcaster_module, "AcquisitionWorker", _StubAcquisitionWorker
+    ):
+        broadcaster = _make_broadcaster(backend_kind, registry, clock, created)
+
+        # First viewer opens the single device claim (start-on-first-viewer).
+        result = broadcaster.subscribe(camera)
+        assert result.accepted
+        assert registry.open_count(camera) == 1
+        assert len(created) == 1, "subscribe should build exactly one backend"
+        session_backend = created[0]
+        assert session_backend.open_count == 1
+
+        # Publish a frame into the live session so the reused-claim read has a
+        # deterministically-available, fresh frame (no real worker thread runs).
+        session = broadcaster._sessions[camera]
+        session.publish(
+            make_raw_frame(seq=seq, width=width, height=height), now=clock.time()
+        )
+
+        # Snapshot interaction counts immediately before the inference read.
+        opens_before = session_backend.open_count
+        backends_before = len(created)
+
+        frame = broadcaster.get_inference_frame(camera)
+
+        # A frame dict in the legacy shape is returned from the reused claim.
+        assert isinstance(frame, dict)
+        assert set(frame.keys()) == {"data", "height", "width"}
+        assert frame["width"] == width
+        assert frame["height"] == height
+
+        # The running claim was reused: no second backend, no second open(), and
+        # the open-claim count stayed exactly 1 (never overlapped).
+        assert len(created) == backends_before, "no second backend may be built"
+        assert session_backend.open_count == opens_before, "no second open() may occur"
+        assert registry.open_count(camera) == 1
+        assert registry.max_concurrent.get(camera) == 1
+        assert not registry.overlap_detected
+
+        # The session is left intact (still RUNNING, claim retained, viewer kept).
+        assert broadcaster._sessions.get(camera) is session
+        assert session.state == SessionState.RUNNING
+        assert broadcaster.viewer_count(camera) == 1
+
+        # Cleanup: drop the viewer so the claim is released through the normal path.
+        broadcaster.unsubscribe(camera, result.viewer_id)
+        assert registry.open_count(camera) == 0
+
+
+@pytest.mark.parametrize("backend_kind", BACKEND_KINDS)
+@given(
+    camera=st.sampled_from(CAMERAS),
+    width=st.integers(min_value=1, max_value=64),
+    height=st.integers(min_value=1, max_value=64),
+)
+@_PROP_SETTINGS
+def test_inference_falls_back_to_dedicated_claim_when_no_session(
+    backend_kind, camera, width, height
+):
+    """No session: inference opens exactly one dedicated claim and releases it (Req 6.3).
+
+    Feature: concurrent-camera-stream-viewing, Property 16: Inference reuses the
+    session claim, falls back when none.
+    Validates: Requirements 6.3.
+    """
+    registry = ClaimRegistry()
+    clock = MockClock(start=2_000.0)
+    created: List[MockCameraBackend] = []
+
+    with mock.patch.object(
+        broadcaster_module, "AcquisitionWorker", _StubAcquisitionWorker
+    ):
+        broadcaster = _make_broadcaster(backend_kind, registry, clock, created)
+
+        # Precondition: no session and no open claim for this camera.
+        assert broadcaster._sessions.get(camera) is None
+        assert registry.open_count(camera) == 0
+
+        frame = broadcaster.get_inference_frame(camera, config={"width": width})
+
+        # A frame dict in the legacy shape is returned from the dedicated grab.
+        assert isinstance(frame, dict)
+        assert set(frame.keys()) == {"data", "height", "width"}
+
+        # Exactly one dedicated backend was built, opened once, grabbed, and closed.
+        assert len(created) == 1, "exactly one dedicated backend should be built"
+        dedicated = created[0]
+        assert dedicated.open_count == 1, "exactly one dedicated claim opened"
+        assert dedicated.close_count == 1, "the dedicated claim must be released"
+        assert dedicated.grab_count == 1
+
+        # The claim was released: open count returns to 0, peak concurrency was 1,
+        # and no overlapping claim was ever observed.
+        assert registry.open_count(camera) == 0
+        assert registry.max_concurrent.get(camera) == 1
+        assert not registry.overlap_detected
+        assert not registry.released_without_open
+
+        # No lingering session was created by the fallback.
+        assert broadcaster._sessions.get(camera) is None
+        assert broadcaster.viewer_count(camera) == 0

--- a/test/backend-test/utils/streaming/test_override_isolation.py
+++ b/test/backend-test/utils/streaming/test_override_isolation.py
@@ -1,0 +1,306 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based test for override-preview isolation.
+
+Feature: concurrent-camera-stream-viewing, Property 20: Override preview isolation
+— for any per-request configuration override previewed against a *running* session,
+the session's applied control values (``session.applied_features``) and the shared
+latest-frame slot delivered to other viewers are left exactly unchanged by the
+override request.
+
+Validates: Requirements 5.4.
+
+How the property is exercised
+-----------------------------
+A real :class:`StreamBroadcaster` is wired with an injected ``backend_factory``
+(building the hardware-free :class:`MockCameraBackend` registered against one shared
+:class:`ClaimRegistry`) and an injected :class:`MockClock`, exactly like the other
+broadcaster property tests. For each example we:
+
+1. Subscribe a generated number of viewers to one camera. Start-on-first opens the
+   single device claim; the rest reuse it. A test-only worker stub marks the session
+   RUNNING and publishes one deterministic frame into the shared latest-frame slot
+   (mirroring the real acquisition worker after its first published frame).
+2. Optionally perform a prior successful ``apply_settings`` so the session has a
+   non-empty ``applied_features`` (the in-effect control set) to protect.
+3. Snapshot the protected state: a deep copy of ``session.applied_features``, the
+   identity + seq + bytes of the current latest-frame slot, the backend's
+   ``apply_features`` call count, and the frame every viewer currently reads via
+   ``get_frame``.
+4. Call ``preview_with_override(camera_id, override_config)`` with a generated
+   override config (optionally several times).
+
+We then assert the isolation post-condition (per task 8.3): after the call(s),
+
+* ``session.applied_features`` is byte-for-byte unchanged (equal to the snapshot);
+* the shared latest-frame slot is the *same object* with the same seq and bytes — so
+  every other viewer's ``get_frame`` returns the identical, same-seq frame; and
+* the backend saw no additional ``apply_features`` call from the preview (the override
+  was never applied to the live claim) and the single claim is still held.
+
+Note (per task 8.3): while a session is active the override is intentionally NOT
+applied to the live claim — isolation is the guarantee. This test asserts isolation,
+not that the override is reflected in the returned preview.
+
+Test-only technique (no production code changed)
+------------------------------------------------
+Like ``test_inference_reuse.py`` / ``test_inference_failure.py``, the
+``AcquisitionWorker`` symbol in the broadcaster module is patched with a no-op stub
+for the lifetime of each example so no real daemon thread / wall-clock grab loop
+runs. The stub marks the session RUNNING and publishes a single deterministic frame
+on ``start()`` (mirroring the real worker after its first frame). The broadcaster's
+subscribe / apply_settings / preview_with_override logic runs completely unchanged.
+"""
+from __future__ import annotations
+
+import copy
+import unittest.mock as mock
+from typing import List, Optional
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+import utils.streaming.broadcaster as broadcaster_module
+from mock_camera_backend import (
+    MOCK_BACKEND_CLASSES,
+    ClaimRegistry,
+    MockCameraBackend,
+    MockClock,
+    make_raw_frame,
+)
+from utils.streaming.broadcaster import StreamBroadcaster
+from utils.streaming.models import FrameStatus, SessionState, StreamConfig
+
+# Keep max_viewers comfortably above the generated viewer count so the active
+# session (not the viewer-limit branch) is what we exercise.
+_CONFIG = StreamConfig(max_viewers=8, stale_after_s=600.0)
+_CAMERA = "Fake_override_iso_1"
+
+# The deterministic frame the worker stub publishes into the shared slot. Its
+# byte payload is unique so "same frame" can be asserted on identity AND content.
+_SESSION_FRAME_SEQ = 7
+_SESSION_FRAME = make_raw_frame(seq=_SESSION_FRAME_SEQ, width=8, height=8)
+
+
+def _make_worker_stub(frame, clock):
+    """Build a no-op ``AcquisitionWorker`` stub that publishes ``frame`` on start.
+
+    The stub matches the broadcaster's construction/usage contract
+    (``AcquisitionWorker(session, stream_config=..., time_fn=...)`` then ``start()`` /
+    ``stop()`` / ``join()``) but runs no thread. ``start()`` marks the session RUNNING
+    and publishes a single deterministic frame into the shared latest-frame slot,
+    mirroring the real worker after its first published frame.
+    """
+
+    class _StubAcquisitionWorker:
+        def __init__(self, session, *, stream_config=None, time_fn=None, **kwargs):
+            self.session = session
+
+        def start(self):
+            self.session.state = SessionState.RUNNING
+            self.session.publish(frame, now=clock.time())
+            return None
+
+        def stop(self):
+            return None
+
+        def join(self, timeout: Optional[float] = None):
+            return None
+
+    return _StubAcquisitionWorker
+
+
+# --- generators -------------------------------------------------------------
+
+# A single control value: ints / floats / short strings, the shapes the backend's
+# apply_features accepts for gain / exposure / advanced controls.
+_control_values = st.one_of(
+    st.integers(min_value=-100, max_value=10_000),
+    st.floats(min_value=0.0, max_value=10_000.0, allow_nan=False, allow_infinity=False),
+    st.text(min_size=0, max_size=8),
+    st.booleans(),
+)
+
+# An image-source-style control dict (gain / exposure / brightness / contrast ...).
+_control_dict = st.dictionaries(
+    keys=st.sampled_from(["gain", "exposure", "brightness", "contrast", "gamma"]),
+    values=_control_values,
+    min_size=0,
+    max_size=5,
+)
+
+# An advanced-settings device-feature list ([{"feature","value"}, ...]).
+_advanced_list = st.lists(
+    st.fixed_dictionaries(
+        {
+            "feature": st.sampled_from(
+                ["Gain", "ExposureTime", "Gamma", "BlackLevel", "AcquisitionFrameRate"]
+            ),
+            "value": _control_values,
+        }
+    ),
+    min_size=0,
+    max_size=4,
+)
+
+
+@st.composite
+def _override_configs(draw):
+    """Generate a varied per-request override config (dict / list / advanced / None)."""
+    kind = draw(st.sampled_from(["dict", "dict_with_advanced", "feature_list", "none", "empty"]))
+    if kind == "none":
+        return None
+    if kind == "empty":
+        return {}
+    if kind == "feature_list":
+        return draw(_advanced_list)
+    config = draw(_control_dict)
+    if kind == "dict_with_advanced":
+        config = dict(config)
+        config["advancedSettings"] = draw(_advanced_list)
+    return config
+
+
+# Feature: concurrent-camera-stream-viewing, Property 20: Override preview isolation
+# Validates: Requirements 5.4
+@pytest.mark.parametrize(
+    "backend_cls", MOCK_BACKEND_CLASSES.values(), ids=list(MOCK_BACKEND_CLASSES)
+)
+@settings(max_examples=150, deadline=None)
+@given(
+    num_viewers=st.integers(min_value=1, max_value=_CONFIG.max_viewers),
+    prior_features=st.one_of(st.none(), _control_dict),
+    override_config=_override_configs(),
+    num_previews=st.integers(min_value=1, max_value=4),
+    clock_advance=st.floats(
+        min_value=0.0, max_value=120.0, allow_nan=False, allow_infinity=False
+    ),
+)
+def test_property_20_override_preview_isolation(
+    backend_cls, num_viewers, prior_features, override_config, num_previews, clock_advance
+):
+    """An override preview against a running session leaves the session's applied
+    control values and the shared latest-frame slot exactly unchanged for every viewer.
+
+    Feature: concurrent-camera-stream-viewing, Property 20: Override preview isolation
+    Validates: Requirements 5.4
+    """
+    registry = ClaimRegistry()
+    clock = MockClock(start=1000.0)
+    created: dict[str, MockCameraBackend] = {}
+
+    def backend_factory(camera_id, config):
+        backend = backend_cls(camera_id, claim_registry=registry, clock=clock)
+        created[camera_id] = backend
+        return backend
+
+    broadcaster = StreamBroadcaster(
+        stream_config=_CONFIG,
+        backend_factory=backend_factory,
+        time_fn=clock.time,
+    )
+
+    worker_stub = _make_worker_stub(_SESSION_FRAME, clock)
+
+    with mock.patch.object(broadcaster_module, "AcquisitionWorker", worker_stub):
+        # 1. Subscribe the generated number of viewers; start-on-first opens the one
+        #    claim and the worker stub publishes the deterministic frame + marks RUNNING.
+        viewer_ids: List[str] = []
+        for _ in range(num_viewers):
+            result = broadcaster.subscribe(_CAMERA)
+            assert result.accepted is True
+            viewer_ids.append(result.viewer_id)
+
+        session = broadcaster._sessions[_CAMERA]
+        backend = created[_CAMERA]
+        assert session.state == SessionState.RUNNING
+        assert broadcaster.viewer_count(_CAMERA) == num_viewers
+        assert registry.open_count(_CAMERA) == 1
+        assert session.latest is not None  # the worker stub published a frame
+
+        # 2. Optionally establish a non-empty applied_features via a prior successful
+        #    apply_settings (the in-effect control set the override must not disturb).
+        if prior_features:
+            broadcaster.apply_settings(_CAMERA, prior_features)
+
+        # 3. Snapshot the protected state BEFORE the override preview.
+        applied_before = copy.deepcopy(session.applied_features)
+        latest_obj_before = session.latest
+        seq_before = session.latest.seq
+        data_before = session.latest.data
+        apply_count_before = backend.apply_features_count
+        opens_before = backend.open_count
+        closes_before = backend.close_count
+
+        # The frame every viewer currently reads (get_frame refreshes heartbeat but
+        # must not alter the slot). Captured before the override for comparison.
+        frames_before = {}
+        for viewer_id in viewer_ids:
+            res = broadcaster.get_frame(_CAMERA, viewer_id)
+            assert res.status == FrameStatus.OK
+            frames_before[viewer_id] = (res.frame.seq, res.frame.data)
+
+        # Vary the freshness context; isolation must hold regardless of clock.
+        clock.advance(clock_advance)
+
+        # 4. Drive the override preview request(s) against the running session.
+        for _ in range(num_previews):
+            preview = broadcaster.preview_with_override(_CAMERA, override_config)
+            # Active-session path returns a pure read of the current latest frame;
+            # since a frame was published it returns that frame's payload (the
+            # override is intentionally NOT reflected — isolation is the guarantee).
+            assert preview is not None
+            assert preview["data"] == data_before
+
+        # --- assertions: the session is fully isolated from the override (Req 5.4) ---
+
+        # (a) applied_features is byte-for-byte unchanged.
+        assert session.applied_features == applied_before
+
+        # (b) the shared latest-frame slot is the SAME object with the same seq/bytes,
+        #     so the override never touched the frame other viewers read.
+        assert session.latest is latest_obj_before
+        assert session.latest.seq == seq_before
+        assert session.latest.data == data_before
+
+        # (c) every viewer still reads the identical, same-seq frame after the override.
+        for viewer_id in viewer_ids:
+            res = broadcaster.get_frame(_CAMERA, viewer_id)
+            assert res.status == FrameStatus.OK
+            assert (res.frame.seq, res.frame.data) == frames_before[viewer_id]
+            assert res.frame.seq == seq_before
+            assert res.frame.data == data_before
+
+        # (d) the override was never applied to the live claim: no extra apply_features,
+        #     and no second claim opened / claim released by the preview.
+        assert backend.apply_features_count == apply_count_before
+        assert backend.open_count == opens_before
+        assert backend.close_count == closes_before
+        assert registry.open_count(_CAMERA) == 1
+        assert registry.total_open() == 1
+
+        # The session is left intact (still RUNNING, viewer set unchanged).
+        assert session.state == SessionState.RUNNING
+        assert broadcaster.viewer_count(_CAMERA) == num_viewers
+        assert set(session.viewers.keys()) == set(viewer_ids)
+
+        # The single-claim invariant held throughout.
+        registry.assert_single_claim()
+
+        # Cleanup: drain viewers so the session stops and the claim is released.
+        for viewer_id in list(session.viewers.keys()):
+            broadcaster.unsubscribe(_CAMERA, viewer_id)
+
+    assert registry.open_count(_CAMERA) == 0

--- a/test/backend-test/utils/streaming/test_session_fanout.py
+++ b/test/backend-test/utils/streaming/test_session_fanout.py
@@ -1,0 +1,123 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based test for stream fan-out.
+
+Feature: concurrent-camera-stream-viewing, Property 3: Fan-out delivers the
+identical latest frame to every viewer — for any set of 1..max_viewers viewers
+and any sequence of published frames, every viewer reading after a publish (and
+before the next publish) receives a byte-identical frame carrying the same seq
+as every other viewer reading in that interval, and that frame is the most
+recently published one (Req 1.1, 1.4, 2.2, 2.5).
+"""
+import uuid
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from mock_camera_backend import (
+    MOCK_BACKEND_CLASSES,
+    MockClock,
+    make_raw_frame,
+)
+from utils.streaming.models import FrameStatus, StreamConfig, Viewer
+from utils.streaming.session import StreamSession
+
+# Per-camera viewer ceiling the property quantifies over (StreamConfig default).
+MAX_VIEWERS = StreamConfig().max_viewers
+
+
+def _make_viewer(camera_id: str, now: float) -> Viewer:
+    """Build a Viewer with a unique id for registration in a session."""
+    return Viewer(
+        viewer_id=str(uuid.uuid4()),
+        camera_id=camera_id,
+        subscribed_at=now,
+        last_active=now,
+    )
+
+
+# A sequence of frames: vary count (1..12) and the raw bytes of each frame so the
+# fan-out assertion is exercised over many distinct, byte-distinguishable frames.
+_frame_payloads = st.lists(
+    st.binary(min_size=0, max_size=32),
+    min_size=1,
+    max_size=12,
+)
+
+
+# Feature: concurrent-camera-stream-viewing, Property 3: Fan-out delivers the identical latest frame to every viewer
+# Validates: Requirements 1.1, 1.4, 2.2, 2.5
+@pytest.mark.parametrize("backend_cls", MOCK_BACKEND_CLASSES.values(), ids=list(MOCK_BACKEND_CLASSES))
+@settings(max_examples=150)
+@given(
+    payloads=_frame_payloads,
+    num_viewers=st.integers(min_value=1, max_value=MAX_VIEWERS),
+    width=st.integers(min_value=1, max_value=64),
+    height=st.integers(min_value=1, max_value=64),
+)
+def test_property_3_fanout_identical_latest_frame(
+    backend_cls, payloads, num_viewers, width, height
+):
+    """Every viewer reading in an interval gets the same-seq, byte-identical, most-recent frame.
+
+    Feature: concurrent-camera-stream-viewing, Property 3: Fan-out delivers the identical latest frame to every viewer
+    Validates: Requirements 1.1, 1.4, 2.2, 2.5
+    """
+    camera_id = "Fake_1"
+    clock = MockClock(start=1000.0)
+    backend = backend_cls(camera_id, clock=clock)
+    # Generous freshness window so the injected clock keeps every read OK.
+    session = StreamSession(
+        camera_id,
+        backend=backend,
+        stream_config=StreamConfig(stale_after_s=10_000.0),
+    )
+
+    # Register 1..max_viewers distinct viewers; all share the one latest-frame slot.
+    for _ in range(num_viewers):
+        session.add_viewer(_make_viewer(camera_id, clock.time()))
+    assert session.viewer_count() == num_viewers
+
+    for payload in payloads:
+        # The producer publishes the next frame at the current clock time so the
+        # frame is fresh (now == acquired_at) when read in this interval.
+        now = clock.time()
+        frame = make_raw_frame(width=width, height=height, data=payload)
+        published = session.publish(frame, now=now)
+
+        # Every viewer reads after the publish and before the next one. Collect
+        # each viewer's result; they must agree with each other and the publish.
+        results = [session.read_latest(now) for _ in range(num_viewers)]
+
+        for result in results:
+            # The frame is fresh, so the read classifies OK (Req 1.1, 1.4).
+            assert result.status == FrameStatus.OK
+            assert result.frame is not None
+            # Same seq as the most recent publish (Req 2.5).
+            assert result.frame.seq == published.seq
+            # Byte-identical data equal to the most recent publish (Req 2.2).
+            assert result.frame.data == payload
+            assert result.frame.width == width
+            assert result.frame.height == height
+            # The served frame is the most recently published one.
+            assert result.frame is published
+
+        # All viewers observed exactly one identical seq in this interval.
+        seqs = {r.frame.seq for r in results}
+        datas = {bytes(r.frame.data) for r in results}
+        assert len(seqs) == 1, "viewers disagreed on the latest seq"
+        assert len(datas) == 1, "viewers received differing frame bytes"
+
+        clock.advance(0.001)

--- a/test/backend-test/utils/streaming/test_session_freshness.py
+++ b/test/backend-test/utils/streaming/test_session_freshness.py
@@ -1,0 +1,127 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based tests for ``StreamSession`` frame freshness classification.
+
+Feature: concurrent-camera-stream-viewing, Property 11: Frame freshness predicate
+— for any latest frame published at ``acquired_at`` and any request time ``now``,
+``StreamSession.read_latest(now)`` returns status ``OK`` (with the frame) when
+``now - acquired_at <= stale_after_s`` and status ``STALE`` (still carrying the
+last frame) otherwise. The boundary ``now - acquired_at == stale_after_s`` is
+classified ``OK``.
+
+Validates: Requirements 4.6, 4.7
+"""
+import math
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from utils.streaming.models import FrameStatus, StreamConfig
+from utils.streaming.session import StreamSession
+
+# StreamConfig's documented default freshness ceiling (Req 4.6).
+DEFAULT_STALE_AFTER_S = 2.0
+
+# Acquired-at / now request times. Bounded to a wide but finite span so the
+# float subtraction ``now - acquired_at`` stays well-conditioned (no NaN/inf and
+# no catastrophic-cancellation surprises), while still spanning frames that are
+# fresh, exactly at the ceiling, and arbitrarily stale.
+_times = st.floats(min_value=-1.0e6, max_value=1.0e6, allow_nan=False, allow_infinity=False)
+
+# Arbitrary freshness ceilings, including 0.0 (everything but a same-instant read
+# is stale) up through long windows.
+_stale_after = st.floats(min_value=0.0, max_value=1.0e4, allow_nan=False, allow_infinity=False)
+
+# Integer-valued times for exact-boundary tests: ``int + int`` is representable
+# exactly as a float in this range, so ``now - acquired_at == stale_after_s``
+# holds without floating-point drift.
+_int_times = st.integers(min_value=-100_000, max_value=100_000)
+_int_stale = st.integers(min_value=0, max_value=10_000)
+
+
+def _session(stale_after_s: float) -> StreamSession:
+    """Build a session whose freshness ceiling is ``stale_after_s``."""
+    return StreamSession(
+        camera_id="cam-freshness",
+        stream_config=StreamConfig(stale_after_s=stale_after_s),
+    )
+
+
+# Feature: concurrent-camera-stream-viewing, Property 11: Frame freshness predicate
+# Validates: Requirements 4.6, 4.7
+@settings(max_examples=200, deadline=None)
+@given(acquired_at=_times, now=_times, stale_after_s=_stale_after)
+def test_property_11_frame_freshness_predicate(acquired_at, now, stale_after_s):
+    """read_latest is OK when age <= stale_after_s and STALE when age exceeds it.
+
+    Feature: concurrent-camera-stream-viewing, Property 11: Frame freshness predicate
+    Validates: Requirements 4.6, 4.7
+    """
+    session = _session(stale_after_s)
+    published = session.publish(b"frame-payload", width=4, height=2, now=acquired_at)
+
+    result = session.read_latest(now)
+
+    age = now - acquired_at
+    if age <= stale_after_s:
+        # Fresh (or exactly at the ceiling): OK and carries the published frame.
+        assert result.status == FrameStatus.OK
+        assert result.frame is published
+    else:
+        # Older than the ceiling: STALE, still surfacing the last good frame.
+        assert result.status == FrameStatus.STALE
+        assert result.frame is published
+
+
+# Feature: concurrent-camera-stream-viewing, Property 11: Frame freshness predicate
+# Validates: Requirements 4.6, 4.7
+@settings(max_examples=200, deadline=None)
+@given(acquired_at=_int_times, stale_after_s=_int_stale)
+def test_property_11_exact_boundary_is_ok(acquired_at, stale_after_s):
+    """A frame whose age equals ``stale_after_s`` exactly classifies as OK.
+
+    Feature: concurrent-camera-stream-viewing, Property 11: Frame freshness predicate
+    Validates: Requirements 4.6, 4.7
+    """
+    session = _session(float(stale_after_s))
+    session.publish(b"frame-payload", width=4, height=2, now=float(acquired_at))
+
+    # now - acquired_at == stale_after_s exactly (integer-valued floats).
+    now = float(acquired_at) + float(stale_after_s)
+    result = session.read_latest(now)
+
+    assert result.status == FrameStatus.OK
+
+
+# Feature: concurrent-camera-stream-viewing, Property 11: Frame freshness predicate
+# Validates: Requirements 4.6, 4.7
+@settings(max_examples=200, deadline=None)
+@given(acquired_at=_times, stale_after_s=_stale_after)
+def test_property_11_just_past_boundary_is_stale(acquired_at, stale_after_s):
+    """A frame even marginally older than ``stale_after_s`` classifies as STALE.
+
+    Feature: concurrent-camera-stream-viewing, Property 11: Frame freshness predicate
+    Validates: Requirements 4.6, 4.7
+    """
+    session = _session(stale_after_s)
+    session.publish(b"frame-payload", width=4, height=2, now=acquired_at)
+
+    # The smallest representable step beyond the ceiling: age > stale_after_s.
+    boundary = acquired_at + stale_after_s
+    now = math.nextafter(boundary, math.inf)
+    # Guard against the rare case where nextafter does not increase the age past
+    # the ceiling at this magnitude; only assert when the age is strictly greater.
+    if now - acquired_at > stale_after_s:
+        result = session.read_latest(now)
+        assert result.status == FrameStatus.STALE

--- a/test/backend-test/utils/streaming/test_session_heartbeat.py
+++ b/test/backend-test/utils/streaming/test_session_heartbeat.py
@@ -1,0 +1,211 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based tests for viewer heartbeat update and the staleness predicate.
+
+Feature: concurrent-camera-stream-viewing, Property 9: Heartbeat update and
+staleness predicate — for any viewer and any receipt time ``t``, processing a
+heartbeat sets that viewer's ``last_active`` timestamp to ``t``; and for any
+``last_active`` time and current time ``now``, the viewer is classified stale
+exactly when ``now - last_active > stale_timeout_s``. The boundary
+``now - last_active == stale_timeout_s`` is classified NOT stale.
+
+Validates: Requirements 3.9, 8.3
+
+Scope note (pending task 5.3)
+-----------------------------
+The broadcaster's heartbeat refresh and stale-viewer sweep are implemented in
+task 5.3, which is not yet complete. At the level available today the contract
+this test pins is:
+
+* a heartbeat at time ``t`` means the viewer's ``last_active`` becomes ``t`` — we
+  validate this directly against the :class:`Viewer` model (the single field the
+  broadcaster mutates on heartbeat / frame GET, per Req 8.3); and
+* the staleness classification is ``now - last_active > stale_timeout_s`` — we
+  validate this against a small local predicate that mirrors the design
+  (``StreamBroadcaster.sweep_stale_viewers`` / ``STALE_TIMEOUT_S``). The predicate
+  is exercised against ``StreamConfig.stale_timeout_s`` so it pins the exact
+  threshold the task-5.3 implementation must satisfy.
+
+This module imports only ``Viewer`` and ``StreamConfig`` (both pure data, no
+``gi`` / native dependency), so it is import-safe on hosts without the GenICam /
+GStreamer stack.
+"""
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from utils.streaming.models import StreamConfig, Viewer
+
+# StreamConfig's documented default stale window (Req 8.3 / design STALE_TIMEOUT_S).
+DEFAULT_STALE_TIMEOUT_S = 30
+
+
+def _is_stale(last_active: float, now: float, stale_timeout_s: float) -> bool:
+    """Local mirror of the design's staleness predicate (pending task 5.3).
+
+    A viewer is stale exactly when it has been inactive *longer than* the stale
+    window: ``now - last_active > stale_timeout_s``. Equality (inactive for
+    exactly the window) is NOT stale.
+    """
+    return (now - last_active) > stale_timeout_s
+
+
+def _heartbeat(viewer: Viewer, t: float) -> Viewer:
+    """Local mirror of the design's heartbeat refresh (pending task 5.3).
+
+    Processing a heartbeat received at ``t`` sets the viewer's ``last_active`` to
+    ``t`` (Req 8.3). Returns the same viewer for convenience.
+    """
+    viewer.last_active = t
+    return viewer
+
+
+# Wide-but-finite timestamps so the float subtraction ``now - last_active`` stays
+# well-conditioned (no NaN/inf, no catastrophic-cancellation surprises) while
+# still spanning viewers that are fresh, exactly at the window, and very stale.
+_times = st.floats(min_value=-1.0e6, max_value=1.0e6, allow_nan=False, allow_infinity=False)
+
+# Stale windows including 0 (any elapsed time makes a viewer stale) through long
+# windows.
+_timeouts = st.floats(min_value=0.0, max_value=1.0e4, allow_nan=False, allow_infinity=False)
+
+# Integer-valued times for the exact-boundary test: ``int + int`` is representable
+# exactly as a float in this range, so ``now - last_active == stale_timeout_s``
+# holds without floating-point drift.
+_int_times = st.integers(min_value=-100_000, max_value=100_000)
+_int_timeouts = st.integers(min_value=0, max_value=10_000)
+
+
+def _viewer(last_active: float = 0.0) -> Viewer:
+    """Build a viewer with the given ``last_active`` timestamp."""
+    return Viewer(
+        viewer_id="viewer-hb",
+        camera_id="cam-hb",
+        subscribed_at=0.0,
+        last_active=last_active,
+    )
+
+
+# Feature: concurrent-camera-stream-viewing, Property 9: Heartbeat update and staleness predicate
+# Validates: Requirements 3.9, 8.3
+@settings(max_examples=200, deadline=None)
+@given(initial=_times, t=_times)
+def test_property_9_heartbeat_sets_last_active(initial, t):
+    """Processing a heartbeat at ``t`` sets the viewer's ``last_active`` to ``t``.
+
+    Feature: concurrent-camera-stream-viewing, Property 9: Heartbeat update and staleness predicate
+    Validates: Requirements 3.9, 8.3
+    """
+    viewer = _viewer(last_active=initial)
+
+    _heartbeat(viewer, t)
+
+    assert viewer.last_active == t
+
+
+# Feature: concurrent-camera-stream-viewing, Property 9: Heartbeat update and staleness predicate
+# Validates: Requirements 3.9, 8.3
+@settings(max_examples=200, deadline=None)
+@given(initial=_times, first=_times, second=_times)
+def test_property_9_heartbeat_overwrites_previous(initial, first, second):
+    """Each heartbeat overwrites the prior ``last_active`` with the new receipt time.
+
+    Feature: concurrent-camera-stream-viewing, Property 9: Heartbeat update and staleness predicate
+    Validates: Requirements 3.9, 8.3
+    """
+    viewer = _viewer(last_active=initial)
+
+    _heartbeat(viewer, first)
+    assert viewer.last_active == first
+
+    _heartbeat(viewer, second)
+    assert viewer.last_active == second
+
+
+# Feature: concurrent-camera-stream-viewing, Property 9: Heartbeat update and staleness predicate
+# Validates: Requirements 3.9, 8.3
+@settings(max_examples=200, deadline=None)
+@given(last_active=_times, now=_times, stale_timeout_s=_timeouts)
+def test_property_9_staleness_predicate(last_active, now, stale_timeout_s):
+    """A viewer is stale exactly when ``now - last_active > stale_timeout_s``.
+
+    Feature: concurrent-camera-stream-viewing, Property 9: Heartbeat update and staleness predicate
+    Validates: Requirements 3.9, 8.3
+    """
+    stale = _is_stale(last_active, now, stale_timeout_s)
+
+    inactive_for = now - last_active
+    if inactive_for > stale_timeout_s:
+        assert stale is True
+    else:
+        assert stale is False
+
+
+# Feature: concurrent-camera-stream-viewing, Property 9: Heartbeat update and staleness predicate
+# Validates: Requirements 3.9, 8.3
+@settings(max_examples=200, deadline=None)
+@given(last_active=_int_times, stale_timeout_s=_int_timeouts)
+def test_property_9_exact_boundary_is_not_stale(last_active, stale_timeout_s):
+    """Inactive for exactly ``stale_timeout_s`` is NOT stale (strict ``>``).
+
+    Feature: concurrent-camera-stream-viewing, Property 9: Heartbeat update and staleness predicate
+    Validates: Requirements 3.9, 8.3
+    """
+    # now - last_active == stale_timeout_s exactly (integer-valued floats).
+    now = float(last_active) + float(stale_timeout_s)
+
+    assert _is_stale(float(last_active), now, float(stale_timeout_s)) is False
+
+
+# Feature: concurrent-camera-stream-viewing, Property 9: Heartbeat update and staleness predicate
+# Validates: Requirements 3.9, 8.3
+@settings(max_examples=200, deadline=None)
+@given(last_active=_int_times, stale_timeout_s=_int_timeouts)
+def test_property_9_one_past_boundary_is_stale(last_active, stale_timeout_s):
+    """Inactive for ``stale_timeout_s + 1`` is stale (just beyond the window).
+
+    Feature: concurrent-camera-stream-viewing, Property 9: Heartbeat update and staleness predicate
+    Validates: Requirements 3.9, 8.3
+    """
+    now = float(last_active) + float(stale_timeout_s) + 1.0
+
+    assert _is_stale(float(last_active), now, float(stale_timeout_s)) is True
+
+
+# Feature: concurrent-camera-stream-viewing, Property 9: Heartbeat update and staleness predicate
+# Validates: Requirements 3.9, 8.3
+@settings(max_examples=200, deadline=None)
+@given(subscribed_at=_int_times, t=_int_times)
+def test_property_9_heartbeat_then_staleness_against_config(subscribed_at, t):
+    """End-to-end: a heartbeat at ``t`` makes the viewer fresh until the configured window.
+
+    Pins the contract task 5.3 must satisfy against ``StreamConfig.stale_timeout_s``:
+    immediately after a heartbeat at ``t`` the viewer is fresh, remains fresh at
+    exactly ``t + stale_timeout_s``, and is stale one tick later.
+
+    Feature: concurrent-camera-stream-viewing, Property 9: Heartbeat update and staleness predicate
+    Validates: Requirements 3.9, 8.3
+    """
+    config = StreamConfig()
+    timeout = config.stale_timeout_s
+    assert timeout == DEFAULT_STALE_TIMEOUT_S
+
+    viewer = _viewer(last_active=float(subscribed_at))
+    _heartbeat(viewer, float(t))
+
+    # At receipt time: fresh.
+    assert _is_stale(viewer.last_active, float(t), timeout) is False
+    # At exactly the window boundary: still fresh (strict ``>``).
+    assert _is_stale(viewer.last_active, float(t) + timeout, timeout) is False
+    # One tick past the window: stale.
+    assert _is_stale(viewer.last_active, float(t) + timeout + 1.0, timeout) is True

--- a/test/backend-test/utils/streaming/test_session_noframe.py
+++ b/test/backend-test/utils/streaming/test_session_noframe.py
@@ -1,0 +1,93 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based tests for ``StreamSession`` no-frame-yet handling.
+
+Feature: concurrent-camera-stream-viewing, Property 12: No-frame-yet handling —
+for any session that has started but published no frame, ``read_latest`` returns
+status ``NO_FRAME`` and the session remains active (not stopped).
+"""
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from utils.streaming.models import FrameStatus, SessionState, StreamConfig
+from utils.streaming.session import StreamSession
+
+# The non-terminal / "started" lifecycle states a session can occupy while it has
+# come up but not yet published its first frame. STOPPED is the terminal state and
+# is deliberately excluded: Property 12 asserts a started session is *not* moved to
+# STOPPED merely by a no-frame read.
+_STARTED_STATES = [
+    SessionState.STARTING,
+    SessionState.RUNNING,
+    SessionState.STOPPING,
+    SessionState.ERROR,
+]
+
+# Arbitrary injected "now" clock values spanning negative, zero, and large epochs.
+_now_values = st.floats(
+    allow_nan=False,
+    allow_infinity=False,
+    min_value=-1_000_000.0,
+    max_value=1_000_000_000.0,
+)
+
+
+# Feature: concurrent-camera-stream-viewing, Property 12: No-frame-yet handling
+# Validates: Requirements 2.6, 4.2
+@settings(max_examples=200)
+@given(
+    state=st.sampled_from(_STARTED_STATES),
+    stale_after_s=st.floats(
+        allow_nan=False, allow_infinity=False, min_value=0.0, max_value=120.0
+    ),
+    camera_id=st.text(min_size=1, max_size=32),
+    nows=st.lists(_now_values, min_size=1, max_size=5),
+)
+def test_property_12_no_frame_yet_handling(state, stale_after_s, camera_id, nows):
+    """A started session with no published frame reads NO_FRAME and stays active.
+
+    For any started (non-terminal) session state and any injected ``now``, a
+    session that has published no frame yet returns ``FrameStatus.NO_FRAME`` with
+    no frame payload, and the read never advances the session to ``STOPPED`` nor
+    otherwise mutates its lifecycle state.
+
+    Feature: concurrent-camera-stream-viewing, Property 12: No-frame-yet handling
+    Validates: Requirements 2.6, 4.2
+    """
+    config = StreamConfig(stale_after_s=stale_after_s)
+    session = StreamSession(
+        camera_id=camera_id,
+        backend=None,
+        stream_config=config,
+        state=state,
+    )
+
+    # Precondition: the session has started but published no frame.
+    assert session.latest is None
+    assert session.state != SessionState.STOPPED
+
+    # Reading repeatedly with arbitrary clocks must keep yielding NO_FRAME and must
+    # never move the session out of its started state into STOPPED.
+    for now in nows:
+        result = session.read_latest(now)
+
+        # No frame is available, so the status is NO_FRAME with no payload.
+        assert result.status == FrameStatus.NO_FRAME
+        assert result.frame is None
+
+        # The read is non-destructive: the slot stays empty and the session stays
+        # in its original active state (in particular, it is never stopped).
+        assert session.latest is None
+        assert session.state == state
+        assert session.state != SessionState.STOPPED

--- a/test/backend-test/utils/streaming/test_session_reads.py
+++ b/test/backend-test/utils/streaming/test_session_reads.py
@@ -1,0 +1,179 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based tests for independent, no-re-grab latest-frame reads.
+
+Feature: concurrent-camera-stream-viewing, Property 4: Reads are independent of
+other viewers and do not re-grab — for any viewer and any number of other
+viewers in any read state, a viewer's ``read_latest`` returns the current latest
+frame as a pure function of the slot, independent of the presence / count /
+pending reads of other viewers; repeated reads with no intervening publish
+return the same frame without invoking a device grab.
+
+Validates: Requirements 1.5, 2.4
+"""
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from utils.streaming.models import FrameStatus, StreamConfig, Viewer
+from utils.streaming.session import StreamSession
+
+from mock_camera_backend import (
+    BACKEND_KINDS,
+    MockClock,
+    make_backend,
+    make_raw_frame,
+)
+
+
+def _build_published_session(backend_kind, clock):
+    """Create a started session backed by a mock backend with one published frame.
+
+    Mirrors what the acquisition worker does for a single interval: open the
+    claim, start the stream, perform exactly one device ``grab``, and publish the
+    resulting frame into the latest-frame slot. Returns the session, the backend,
+    the published frame, and the backend ``grab_count`` observed immediately after
+    the publish so reads can be asserted to never increase it.
+    """
+    backend = make_backend(backend_kind, camera_id="Fake_1", clock=clock)
+    backend.queue_frame(make_raw_frame(seq=7, width=8, height=8))
+    backend.open()
+    backend.start_stream()
+
+    raw = backend.grab(timeout_ms=backend.last_grab_timeout_ms or 5000)
+    grabs_after_publish = backend.grab_count  # exactly one device grab so far
+
+    session = StreamSession("Fake_1", backend=backend, stream_config=StreamConfig())
+    published = session.publish(raw, now=clock.time())
+
+    return session, backend, published, grabs_after_publish
+
+
+def _set_viewer_count(session, count, clock):
+    """Add/remove viewers so the registry holds exactly ``count`` viewers.
+
+    Models "any number of other viewers in any read state" — the presence and
+    count of viewers must not influence what ``read_latest`` returns.
+    """
+    current = session.viewer_count()
+    while session.viewer_count() < count:
+        idx = session.viewer_count()
+        session.add_viewer(
+            Viewer(
+                viewer_id=f"viewer-{idx}",
+                camera_id=session.camera_id,
+                subscribed_at=clock.time(),
+                last_active=clock.time(),
+            )
+        )
+    # Remove from the end if we overshot a previous, larger count.
+    while session.viewer_count() > count:
+        last_id = f"viewer-{session.viewer_count() - 1}"
+        session.remove_viewer(last_id)
+    return current
+
+
+# Feature: concurrent-camera-stream-viewing, Property 4: Reads are independent of other viewers and do not re-grab
+# Validates: Requirements 1.5, 2.4
+@settings(max_examples=200, deadline=None)
+@given(
+    backend_kind=st.sampled_from(BACKEND_KINDS),
+    # Each entry is (viewer_count_before_read, now_at_read). The viewer count
+    # varies the presence/count of other viewers; now varies the read timing.
+    reads=st.lists(
+        st.tuples(
+            st.integers(min_value=0, max_value=8),
+            st.floats(min_value=0.0, max_value=120.0, allow_nan=False, allow_infinity=False),
+        ),
+        min_size=2,
+        max_size=25,
+    ),
+)
+def test_property_4_reads_independent_and_no_regrab(backend_kind, reads):
+    """read_latest is a pure function of the slot; reads never re-grab.
+
+    Feature: concurrent-camera-stream-viewing, Property 4: Reads are independent
+    of other viewers and do not re-grab
+    Validates: Requirements 1.5, 2.4
+    """
+    clock = MockClock(start=0.0)
+    session, backend, published, grabs_after_publish = _build_published_session(
+        backend_kind, clock
+    )
+
+    # Baseline read with zero other viewers present. Every later read — under any
+    # viewer count and any read order — must return this identical frame.
+    baseline = session.read_latest(now=clock.time())
+    assert baseline.frame is not None
+    assert baseline.frame.seq == published.seq
+    assert baseline.frame.data == published.data
+
+    for viewer_count, now in reads:
+        # Vary the presence/count of "other viewers" before this read. No publish
+        # occurs anywhere in this loop, so the latest-frame slot is unchanged.
+        _set_viewer_count(session, viewer_count, clock)
+
+        result = session.read_latest(now=now)
+
+        # Independent of viewer presence/count: the same latest frame is returned,
+        # byte-identical and with the same monotonic seq, as a pure function of
+        # the slot (Req 1.5, 2.4).
+        assert result.frame is not None
+        assert result.frame.seq == published.seq
+        assert result.frame.data == published.data
+        assert result.frame.width == published.width
+        assert result.frame.height == published.height
+        # Status is never NO_FRAME (a frame has been published) and never
+        # DISCONNECTED (read_latest only classifies freshness).
+        assert result.status in (FrameStatus.OK, FrameStatus.STALE)
+
+        # Reads NEVER trigger a device grab: the backend grab count is unchanged
+        # from the single acquisition that produced the published frame.
+        assert backend.grab_count == grabs_after_publish
+
+    # After all reads, no extra device grabs were issued by reading (Req 2.4),
+    # and the backend never performed more than the one acquisition grab.
+    assert backend.grab_count == grabs_after_publish == 1
+
+
+# Feature: concurrent-camera-stream-viewing, Property 4: Reads are independent of other viewers and do not re-grab
+# Validates: Requirements 1.5, 2.4
+@settings(max_examples=200, deadline=None)
+@given(
+    backend_kind=st.sampled_from(BACKEND_KINDS),
+    repeat=st.integers(min_value=1, max_value=50),
+    now=st.floats(min_value=0.0, max_value=120.0, allow_nan=False, allow_infinity=False),
+)
+def test_property_4_repeated_reads_return_same_frame_without_grab(backend_kind, repeat, now):
+    """Repeated reads with no intervening publish return the same frame, no grab.
+
+    Feature: concurrent-camera-stream-viewing, Property 4: Reads are independent
+    of other viewers and do not re-grab
+    Validates: Requirements 1.5, 2.4
+    """
+    clock = MockClock(start=0.0)
+    session, backend, published, grabs_after_publish = _build_published_session(
+        backend_kind, clock
+    )
+
+    seen = [session.read_latest(now=now) for _ in range(repeat)]
+
+    # Every repeated read returns the byte-identical, same-seq frame because no
+    # publish intervened (pure function of the slot, Req 2.4).
+    for result in seen:
+        assert result.frame is not None
+        assert result.frame.seq == published.seq
+        assert result.frame.data == published.data
+
+    # None of the repeated reads invoked a device grab.
+    assert backend.grab_count == grabs_after_publish == 1

--- a/test/backend-test/utils/streaming/test_settings_apply.py
+++ b/test/backend-test/utils/streaming/test_settings_apply.py
@@ -1,0 +1,313 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based test for live settings apply preserving the session.
+
+Feature: concurrent-camera-stream-viewing, Property 18: Live settings apply
+preserves the session — for any set of valid camera control values applied to a
+running session, the backend reflects the requested values, the session remains
+RUNNING, the subscribed viewer set is unchanged, and the latest frame remains
+readable throughout.
+
+Validates: Requirements 5.1, 5.2, 5.3.
+
+How the property is exercised
+-----------------------------
+:meth:`StreamBroadcaster.apply_settings` is driven against an injected
+``backend_factory`` that builds the hardware-free :class:`MockCameraBackend`
+registered against one shared :class:`ClaimRegistry` (so the test can read the
+true per-camera open-claim count) plus an injected :class:`MockClock` (so frame
+freshness is deterministic). The mock's ``apply_features`` records each request
+and returns the device-accepted values (the normalized requested values), which
+is exactly what the broadcaster hands back to its caller.
+
+Per example Hypothesis generates a camera id, a viewer count ``N`` in
+``[1, max_viewers]``, a frame geometry, and a *valid* feature dict drawn from
+gain / exposure / advancedSettings. The test:
+
+1. Subscribes ``N`` viewers (the first opens the single device claim) and records
+   the exact set of issued viewer ids.
+2. Publishes one fresh frame into the live session so there is a readable latest
+   frame before the apply.
+3. Calls ``apply_settings`` with the generated valid feature dict.
+4. Asserts the post-conditions of Property 18:
+   * the return value equals the device-accepted values (the mock reflects the
+     requested values), and the backend recorded the apply (Req 5.1, 5.2),
+   * ``session.state`` is still ``RUNNING`` (Req 5.3),
+   * the subscribed viewer-id set is byte-for-byte unchanged before/after
+     (Req 5.3),
+   * ``get_frame`` still returns ``OK`` with a readable frame (the same published
+     payload) after the apply — the latest frame stayed readable throughout
+     (Req 5.2, 5.3),
+   * the single device claim was neither re-opened nor released (count stays 1).
+
+Worker-stub technique (test-only; mirrors ``test_inference_reuse.py``)
+----------------------------------------------------------------------
+In production a subscribe starts a real :class:`AcquisitionWorker` on a daemon
+thread (a ``grab -> publish`` loop). That thread is irrelevant to the
+settings-apply property and would make the live frame non-deterministic. For the
+lifetime of each example the ``AcquisitionWorker`` symbol in the broadcaster
+module is patched with a no-op stub that simply marks the session RUNNING on
+``start()`` (mirroring the real worker after its first published frame). The
+live frame is then made deterministically available by publishing it through the
+session directly before the apply. The broadcaster's subscribe / apply_settings /
+get_frame logic — and therefore every ``open()`` / ``close()`` / ``apply_features``
+that touches the device — runs completely unchanged. No production code is
+modified.
+"""
+from __future__ import annotations
+
+import unittest.mock as mock
+from typing import List, Optional
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+import utils.streaming.broadcaster as broadcaster_module
+from mock_camera_backend import (
+    BACKEND_KINDS,
+    ClaimRegistry,
+    MockCameraBackend,
+    MockClock,
+    make_backend,
+    make_raw_frame,
+)
+from utils.streaming.broadcaster import StreamBroadcaster
+from utils.streaming.models import FrameStatus, SessionState, StreamConfig
+
+# A small fixed set of physical cameras the property quantifies over.
+CAMERAS = ("cam_a", "cam_b", "cam_c")
+
+# Keep max_viewers small so subscribing the full range stays fast while still
+# exercising varied viewer counts (the property must hold for any N in range).
+_MAX_VIEWERS = 4
+_STREAM_CONFIG = StreamConfig(max_viewers=_MAX_VIEWERS, stale_timeout_s=30)
+
+# Hypothesis runs >= 100 iterations; the work per example is tiny and synchronous.
+_PROP_SETTINGS = settings(max_examples=120, deadline=None)
+
+
+class _StubAcquisitionWorker:
+    """No-op stand-in for ``AcquisitionWorker`` (test-only; see module docstring).
+
+    Matches the construction/usage contract the broadcaster relies on
+    (``AcquisitionWorker(session, stream_config=..., time_fn=...)`` then
+    ``start()`` / ``stop()`` / ``join()``) but runs no thread and performs no
+    grabs, so the session frame and the open-claim count are deterministic.
+    ``start()`` marks the session RUNNING to mirror the real worker after its
+    first published frame.
+    """
+
+    def __init__(self, session, *, stream_config=None, time_fn=None, **kwargs) -> None:
+        self.session = session
+
+    def start(self):
+        self.session.state = SessionState.RUNNING
+        return None
+
+    def stop(self) -> None:
+        return None
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Strategy: a *valid* camera-control feature dict (gain / exposure / advanced).
+# --------------------------------------------------------------------------- #
+# Valid gain / exposure scalar values. Kept to finite, in-range numbers so the
+# device (mock) accepts them verbatim — Property 18 is about valid values being
+# reflected (out-of-range rejection is Property 19, out of scope here).
+_gain_values = st.floats(min_value=0.0, max_value=48.0, allow_nan=False, allow_infinity=False)
+_exposure_values = st.floats(
+    min_value=1.0, max_value=100_000.0, allow_nan=False, allow_infinity=False
+)
+
+# An advancedSettings entry is a {"feature","value"} device-feature mapping.
+_advanced_feature_names = st.sampled_from(
+    ["Gamma", "BlackLevel", "Sharpness", "Saturation", "Brightness"]
+)
+_advanced_entry = st.fixed_dictionaries(
+    {
+        "feature": _advanced_feature_names,
+        "value": st.one_of(
+            st.floats(min_value=0.0, max_value=4.0, allow_nan=False, allow_infinity=False),
+            st.integers(min_value=0, max_value=255),
+        ),
+    }
+)
+
+
+@st.composite
+def valid_feature_dicts(draw):
+    """Generate a non-empty image-source-style feature dict of valid controls.
+
+    Produces some combination of ``gain`` / ``exposure`` / ``advancedSettings``
+    (at least one present) so every generated request carries at least one
+    control to apply. ``advancedSettings`` is a list of distinct-named feature
+    entries.
+    """
+    include_gain = draw(st.booleans())
+    include_exposure = draw(st.booleans())
+    include_advanced = draw(st.booleans())
+    # Ensure at least one control is present.
+    if not (include_gain or include_exposure or include_advanced):
+        include_gain = True
+
+    features: dict = {}
+    if include_gain:
+        features["gain"] = draw(_gain_values)
+    if include_exposure:
+        features["exposure"] = draw(_exposure_values)
+    if include_advanced:
+        entries = draw(
+            st.lists(_advanced_entry, min_size=1, max_size=5, unique_by=lambda e: e["feature"])
+        )
+        features["advancedSettings"] = entries
+    return features
+
+
+def _make_broadcaster(backend_kind, registry, clock, created):
+    """Build a broadcaster whose factory records every backend it creates.
+
+    Each backend shares the one ``registry`` + ``clock`` so the test reads the
+    true per-camera open-claim count; the ``created`` list captures every backend
+    instance so the test can assert no second claim was opened during the apply.
+    """
+
+    def backend_factory(camera_id, config) -> MockCameraBackend:
+        backend = make_backend(
+            backend_kind,
+            camera_id,
+            claim_registry=registry,
+            clock=clock,
+        )
+        created.append(backend)
+        return backend
+
+    return StreamBroadcaster(
+        stream_config=_STREAM_CONFIG,
+        backend_factory=backend_factory,
+        time_fn=clock.time,
+    )
+
+
+@pytest.mark.parametrize("backend_kind", BACKEND_KINDS)
+@given(
+    camera=st.sampled_from(CAMERAS),
+    viewer_count=st.integers(min_value=1, max_value=_MAX_VIEWERS),
+    width=st.integers(min_value=1, max_value=64),
+    height=st.integers(min_value=1, max_value=64),
+    seq=st.integers(min_value=1, max_value=1000),
+    features=valid_feature_dicts(),
+)
+@_PROP_SETTINGS
+def test_live_settings_apply_preserves_session(
+    backend_kind, camera, viewer_count, width, height, seq, features
+):
+    """Applying valid settings to a running session preserves it (Req 5.1, 5.2, 5.3).
+
+    Feature: concurrent-camera-stream-viewing, Property 18: Live settings apply
+    preserves the session.
+    Validates: Requirements 5.1, 5.2, 5.3.
+    """
+    registry = ClaimRegistry()
+    clock = MockClock(start=1_000.0)
+    created: List[MockCameraBackend] = []
+
+    with mock.patch.object(
+        broadcaster_module, "AcquisitionWorker", _StubAcquisitionWorker
+    ):
+        broadcaster = _make_broadcaster(backend_kind, registry, clock, created)
+
+        # Subscribe N viewers (the first opens the single device claim). Record the
+        # exact set of issued viewer ids so we can prove it is unchanged later.
+        viewer_ids = set()
+        for _ in range(viewer_count):
+            result = broadcaster.subscribe(camera)
+            assert result.accepted, "subscribe within max_viewers must be accepted"
+            viewer_ids.add(result.viewer_id)
+
+        assert len(viewer_ids) == viewer_count
+        assert registry.open_count(camera) == 1, "exactly one claim for the active camera"
+        assert len(created) == 1, "subscribe should build exactly one backend"
+        backend = created[0]
+
+        session = broadcaster._sessions[camera]
+        assert session.state == SessionState.RUNNING
+
+        # Publish a fresh frame into the live session so there is a readable latest
+        # frame before the apply (no real worker thread runs).
+        published = session.publish(
+            make_raw_frame(seq=seq, width=width, height=height), now=clock.time()
+        )
+
+        # Confirm the frame is readable BEFORE the apply.
+        viewer_for_read = next(iter(viewer_ids))
+        before = broadcaster.get_frame(camera, viewer_for_read)
+        assert before.status == FrameStatus.OK
+        assert before.frame is not None
+
+        # Snapshot the viewer set and claim accounting immediately before applying.
+        viewers_before = set(session.viewers.keys())
+        assert viewers_before == viewer_ids
+        opens_before = backend.open_count
+        closes_before = backend.close_count
+        applies_before = backend.apply_features_count
+
+        # --- the operation under test: apply valid live settings ---
+        accepted = broadcaster.apply_settings(camera, features)
+
+        # 1) The backend reflects the requested values: the broadcaster returns
+        #    exactly the device-accepted set, and the backend recorded the apply
+        #    (Req 5.1, 5.2). The mock echoes the normalized requested values.
+        assert isinstance(accepted, dict)
+        assert backend.apply_features_count == applies_before + 1
+        assert backend.applied_features[-1] == features
+        assert accepted == backend.last_applied_features
+        expected_accepted = MockCameraBackend._normalize_features(features)
+        assert accepted == expected_accepted
+
+        # 2) The session remains RUNNING (Req 5.3).
+        assert broadcaster._sessions.get(camera) is session
+        assert session.state == SessionState.RUNNING
+
+        # 3) The subscribed viewer set is unchanged before/after (Req 5.3).
+        viewers_after = set(session.viewers.keys())
+        assert viewers_after == viewers_before == viewer_ids
+        assert broadcaster.viewer_count(camera) == viewer_count
+
+        # 4) The latest frame is still readable after the apply, returning the same
+        #    published payload/seq (the slot was never cleared) (Req 5.2, 5.3).
+        after = broadcaster.get_frame(camera, viewer_for_read)
+        assert after.status == FrameStatus.OK
+        assert after.frame is not None
+        assert after.frame.seq == published.seq
+        assert after.frame.data == published.data
+        assert after.frame.width == width
+        assert after.frame.height == height
+
+        # 5) The single device claim was neither re-opened nor released by the apply
+        #    (the live claim is reused; no overlap ever observed).
+        assert backend.open_count == opens_before, "apply must not re-open the claim"
+        assert backend.close_count == closes_before, "apply must not release the claim"
+        assert registry.open_count(camera) == 1
+        assert registry.max_concurrent.get(camera) == 1
+        assert not registry.overlap_detected
+        assert len(created) == 1, "no second backend may be built by apply"
+
+        # Cleanup: drop all viewers so the claim is released through the normal path.
+        for viewer_id in viewer_ids:
+            broadcaster.unsubscribe(camera, viewer_id)
+        assert registry.open_count(camera) == 0

--- a/test/backend-test/utils/streaming/test_settings_failure.py
+++ b/test/backend-test/utils/streaming/test_settings_failure.py
@@ -1,0 +1,275 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based test for settings-apply failure retention.
+
+Feature: concurrent-camera-stream-viewing, Property 19: Settings-apply failure
+retains prior values — for any apply request in which at least one control fails,
+the operation returns an error identifying the failed control, the control values
+in effect before the request are retained unchanged, and the session remains
+active.
+
+Validates: Requirements 5.5.
+
+How the property is exercised
+-----------------------------
+A real :class:`StreamBroadcaster` is wired with an injected ``backend_factory``
+(building the shared :class:`MockCameraBackend` registered against one shared
+:class:`ClaimRegistry`) and an injected :class:`MockClock`, exactly like the
+single-claim / inference-failure property tests. For each example we:
+
+1. Subscribe a generated number of viewers to a single camera (start-on-first
+   opens the one device claim; the rest reuse it). The session is now ACTIVE
+   (RUNNING) holding exactly one claim.
+2. *Optionally* perform one successful ``apply_settings`` first (mock
+   ``fail_apply`` off) to establish the prior in-effect control values
+   (``session.applied_features``).
+3. Flip the mock backend to ``fail_apply=True`` and issue a subsequent
+   ``apply_settings`` with a generated, non-empty feature set, which the backend
+   rejects (models "at least one control fails").
+
+We then assert, for every variation, prior/failed feature set and viewer count,
+that the failed request (Req 5.5, Property 19):
+
+* raised :class:`SettingsApplyError`;
+* the error names the failed control(s) (``err.control`` matches the controls in
+  the failed request);
+* the prior in-effect values are retained unchanged — ``err.retained`` and the
+  session's ``applied_features`` both still equal the pre-request snapshot; and
+* the session remained active (still present, still ``RUNNING``) with its viewer
+  set unchanged and its single device claim still held.
+
+Test-only technique (no production code changed)
+------------------------------------------------
+Like ``test_broadcaster_claim.py`` / ``test_inference_failure.py``, this patches
+the ``AcquisitionWorker`` symbol in the broadcaster module with a no-op stub for
+the duration of each example so no real daemon thread / wall-clock grab loop runs.
+The stub marks the session RUNNING on ``start()`` (mirroring the real worker after
+its first published frame), which is exactly the live state the property
+quantifies over. Failure is induced purely through the mock backend's existing
+``fail_apply`` knob; production code is untouched.
+"""
+from __future__ import annotations
+
+import unittest.mock as mock
+from typing import Optional
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from mock_camera_backend import (
+    MOCK_BACKEND_CLASSES,
+    ClaimRegistry,
+    MockClock,
+)
+from utils.streaming import broadcaster as broadcaster_module
+from utils.streaming.broadcaster import (
+    SettingsApplyError,
+    StreamBroadcaster,
+    _describe_failed_controls,
+)
+from utils.streaming.models import SessionState, StreamConfig
+
+# Keep max_viewers comfortably above the generated viewer count so the active
+# session — not the viewer-limit branch — is what we exercise.
+_CONFIG = StreamConfig(max_viewers=8, stale_after_s=2.0)
+_CAMERA = "Fake_settings_fail_1"
+
+
+class _StubAcquisitionWorker:
+    """No-op stand-in for ``AcquisitionWorker`` (test-only; see module docstring).
+
+    Matches the broadcaster's construction/usage contract
+    (``AcquisitionWorker(session, stream_config=..., time_fn=...)`` then
+    ``start()`` / ``stop()`` / ``join()``) but runs no thread and performs no
+    grabs, so the session state is deterministic. ``start()`` marks the session
+    RUNNING to mirror the real worker after its first published frame.
+    """
+
+    def __init__(self, session, *, stream_config=None, time_fn=None, **kwargs) -> None:
+        self.session = session
+
+    def start(self):
+        self.session.state = SessionState.RUNNING
+        return None
+
+    def stop(self) -> None:
+        return None
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        return None
+
+
+@st.composite
+def _feature_dict(draw, *, require_nonempty: bool = False):
+    """Generate a varied image-source-style camera-control feature dict.
+
+    Produces an arbitrary subset of ``gain`` / ``exposure`` plus an optional
+    ``advancedSettings`` list of named GenICam features — the shapes
+    ``apply_features`` / ``_describe_failed_controls`` accept. When
+    ``require_nonempty`` is set the result is guaranteed to carry at least one
+    named control (used for the failing request so a control name is always
+    derivable).
+    """
+    features: dict = {}
+    if draw(st.booleans()):
+        features["gain"] = draw(st.integers(min_value=0, max_value=100))
+    if draw(st.booleans()):
+        features["exposure"] = draw(st.integers(min_value=1, max_value=100000))
+    advanced = draw(
+        st.lists(
+            st.fixed_dictionaries(
+                {
+                    "feature": st.sampled_from(
+                        ["Gamma", "BlackLevel", "Sharpness", "Saturation"]
+                    ),
+                    "value": st.integers(min_value=0, max_value=255),
+                }
+            ),
+            max_size=3,
+        )
+    )
+    if advanced:
+        features["advancedSettings"] = advanced
+    if require_nonempty and not features:
+        features["gain"] = draw(st.integers(min_value=0, max_value=100))
+    return features
+
+
+# Feature: concurrent-camera-stream-viewing, Property 19: Settings-apply failure retains prior values
+# Validates: Requirements 5.5
+@pytest.mark.parametrize(
+    "backend_cls", MOCK_BACKEND_CLASSES.values(), ids=list(MOCK_BACKEND_CLASSES)
+)
+@settings(max_examples=150, deadline=None)
+@given(
+    num_viewers=st.integers(min_value=1, max_value=_CONFIG.max_viewers),
+    establish_prior=st.booleans(),
+    prior_features=_feature_dict(),
+    failed_features=_feature_dict(require_nonempty=True),
+    clock_advance=st.floats(
+        min_value=0.0, max_value=120.0, allow_nan=False, allow_infinity=False
+    ),
+)
+def test_property_19_settings_apply_failure_retains_prior_values(
+    backend_cls,
+    num_viewers,
+    establish_prior,
+    prior_features,
+    failed_features,
+    clock_advance,
+):
+    """A failing apply raises SettingsApplyError naming the failed control,
+    retains the prior in-effect values unchanged, and leaves the session active
+    (RUNNING) with its viewer set and single claim intact.
+
+    Feature: concurrent-camera-stream-viewing, Property 19: Settings-apply failure retains prior values
+    Validates: Requirements 5.5
+    """
+    registry = ClaimRegistry()
+    clock = MockClock(start=1000.0)
+    created: dict[str, object] = {}
+
+    def backend_factory(camera_id, config):
+        backend = backend_cls(
+            camera_id,
+            claim_registry=registry,
+            clock=clock,
+        )
+        created[camera_id] = backend
+        return backend
+
+    broadcaster = StreamBroadcaster(
+        stream_config=_CONFIG,
+        backend_factory=backend_factory,
+        time_fn=clock.time,
+    )
+
+    with mock.patch.object(broadcaster_module, "AcquisitionWorker", _StubAcquisitionWorker):
+        # 1. Subscribe the generated number of viewers: start-on-first opens the
+        #    one claim, the rest reuse it. The session is now ACTIVE (RUNNING).
+        viewer_ids = []
+        for _ in range(num_viewers):
+            result = broadcaster.subscribe(_CAMERA)
+            assert result.accepted is True
+            viewer_ids.append(result.viewer_id)
+
+        assert broadcaster.viewer_count(_CAMERA) == num_viewers
+        assert registry.open_count(_CAMERA) == 1
+
+        session = broadcaster._sessions[_CAMERA]
+        backend = created[_CAMERA]
+        assert session.state == SessionState.RUNNING
+
+        # 2. Optionally establish the prior in-effect control values via one
+        #    successful apply (fail_apply is off by default on the mock).
+        if establish_prior:
+            accepted = broadcaster.apply_settings(_CAMERA, prior_features)
+            # The session now records the device-accepted prior values.
+            assert session.applied_features == accepted
+
+        # Snapshot the values in effect BEFORE the failing request — these are
+        # exactly what must be retained unchanged afterwards.
+        prior_snapshot = dict(session.applied_features)
+
+        opens_before = backend.open_count
+        closes_before = backend.close_count
+
+        # Varying the clock changes the freshness context; the failed apply must
+        # behave identically (error + retention + active session).
+        clock.advance(clock_advance)
+
+        # 3. Flip the backend to reject the next apply, then issue the failing
+        #    apply request (models "at least one control fails").
+        backend.fail_apply = True
+
+        with pytest.raises(SettingsApplyError) as exc_info:
+            broadcaster.apply_settings(_CAMERA, failed_features)
+
+    err = exc_info.value
+
+    # --- assertions: the failure is descriptive and retains prior state ---
+
+    # The error identifies the camera and names the failed control(s) (Req 5.5).
+    assert err.camera_id == _CAMERA
+    expected_control = _describe_failed_controls(failed_features)
+    assert err.control == expected_control
+    assert expected_control != "<unknown control>"  # a named control was derived
+
+    # The prior in-effect values are retained unchanged: both the error's
+    # ``retained`` payload and the session's recorded applied_features still equal
+    # the pre-request snapshot (the failed request did not mutate them).
+    assert err.retained == prior_snapshot
+    assert session.applied_features == prior_snapshot
+
+    # The session remains active: still present, still RUNNING, viewer set
+    # unchanged, and the single device claim still held (not opened/closed by the
+    # failed apply).
+    assert _CAMERA in broadcaster._sessions
+    assert broadcaster._sessions[_CAMERA] is session
+    assert session.state == SessionState.RUNNING
+    assert broadcaster.viewer_count(_CAMERA) == num_viewers
+    assert set(session.viewers.keys()) == set(viewer_ids)
+    assert registry.open_count(_CAMERA) == 1
+    assert registry.total_open() == 1
+    assert backend.open_count == opens_before    # no new claim opened
+    assert backend.close_count == closes_before  # claim retained (not released)
+    registry.assert_single_claim()
+
+    # Cleanup: drain viewers so the broadcaster stops the session and releases the
+    # claim through its normal stop-on-last path, returning the claim count to 0.
+    with mock.patch.object(broadcaster_module, "AcquisitionWorker", _StubAcquisitionWorker):
+        for viewer_id in list(session.viewers.keys()):
+            broadcaster.unsubscribe(_CAMERA, viewer_id)
+    assert registry.open_count(_CAMERA) == 0

--- a/test/backend-test/utils/streaming/test_stream_models.py
+++ b/test/backend-test/utils/streaming/test_stream_models.py
@@ -1,0 +1,77 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based tests for ``StreamConfig`` timeout clamping.
+
+Feature: concurrent-camera-stream-viewing, Property 15: Timeout/configuration
+clamping — for any configured frame-timeout or open-timeout value, the effective
+timeout used equals that value clamped to the range [500, 30000] ms.
+"""
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from utils.streaming.models import StreamConfig
+
+# The inclusive clamp bounds enforced by StreamConfig (Req 7.1).
+MIN_TIMEOUT_MS = 500
+MAX_TIMEOUT_MS = 30000
+
+# Generate arbitrary integers that straddle the clamp window: a generous span
+# below the lower bound, across the in-range band, and well above the upper
+# bound, so each Hypothesis run exercises below-500, in-range, and above-30000.
+_timeout_ints = st.integers(min_value=-100_000, max_value=1_000_000)
+
+
+def _expected_clamp(value: int) -> int:
+    """Reference clamp into the inclusive [500, 30000] ms range."""
+    return max(MIN_TIMEOUT_MS, min(MAX_TIMEOUT_MS, value))
+
+
+# Feature: concurrent-camera-stream-viewing, Property 15: Timeout/configuration clamping
+# Validates: Requirements 7.1
+@settings(max_examples=200)
+@given(frame_timeout_ms=_timeout_ints, open_timeout_ms=_timeout_ints)
+def test_property_15_timeout_configuration_clamping(frame_timeout_ms, open_timeout_ms):
+    """StreamConfig clamps both timeouts to [500, 30000]; in-range values unchanged.
+
+    Feature: concurrent-camera-stream-viewing, Property 15: Timeout/configuration clamping
+    Validates: Requirements 7.1
+    """
+    config = StreamConfig(
+        frame_timeout_ms=frame_timeout_ms,
+        open_timeout_ms=open_timeout_ms,
+    )
+
+    # The effective timeouts equal the configured values clamped to [500, 30000].
+    assert config.frame_timeout_ms == _expected_clamp(frame_timeout_ms)
+    assert config.open_timeout_ms == _expected_clamp(open_timeout_ms)
+
+    # The clamped results always lie within the accepted inclusive range.
+    assert MIN_TIMEOUT_MS <= config.frame_timeout_ms <= MAX_TIMEOUT_MS
+    assert MIN_TIMEOUT_MS <= config.open_timeout_ms <= MAX_TIMEOUT_MS
+
+    # Values below the floor clamp up to the floor; above the ceiling clamp down
+    # to the ceiling; in-range values are left unchanged.
+    if frame_timeout_ms < MIN_TIMEOUT_MS:
+        assert config.frame_timeout_ms == MIN_TIMEOUT_MS
+    elif frame_timeout_ms > MAX_TIMEOUT_MS:
+        assert config.frame_timeout_ms == MAX_TIMEOUT_MS
+    else:
+        assert config.frame_timeout_ms == frame_timeout_ms
+
+    if open_timeout_ms < MIN_TIMEOUT_MS:
+        assert config.open_timeout_ms == MIN_TIMEOUT_MS
+    elif open_timeout_ms > MAX_TIMEOUT_MS:
+        assert config.open_timeout_ms == MAX_TIMEOUT_MS
+    else:
+        assert config.open_timeout_ms == open_timeout_ms

--- a/test/backend-test/utils/streaming/test_worker_cadence.py
+++ b/test/backend-test/utils/streaming/test_worker_cadence.py
@@ -1,0 +1,198 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based test for producer-cadence independence.
+
+Feature: concurrent-camera-stream-viewing, Property 5: Producer cadence is
+independent of viewer count — for any fixed sequence of frames produced by the
+backend, the sequence of frames published into the latest-frame slot is
+identical whether 1 or ``max_viewers`` viewers are reading arbitrarily, and no
+viewer read prevents or delays a publish (drop-to-latest, no backpressure)
+(Req 4.5).
+
+The acquisition worker is the single producer driving one ``StreamSession``. We
+script the mock ``CameraBackend`` with a fixed, byte-distinguishable frame
+sequence and drive ``AcquisitionWorker.run()`` deterministically with an
+injected ``MockClock`` (used as both the time source and the sleep function, so
+no real threads or wall-clock time are involved). The loop terminates on its
+own once the scripted queue is exhausted (the trailing ``None`` grab is treated
+as a disconnect), so exactly ``len(frames)`` publishes occur.
+
+Arbitrary, interleaved viewer reads are modelled deterministically by hooking
+the session's ``publish`` and issuing a generated number of ``read_latest``
+calls (per viewer) in each inter-publish interval. The test then asserts that
+the captured sequence of published ``(seq, data, width, height)`` tuples is:
+
+* identical for 1 viewer vs ``max_viewers`` viewers, and
+* identical to the scripted input sequence (so reads neither drop, reorder, nor
+  delay a publish).
+"""
+import uuid
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from mock_camera_backend import (
+    MOCK_BACKEND_CLASSES,
+    MockClock,
+    make_raw_frame,
+)
+from utils.streaming.models import SessionState, StreamConfig, Viewer
+from utils.streaming.session import StreamSession
+from utils.streaming.worker import AcquisitionWorker
+
+# Per-camera viewer ceiling the property quantifies over (StreamConfig default).
+MAX_VIEWERS = StreamConfig().max_viewers
+CAMERA_ID = "Fake_1"
+
+
+def _make_viewer(camera_id: str, now: float) -> Viewer:
+    """Build a Viewer with a unique id for registration in a session."""
+    return Viewer(
+        viewer_id=str(uuid.uuid4()),
+        camera_id=camera_id,
+        subscribed_at=now,
+        last_active=now,
+    )
+
+
+def _run_scenario(backend_cls, payloads, width, height, num_viewers, reads_per_interval):
+    """Drive the worker over a fixed scripted sequence with interleaved reads.
+
+    Builds a session served by a freshly-scripted mock backend, registers
+    ``num_viewers`` viewers, hooks ``publish`` to (a) record every frame pushed
+    into the latest-frame slot and (b) issue ``reads_per_interval[i]`` reads per
+    viewer in interval ``i``, then runs the worker loop to natural completion.
+
+    Returns the list of captured ``(seq, data, width, height)`` tuples in the
+    exact order they were published.
+    """
+    # Deterministic virtual clock used as BOTH the worker's time source and its
+    # sleep function, so the rate-ceiling sleep advances virtual time instead of
+    # blocking and no real threads/time are involved.
+    clock = MockClock(start=1000.0)
+
+    scripted = [make_raw_frame(seq=i, width=width, height=height, data=p)
+                for i, p in enumerate(payloads)]
+    # default_grab defaults to None: once the scripted queue drains, the worker
+    # sees a failed grab on an established stream and stops (DISCONNECTED), so
+    # exactly len(scripted) publishes occur.
+    backend = backend_cls(CAMERA_ID, frames=list(scripted), clock=clock)
+    # The broadcaster owns open/start_stream in production; the worker only
+    # grab->publishes. Acquire the single claim and start acquisition before
+    # driving the loop so grab() serves the scripted frames.
+    backend.open()
+    backend.start_stream()
+
+    session = StreamSession(
+        CAMERA_ID,
+        backend=backend,
+        # Generous freshness window so interleaved reads stay OK; irrelevant to
+        # what gets published, but keeps reads representative of live viewers.
+        stream_config=StreamConfig(stale_after_s=10_000.0),
+    )
+
+    viewers = [_make_viewer(CAMERA_ID, clock.time()) for _ in range(num_viewers)]
+    for viewer in viewers:
+        session.add_viewer(viewer)
+    assert session.viewer_count() == num_viewers
+
+    published = []
+    interval = {"i": 0}
+    real_publish = session.publish
+    total = len(scripted)
+
+    worker = AcquisitionWorker(
+        session,
+        time_fn=clock.monotonic,
+        sleep_fn=clock.sleep,
+    )
+
+    def recording_publish(frame, width=None, height=None, now=0.0):
+        result = real_publish(frame, width=width, height=height, now=now)
+        published.append((result.seq, bytes(result.data), result.width, result.height))
+        # Interleave arbitrary viewer reads AFTER this publish and before the
+        # next one. Reads are pure slot reads and must not affect what the
+        # producer publishes next (no backpressure).
+        idx = interval["i"]
+        reads = reads_per_interval[idx] if idx < len(reads_per_interval) else 0
+        for _ in range(reads):
+            for viewer in viewers:
+                session.read_latest(now)
+        interval["i"] += 1
+        # Stop the loop cleanly once the fixed scripted sequence is exhausted, so
+        # the run is deterministic and bounded (no real threads / wall clock).
+        if len(published) >= total:
+            worker.stop()
+        return result
+
+    # Hook the single producer's publish path to capture + interleave reads.
+    session.publish = recording_publish
+
+    worker.run()
+
+    return published
+
+
+# Fixed scripted frame sequence: 1..10 byte-distinguishable frames.
+_payloads = st.lists(st.binary(min_size=0, max_size=24), min_size=1, max_size=10)
+# Arbitrary per-interval read counts (per viewer) modelling interleaved reads.
+_reads = st.lists(st.integers(min_value=0, max_value=4), min_size=0, max_size=10)
+
+
+# Feature: concurrent-camera-stream-viewing, Property 5: Producer cadence is independent of viewer count
+# Validates: Requirements 4.5
+@pytest.mark.parametrize("backend_cls", MOCK_BACKEND_CLASSES.values(), ids=list(MOCK_BACKEND_CLASSES))
+@settings(max_examples=150)
+@given(
+    payloads=_payloads,
+    width=st.integers(min_value=1, max_value=64),
+    height=st.integers(min_value=1, max_value=64),
+    reads_single=_reads,
+    reads_multi=_reads,
+)
+def test_property_5_producer_cadence_independent_of_viewers(
+    backend_cls, payloads, width, height, reads_single, reads_multi
+):
+    """Published frame sequence is identical for 1 vs max_viewers readers.
+
+    Feature: concurrent-camera-stream-viewing, Property 5: Producer cadence is independent of viewer count
+    Validates: Requirements 4.5
+    """
+    # The fixed input the producer should publish verbatim, regardless of how
+    # many viewers read or how often they read (seq is the monotonic 1-based
+    # publish index).
+    expected = [(i + 1, bytes(p), width, height) for i, p in enumerate(payloads)]
+
+    # One viewer reading arbitrarily.
+    published_single = _run_scenario(
+        backend_cls, payloads, width, height,
+        num_viewers=1, reads_per_interval=reads_single,
+    )
+
+    # max_viewers all reading arbitrarily (more, differently-scheduled reads).
+    published_multi = _run_scenario(
+        backend_cls, payloads, width, height,
+        num_viewers=MAX_VIEWERS, reads_per_interval=reads_multi,
+    )
+
+    # No read prevented or delayed a publish: every scripted frame was published
+    # exactly once, in order, with identical bytes — for either viewer count.
+    assert published_single == expected
+    assert published_multi == expected
+
+    # The producer cadence is therefore independent of viewer count and reads.
+    assert published_single == published_multi
+    assert len(published_single) == len(payloads)
+    assert len(published_multi) == len(payloads)

--- a/test/backend-test/utils/streaming/test_worker_failure.py
+++ b/test/backend-test/utils/streaming/test_worker_failure.py
@@ -1,0 +1,153 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based tests for acquisition-failure last-good-frame retention.
+
+Feature: concurrent-camera-stream-viewing, Property 13: Acquisition failure
+preserves the last good frame — for any published latest frame followed by a
+failed grab, the latest-frame slot still equals the last successfully published
+frame (the failed grab does not overwrite it) and an acquisition-failure
+indication is produced (the session transitions to ERROR and the worker stops
+with reason DISCONNECTED).
+
+Validates: Requirements 2.7
+"""
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from utils.streaming.models import SessionState, StreamConfig
+from utils.streaming.session import StreamSession
+from utils.streaming.worker import AcquisitionWorker, WorkerStopReason
+
+from mock_camera_backend import (
+    BACKEND_KINDS,
+    MockClock,
+    make_backend,
+    make_raw_frame,
+)
+
+
+def _build_running_session(backend_kind, good_frames, clock):
+    """Create a session + worker scripted with ``good_frames`` then a failed grab.
+
+    Opens the device claim and starts the stream (the worker drives only
+    ``grab`` / ``publish``, never ``open``/``start_stream``), queues the supplied
+    good frames, and leaves the backend's exhausted-queue default as ``None`` so
+    the grab immediately after the last good frame is a failed grab (timeout /
+    acquisition failure) on an already-established stream.
+
+    Returns the session, backend, worker, and the list of queued good frames.
+    """
+    backend = make_backend(backend_kind, camera_id="Fake_1", clock=clock)
+    # The worker reads grab() directly; the claim must be open so grab() does not
+    # short-circuit to None. Establish the stream first.
+    backend.open()
+    backend.start_stream()
+    backend.queue_frames(good_frames)
+    # default_grab is None -> the grab after the queue drains is a failed grab.
+
+    session = StreamSession("Fake_1", backend=backend, stream_config=StreamConfig())
+    worker = AcquisitionWorker(
+        session,
+        time_fn=clock,
+        sleep_fn=clock.sleep,
+    )
+    return session, backend, worker, good_frames
+
+
+# Feature: concurrent-camera-stream-viewing, Property 13: Acquisition failure preserves the last good frame
+# Validates: Requirements 2.7
+@settings(max_examples=200, deadline=None)
+@given(
+    backend_kind=st.sampled_from(BACKEND_KINDS),
+    # Arbitrary good-frame payloads (>= 1 establishes the stream and a last-good
+    # latest-frame). Distinct, byte-distinguishable payloads so "not overwritten"
+    # is verifiable down to the exact bytes of the last good frame.
+    payloads=st.lists(
+        st.binary(min_size=1, max_size=32),
+        min_size=1,
+        max_size=10,
+    ),
+    width=st.integers(min_value=1, max_value=64),
+    height=st.integers(min_value=1, max_value=64),
+)
+def test_property_13_failed_grab_preserves_last_good_frame(backend_kind, payloads, width, height):
+    """A failed grab keeps the last good frame and yields a DISCONNECTED stop.
+
+    Feature: concurrent-camera-stream-viewing, Property 13: Acquisition failure
+    preserves the last good frame
+    Validates: Requirements 2.7
+    """
+    clock = MockClock(start=0.0)
+    good_frames = [
+        make_raw_frame(seq=i, width=width, height=height, data=payload)
+        for i, payload in enumerate(payloads)
+    ]
+    session, backend, worker, good_frames = _build_running_session(
+        backend_kind, good_frames, clock
+    )
+
+    last_good = good_frames[-1]
+
+    # Drive the grab -> publish loop. It publishes every good frame, then hits the
+    # failed grab (None) on the established stream and returns.
+    reason = worker.run()
+
+    # --- acquisition-failure indication is produced (Req 2.7) ----------------
+    assert reason == WorkerStopReason.DISCONNECTED
+    assert worker.stop_reason == WorkerStopReason.DISCONNECTED
+    assert session.state == SessionState.ERROR
+    assert worker.error is not None and "disconnect" in worker.error.lower()
+
+    # The backend was grabbed exactly once per good frame plus the one failed grab.
+    assert backend.grab_count == len(good_frames) + 1
+
+    # --- the failed grab did NOT overwrite the latest-frame slot (Req 2.7) ----
+    assert session.latest is not None
+    # seq is monotonic and assigned only on publish: equals the count of good
+    # frames, proving the failed grab did not publish a new frame.
+    assert session.latest.seq == len(good_frames)
+    # The slot still holds the last successfully published frame, byte-identical.
+    assert session.latest.data == last_good.data
+    assert session.latest.width == last_good.width
+    assert session.latest.height == last_good.height
+
+    # A subsequent read returns that same retained last-good frame (it was not
+    # cleared or overwritten by the failure).
+    assert session.read_latest(now=clock.time()).frame is not None
+    assert session.read_latest(now=clock.time()).frame.seq == len(good_frames)
+    assert session.read_latest(now=clock.time()).frame.data == last_good.data
+
+
+# Feature: concurrent-camera-stream-viewing, Property 13: Acquisition failure preserves the last good frame
+# Validates: Requirements 2.7
+def test_property_13_single_good_frame_then_failure_example():
+    """Concrete example: one good frame, then a failed grab retains it.
+
+    Feature: concurrent-camera-stream-viewing, Property 13: Acquisition failure
+    preserves the last good frame
+    Validates: Requirements 2.7
+    """
+    clock = MockClock(start=0.0)
+    good = make_raw_frame(seq=0, width=8, height=8, data=b"good-frame")
+    session, backend, worker, _ = _build_running_session("aravis", [good], clock)
+
+    reason = worker.run()
+
+    assert reason == WorkerStopReason.DISCONNECTED
+    assert session.state == SessionState.ERROR
+    # One good publish (seq 1) retained after the failed grab; not overwritten.
+    assert session.latest is not None
+    assert session.latest.seq == 1
+    assert session.latest.data == b"good-frame"
+    assert backend.grab_count == 2  # one good grab + one failed grab

--- a/test/backend-test/utils/test_camera_manager.py
+++ b/test/backend-test/utils/test_camera_manager.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import patch
+import inspect
+
+from unittest.mock import patch, Mock
 from utils.common import CameraStatusEnum
 from local_server_base_test_case import LocalServerBaseTestCase
 from exceptions.api.aravis_camera_exception import AravisCameraException
@@ -68,3 +70,123 @@ class TestCameraManager(LocalServerBaseTestCase):
         from utils.camera_manager import get_camera_status 
         result = get_camera_status("fake")
         self.assertEqual(result.status, CameraStatusEnum.DISCONNECTED)
+
+
+class TestGetCameraFrameCompatibility(LocalServerBaseTestCase):
+    """Regression tests for ``get_camera_frame`` after it was rewired (task 7.2)
+    onto ``StreamBroadcaster.get_inference_frame`` (task 7.7).
+
+    The existing ``digital_input_*`` / ``workflow`` / capture callers depend on a
+    stable contract for ``get_camera_frame(camera_id, camera_config)``:
+
+    * the signature is unchanged — ``camera_config`` is positional-or-keyword and
+      defaults to ``None``,
+    * on success it returns the broadcaster's frame dict (``{'data','height','width'}``)
+      verbatim,
+    * on no-frame it raises an ``Exception`` (the capture / workflow endpoints catch
+      this and surface an HTTP error),
+    * ``camera_id`` and ``camera_config`` are forwarded unchanged to the broadcaster.
+
+    These tests pin that contract by patching the broadcaster singleton, so they do
+    not need a real camera / device stack. ``get_camera_frame`` resolves the
+    broadcaster via a function-level ``from utils.streaming.broadcaster import
+    get_broadcaster``, so patching ``utils.streaming.broadcaster.get_broadcaster`` is
+    what the call picks up.
+    _Validates: Requirements 6.1, 6.3_
+    """
+
+    def _patch_broadcaster(self, frame):
+        """Patch the broadcaster singleton so ``get_inference_frame`` returns ``frame``.
+
+        Returns the started patcher (caller stops it) and the stub broadcaster so the
+        test can assert how it was called.
+        """
+        stub = Mock(name="StreamBroadcaster")
+        stub.get_inference_frame.return_value = frame
+        patcher = patch(
+            "utils.streaming.broadcaster.get_broadcaster", return_value=stub
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return stub
+
+    def test_signature_is_unchanged(self):
+        """The public signature stays ``get_camera_frame(camera_id, camera_config=None)``
+        so positional callers (``digital_input_*`` / ``workflow`` / capture) keep working."""
+        from utils.camera_manager import get_camera_frame
+
+        sig = inspect.signature(get_camera_frame)
+        params = list(sig.parameters)
+        self.assertEqual(params, ["camera_id", "camera_config"])
+        # camera_config must remain optional (defaults to None) for the single-arg
+        # callers and for backwards compatibility.
+        self.assertEqual(
+            sig.parameters["camera_config"].default, None
+        )
+
+    def test_returns_broadcaster_frame_dict_on_success(self):
+        """A successful inference frame is returned verbatim as the legacy dict shape."""
+        from utils.camera_manager import get_camera_frame
+
+        frame = {"data": b"\x00\x01\x02\x03", "height": 2, "width": 2}
+        stub = self._patch_broadcaster(frame)
+
+        result = get_camera_frame("Fake_1", {"gain": 5, "exposure": 1000})
+
+        self.assertIs(result, frame)
+        self.assertEqual(result, {"data": b"\x00\x01\x02\x03", "height": 2, "width": 2})
+        stub.get_inference_frame.assert_called_once_with(
+            "Fake_1", {"gain": 5, "exposure": 1000}
+        )
+
+    def test_forwards_camera_id_and_config_unchanged(self):
+        """``camera_id`` and ``camera_config`` are passed through to the broadcaster
+        untouched, so capture/workflow per-capture config still reaches the device path."""
+        from utils.camera_manager import get_camera_frame
+
+        config = {"type": "Camera", "imageSourceConfiguration": {"gain": 2}}
+        stub = self._patch_broadcaster({"data": b"x", "height": 1, "width": 1})
+
+        get_camera_frame("camera-123", config)
+
+        stub.get_inference_frame.assert_called_once_with("camera-123", config)
+
+    def test_defaults_camera_config_to_none_for_single_arg_callers(self):
+        """Single-argument callers (``get_camera_frame(camera_id)``) forward ``None``
+        as the config, exercising the broadcaster's no-config path."""
+        from utils.camera_manager import get_camera_frame
+
+        stub = self._patch_broadcaster({"data": b"y", "height": 1, "width": 1})
+
+        get_camera_frame("Fake_1")
+
+        stub.get_inference_frame.assert_called_once_with("Fake_1", None)
+
+    def test_raises_when_broadcaster_returns_none(self):
+        """When no frame is available the broadcaster returns ``None``; the legacy
+        contract requires ``get_camera_frame`` to raise so callers surface an error."""
+        from utils.camera_manager import get_camera_frame
+
+        self._patch_broadcaster(None)
+
+        with self.assertRaises(Exception) as ctx:
+            get_camera_frame("Fake_1", {"gain": 1})
+        self.assertIn("Fake_1", str(ctx.exception))
+
+    def test_capture_caller_surfaces_no_frame_as_exception(self):
+        """End-to-end-ish: the capture helper (``captured_images_utils``) wraps
+        ``get_camera_frame`` in try/except and re-raises as an HTTP error, so a
+        ``None`` from the broadcaster must propagate as a raised exception, not a
+        ``None`` return that would slip past the caller's error handling."""
+        from utils.camera_manager import get_camera_frame
+
+        self._patch_broadcaster(None)
+
+        # The capture path does: try: return get_camera_frame(...) except Exception: raise HTTPException
+        # so confirm the exception is raised (not swallowed / not a None return).
+        raised = False
+        try:
+            get_camera_frame("Fake_1", {})
+        except Exception:
+            raised = True
+        self.assertTrue(raised, "get_camera_frame must raise on no-frame for callers")

--- a/test/backend-test/utils/test_camera_manager.py
+++ b/test/backend-test/utils/test_camera_manager.py
@@ -73,42 +73,25 @@ class TestCameraManager(LocalServerBaseTestCase):
 
 
 class TestGetCameraFrameCompatibility(LocalServerBaseTestCase):
-    """Regression tests for ``get_camera_frame`` after it was rewired (task 7.2)
-    onto ``StreamBroadcaster.get_inference_frame`` (task 7.7).
+    """Regression tests for ``get_camera_frame`` after reverting it to the cached,
+    persistent connection model (the production ``LIBUSB_ERROR_BUSY`` fix).
 
-    The existing ``digital_input_*`` / ``workflow`` / capture callers depend on a
-    stable contract for ``get_camera_frame(camera_id, camera_config)``:
+    The earlier broadcaster rewiring (task 7.2) opened AND closed a fresh device
+    claim on every call via the broadcaster's no-session path; on real USB3Vision
+    hardware the ~500 ms preview poll overlapped those open/close cycles and the
+    device rejected the next claim with ``LIBUSB_ERROR_BUSY``, breaking the live
+    view. ``get_camera_frame`` is back to the proven model: open the camera once
+    (``connect_camera`` -> ``camera_objects``) and **reuse** it across calls,
+    performing only a per-request ``start_acquisition``/``get_frame``/
+    ``stop_acquisition`` (in ``_get_camera_frame``) without releasing the claim
+    between calls.
 
-    * the signature is unchanged — ``camera_config`` is positional-or-keyword and
-      defaults to ``None``,
-    * on success it returns the broadcaster's frame dict (``{'data','height','width'}``)
-      verbatim,
-    * on no-frame it raises an ``Exception`` (the capture / workflow endpoints catch
-      this and surface an HTTP error),
-    * ``camera_id`` and ``camera_config`` are forwarded unchanged to the broadcaster.
-
-    These tests pin that contract by patching the broadcaster singleton, so they do
-    not need a real camera / device stack. ``get_camera_frame`` resolves the
-    broadcaster via a function-level ``from utils.streaming.broadcaster import
-    get_broadcaster``, so patching ``utils.streaming.broadcaster.get_broadcaster`` is
-    what the call picks up.
-    _Validates: Requirements 6.1, 6.3_
+    The caller contract (``digital_input_*`` / ``workflow`` / capture / preview) is
+    unchanged: same signature, returns the ``{'data','height','width'}`` dict on
+    success, raises ``Exception`` on no-frame/failure. These tests pin that contract
+    and the no-per-call-reconnect behavior by patching ``camera_objects`` /
+    ``connect_camera`` / ``_get_camera_frame`` so no real device is needed.
     """
-
-    def _patch_broadcaster(self, frame):
-        """Patch the broadcaster singleton so ``get_inference_frame`` returns ``frame``.
-
-        Returns the started patcher (caller stops it) and the stub broadcaster so the
-        test can assert how it was called.
-        """
-        stub = Mock(name="StreamBroadcaster")
-        stub.get_inference_frame.return_value = frame
-        patcher = patch(
-            "utils.streaming.broadcaster.get_broadcaster", return_value=stub
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
-        return stub
 
     def test_signature_is_unchanged(self):
         """The public signature stays ``get_camera_frame(camera_id, camera_config=None)``
@@ -124,69 +107,53 @@ class TestGetCameraFrameCompatibility(LocalServerBaseTestCase):
             sig.parameters["camera_config"].default, None
         )
 
-    def test_returns_broadcaster_frame_dict_on_success(self):
-        """A successful inference frame is returned verbatim as the legacy dict shape."""
+    def test_reuses_cached_camera_without_reconnecting(self):
+        """When the camera is already cached, get_camera_frame reuses it and does NOT
+        re-open the USB claim (the crux of the LIBUSB_ERROR_BUSY fix)."""
         from utils.camera_manager import get_camera_frame
 
         frame = {"data": b"\x00\x01\x02\x03", "height": 2, "width": 2}
-        stub = self._patch_broadcaster(frame)
+        fake_camera = Mock(name="Camera")
+        with patch("utils.camera_manager.camera_objects", {"Fake_1": fake_camera}), \
+             patch("utils.camera_manager.connect_camera") as mock_connect, \
+             patch("utils.camera_manager._get_camera_frame", return_value=frame) as mock_grab:
+            result = get_camera_frame("Fake_1", {"gain": 5, "exposure": 1000})
 
-        result = get_camera_frame("Fake_1", {"gain": 5, "exposure": 1000})
+        self.assertEqual(result, frame)
+        # Cached connection reused: no re-open/claim per call.
+        mock_connect.assert_not_called()
+        mock_grab.assert_called_once()
+        # camera_config is forwarded to the per-request grab unchanged.
+        self.assertEqual(mock_grab.call_args[0][2], {"gain": 5, "exposure": 1000})
 
-        self.assertIs(result, frame)
-        self.assertEqual(result, {"data": b"\x00\x01\x02\x03", "height": 2, "width": 2})
-        stub.get_inference_frame.assert_called_once_with(
-            "Fake_1", {"gain": 5, "exposure": 1000}
-        )
-
-    def test_forwards_camera_id_and_config_unchanged(self):
-        """``camera_id`` and ``camera_config`` are passed through to the broadcaster
-        untouched, so capture/workflow per-capture config still reaches the device path."""
+    def test_connects_once_when_not_cached(self):
+        """When no cached camera exists, get_camera_frame connects exactly once
+        (then reuse takes over on subsequent calls)."""
         from utils.camera_manager import get_camera_frame
 
-        config = {"type": "Camera", "imageSourceConfiguration": {"gain": 2}}
-        stub = self._patch_broadcaster({"data": b"x", "height": 1, "width": 1})
+        frame = {"data": b"x", "height": 1, "width": 1}
+        cache = {}
+        fake_camera = Mock(name="Camera")
 
-        get_camera_frame("camera-123", config)
+        def _fake_connect(camera_id):
+            cache[camera_id] = fake_camera
 
-        stub.get_inference_frame.assert_called_once_with("camera-123", config)
+        with patch("utils.camera_manager.camera_objects", cache), \
+             patch("utils.camera_manager.connect_camera", side_effect=_fake_connect) as mock_connect, \
+             patch("utils.camera_manager._get_camera_frame", return_value=frame):
+            result = get_camera_frame("Fake_1")
 
-    def test_defaults_camera_config_to_none_for_single_arg_callers(self):
-        """Single-argument callers (``get_camera_frame(camera_id)``) forward ``None``
-        as the config, exercising the broadcaster's no-config path."""
+        self.assertEqual(result, frame)
+        mock_connect.assert_called_once_with("Fake_1")
+
+    def test_raises_when_no_frame(self):
+        """A None grab result raises Exception (capture/workflow surface it as HTTP error)."""
         from utils.camera_manager import get_camera_frame
 
-        stub = self._patch_broadcaster({"data": b"y", "height": 1, "width": 1})
-
-        get_camera_frame("Fake_1")
-
-        stub.get_inference_frame.assert_called_once_with("Fake_1", None)
-
-    def test_raises_when_broadcaster_returns_none(self):
-        """When no frame is available the broadcaster returns ``None``; the legacy
-        contract requires ``get_camera_frame`` to raise so callers surface an error."""
-        from utils.camera_manager import get_camera_frame
-
-        self._patch_broadcaster(None)
-
-        with self.assertRaises(Exception) as ctx:
-            get_camera_frame("Fake_1", {"gain": 1})
+        fake_camera = Mock(name="Camera")
+        with patch("utils.camera_manager.camera_objects", {"Fake_1": fake_camera}), \
+             patch("utils.camera_manager.connect_camera"), \
+             patch("utils.camera_manager._get_camera_frame", return_value=None):
+            with self.assertRaises(Exception) as ctx:
+                get_camera_frame("Fake_1", {"gain": 1})
         self.assertIn("Fake_1", str(ctx.exception))
-
-    def test_capture_caller_surfaces_no_frame_as_exception(self):
-        """End-to-end-ish: the capture helper (``captured_images_utils``) wraps
-        ``get_camera_frame`` in try/except and re-raises as an HTTP error, so a
-        ``None`` from the broadcaster must propagate as a raised exception, not a
-        ``None`` return that would slip past the caller's error handling."""
-        from utils.camera_manager import get_camera_frame
-
-        self._patch_broadcaster(None)
-
-        # The capture path does: try: return get_camera_frame(...) except Exception: raise HTTPException
-        # so confirm the exception is raised (not swallowed / not a None return).
-        raised = False
-        try:
-            get_camera_frame("Fake_1", {})
-        except Exception:
-            raised = True
-        self.assertTrue(raised, "get_camera_frame must raise on no-frame for callers")


### PR DESCRIPTION
## Summary

Adds **concurrent camera stream viewing**: multiple browser tabs/clients can now view the same camera's live preview at once, instead of one viewer blocking the others. Introduces a broadcast-style frame source — a single acquisition session per physical camera that fans the latest frame out to all subscribed viewers — plus the API and frontend pieces to drive it, behind a new `src/backend/utils/streaming/` package and a `/streams/*` API.

Validated on-device (JetPack 5, Basler USB3Vision): multiple windows view the stream simultaneously and capture works concurrently.

## Background / design

Previously each preview frame ran through a global `get_frame_lock` plus a per-request `start_acquisition`/`get_frame`/`stop_acquisition` cycle, so two tabs polling the same camera serialized on one lock and effectively only one could view. The new model: viewers **subscribe** to a stream, a single producer grabs each frame once and publishes it to a single-writer/many-reader slot, and all viewers read the latest frame. The session starts on the first viewer and stops (releasing the one device claim) on the last, with a heartbeat + stale-viewer sweep as the backstop for abandoned tabs.

Spec (requirements, design with 21 correctness properties, tasks) is included under `.kiro/specs/concurrent-camera-stream-viewing/`.

## Backend — new `utils/streaming/` package

- **`models.py`** — `LatestFrame`, `Viewer`, `SessionState`/`FrameStatus` enums, `FrameResult`/`SubscribeResult`, and `StreamConfig` (with frame/open-timeout clamping to [500, 30000] ms).
- **`backends.py`** — `CameraBackend` protocol + `AravisBackend` and `GStreamerBackend` adapters (gi imports kept lazy so the module is import-safe without the native stack); bounded open with ≤3 attempts; plus a pure `validate_config_against_bounds` capture-config validator.
- **`session.py`** — `StreamSession`: single-writer/many-reader latest-frame slot, viewer registry, freshness classification (OK / NO_FRAME / STALE).
- **`worker.py`** — `AcquisitionWorker`: the single grab→publish producer, with first-frame timeout, disconnect detection, and last-good-frame retention.
- **`broadcaster.py`** — `StreamBroadcaster`: process-wide registry enforcing **one device claim per camera**, subscribe/unsubscribe lifecycle, viewer-limit + open-failure handling, heartbeat refresh + stale-viewer sweep, `get_frame` state encoding + disconnection cascade, `get_inference_frame` (session-claim reuse with dedicated fallback), live `apply_settings` (with failure rollback), and an isolated `preview_with_override` path.

## Backend — API & integration

- **`endpoints/streams.py`** (new) — `POST /streams/{id}/subscribe`, `GET /streams/{id}/frame`, `POST /streams/{id}/heartbeat`, `POST /streams/{id}/unsubscribe`, `GET /streams/{id}/viewers`, `POST /streams/{id}/settings`; thin clients over the broadcaster with status-code mapping (429 viewer-limit, 503 camera-unavailable/disconnected, 204 no-frame, etc.). Registered in `app.py`.
- The broadcaster/streams stack is currently **dormant on the hot path** — see the regression-fix note below; it activates when the frontend is migrated end-to-end to subscribe/heartbeat/unsubscribe.

## Frontend

- **`api/StreamAPI.ts`** — typed client for the `/streams/*` API (arraybuffer frame fetch → object URL, `X-Frame-Status` handling).
- **`components/live-result/useCameraStream.ts`** — hook: subscribe on mount, poll-as-heartbeat, unsubscribe on unmount + `navigator.sendBeacon` on tab close, object-URL lifecycle management.
- **`components/live-result/StreamPreview.tsx`** — renders each frame/subscription state (ok / stale / no-frame / disconnected / viewer-limit / unavailable).
- **`config/Interface.tsx`** — stream endpoint URLs.

## Production regression fix (LIBUSB_ERROR_BUSY)

The initial 1.0.13 deploy broke the live view: every preview returned 500 with `Failed to claim USB interface ... LIBUSB_ERROR_BUSY`. Root cause: the preview endpoint and `get_camera_frame` had been routed onto the broadcaster's no-session path, which opened **and closed** a fresh device claim on every call. The frontend still polls `POST /image-sources/{id}/preview` ~every 500 ms and never starts a session, so each poll opened/closed the USB3 camera; successive cycles overlapped and the device rejected the next claim with `LIBUSB_ERROR_BUSY`.

Fix (commit 2): the preview/capture/inference hot path is restored to the proven **cached, persistent connection** model — `get_camera_frame` reuses a single `Camera` from `camera_objects` (connect once, reuse, per-request start/get/stop, no claim release between calls), and the preview endpoint uses the legacy `get_frame()` helper again. The broadcaster/`/streams` code stays in the tree but off the hot path until the frontend migration is completed.

## Tests

- **21 correctness properties** as Hypothesis property-based tests (≥100 iterations each, mock `CameraBackend` + injected clock, `RuleBasedStateMachine` for the stateful ones, parametrized over both backends): single-claim invariant, session lifecycle, fan-out identity, independent reads, producer cadence, viewer-limit, open-failure, viewer-count/duplicate subscriptions, heartbeat/staleness, stale sweep, disconnection cascade, freshness, no-frame, acquisition-failure retention, inference reuse/failure, settings apply/rollback/override isolation, and capture-config rejection.
- Unit/example tests (backend adapters, stream models), endpoint status-code tests, the `get_camera_frame` regression test (updated to pin the cached-connection contract), and integration/perf tests (first-frame & latency bounds, refresh rate & viewer independence, new-subscriber & applied-setting timing, inference-during-session timing, and end-to-end fake-device tests for both backends).
- The pure-logic streaming suite runs green in a bare checkout (**71 passed, 1 skipped** — the skip is the native-gi e2e test, which runs in the flask-app image). Endpoint/`camera_manager` regression tests run inside the flask-app image.

## Build / deploy notes

- Builds for the arm64 JetPack 5 target (`Dockerfile.jp5`, L4T r35.4.1); in-image curated backend tests pass.
- Because the packaged artifact exceeds the 2 GB Greengrass limit, publishing uses the ECR + S3 path (`gdk-component-build-and-publish.sh`). The fixed build was published and verified on-device as **`aws.edgeml.dda.LocalServer.arm64JP5` v1.0.14**.

## Files changed

48 files: new backend `utils/streaming/` package + `endpoints/streams.py`, `app.py`/`camera_manager.py`/`image_source.py` integration, frontend client/hook/component + `Interface.tsx`, the property/unit/integration test suite, and the spec docs.
