### PR TITLE
Workflow designer bugfixes, custom Python frames, Aravis camera input

### DIFF
--- a/.kiro/specs/aravis-camera-input/.config.kiro
+++ b/.kiro/specs/aravis-camera-input/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "d107061e-32ed-4bda-a91c-f96a823ff1e7", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/aravis-camera-input/design.md
+++ b/.kiro/specs/aravis-camera-input/design.md
@@ -1,0 +1,403 @@
+# Design Document: Aravis Camera Input
+
+## Overview
+
+This feature gives the flow designer a camera input node that speaks the edge application's native camera language. On the edge, camera inputs are Aravis (GenICam) devices: `aravis_functions.getCameras()` enumerates the bus, `utils/camera_manager.py` connects and grabs frames by camera id, and `Camera`-type Image_Sources reference an Aravis camera through their `cameraId` field. The designer's only camera node, `camera_source`, is V4L2-path-shaped, and the camera-registry-sync feature discovers only V4L2 hardware — the Aravis inventory the edge actually manages never reaches the Portal, and the designer cannot express an Aravis-typed input.
+
+The design threads a new `aravis_camera_source` node type through every existing seam the camera-registry-sync feature already built, changing no wire protocols and adding no new transport:
+
+1. **Catalog** — a new `ARAVIS_CAMERA_SOURCE` NodeTypeDescriptor in the shared workflow_core catalog (both mirrored copies), with `camera_id` / `gain` / `exposure` parameters and appsrc-headed mappings on all device architectures (Requirement 1).
+2. **Edge discovery** — an injectable Aravis enumeration layer added to `camera_discovery`, feeding `build_inventory` with `AravisDiscovered` Camera_Sources merged with configured `Camera`-type Image_Sources by camera id, reported through the unchanged `dda-camera-registry` shadow (Requirement 2).
+3. **Designer picker** — the existing Camera_Picker extended to the new node's `camera_id` parameter, offering only Aravis-compatible registry entries and recording the standard `cameraBindingHint` (Requirement 3).
+4. **Packaging + deployment** — the Component_Packager treats the node as a Camera_Input_Node emitting `aravisBinding: true` binding points; `validate_camera_bindings` gains the Aravis type-compatibility rule (Requirements 4, 5).
+5. **Edge resolution + execution** — `resolve_bindings` produces Aravis assignments; the WorkflowExecutor gains a resolution provider (wired to the watcher's existing `binding_resolution` accessor) and an Aravis frame feed that grabs a frame through the Camera_Manager and pushes it into the compiled pipeline's appsrc via `GstPipelineManager.run_pipeline`'s existing `frame_data` mechanism (Requirement 6).
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| New node type vs. discriminator on `camera_source` | A separate `aravis_camera_source` node type | `camera_source` compiles to `v4l2src device={device}` on x86 — a fundamentally different transport with a different identity parameter. A discriminator parameter would fork every mapping, slot, and picker rule inside one descriptor; a second descriptor reuses all generic catalog machinery unchanged and keeps `camera_source` byte-identical (Requirement 7.4) |
+| Aravis node identity parameter | `camera_id` (required string), matching the edge Image_Source's `cameraId` and `camera_manager.connect_camera(camera_id)` | The Aravis camera id (e.g. `Aravis-Fake-GV01`, `Basler-12345678`) is the one identifier every edge camera path already keys on |
+| Device-arch mapping | `appsrc name=appsrc_{nodeId} ! videoconvert` on every physical architecture; sim uses the shared dataset-fed stub | Aravis acquisition happens in the LocalServer process via Camera_Manager (a GStreamer `aravissrc` element is not shipped in the DDA images); the appsrc + Frame_Feed path is exactly how classic `Camera`-type pipelines run today (`GstPipelineManager.run_pipeline(pipeline_str, frame_data)`) |
+| Aravis discovery placement | New `camera_discovery/aravis.py` with an injectable enumerator defaulting to a lazy import of `aravis_functions.getCameras()` | Mirrors the V4L2 module's injectable-ioctl pattern so tests supply fake buses; the lazy import keeps `camera_discovery` importable where the `gi`/Aravis stack is absent (Requirement 2.6, 2.7) |
+| Aravis stable id | `arv-{sha1(vendor + "|" + model + "|" + serial)[:12]}` | Vendor/model/serial are the bus-stable GenICam identity; the Aravis runtime id can embed transport addresses that change across reconnects. Deterministic and collision-resistant per Requirement 2.2 |
+| Merge rule | A configured `Camera`-type Image_Source whose `cameraId` equals a discovered Aravis camera's `id` merges into ONE entry under `cfg-{imageSourceId}` (configured params + discovered identity metadata), exactly like the existing device-path merge for V4L2 | Same shape as the proven `build_inventory` path merge (Requirement 2.4); bindings keep referencing the configured id |
+| Discovered-only type | `AravisDiscovered` | Parallel to the existing `V4L2Discovered` naming; the sync reducer, registry table, and frontend display are type-string generic, so no reducer or storage change is needed (Requirement 7.3) |
+| Binding point marker | `aravisBinding: true`, empty slots, on every device architecture | Parallel to the existing `adapterBinding` (JP4/5) and `csiSensorBinding` (JP6) markers: the binding selects which camera the executor's feed connects, never an element argument |
+| Type compatibility | `aravis_camera_source` ↔ {`Camera`, `AravisDiscovered`}; `AravisDiscovered` also added to `camera_source`'s compatible set | An Aravis node must bind to an Aravis-backed source (Requirement 5.2); conversely a registered GenICam camera is a legitimate camera-backed source for the generic camera node on the adapter-fed architectures (Requirement 5.3) |
+| Executor resolution wiring | `WorkflowExecutor` gains an injectable `binding_resolution_provider(registration_id)` wired to the watcher's existing `binding_resolution()` accessor | The watcher already computes and caches `ResolutionResult` (substituted document + assignments) per registration; the executor currently reloads the raw document from disk and never consumes it. Wiring the provider closes that gap for Aravis assignments (and slot-substituted documents) without new state |
+| Frame feed | Executor pre-grabs one frame per Aravis node via `camera_manager.get_camera_frame(camera_id, config)` and pushes it through `run_pipeline`'s existing `frame_data` appsrc feed | This is byte-for-byte the classic `Camera`-type execution model (`gst_pipeline_executor` → `run_pipeline(pipeline_str, frame_data)`), reusing the cached-connection Camera_Manager path with its existing locking, timeout, and status handling |
+
+## Architecture
+
+### System Context
+
+```mermaid
+graph TB
+    subgraph Portal
+        CAT1[workflow_core catalog - portal layer<br/>+ ARAVIS_CAMERA_SOURCE]
+        NCP[NodeConfigPanel + cameraReference.ts<br/>Aravis camera picker]
+        PKG[workflow_packaging.py<br/>+ aravisBinding points]
+        DEP[deployments.py<br/>+ Aravis type compatibility]
+        REG[(dda-portal-camera-registry<br/>+ AravisDiscovered entries)]
+    end
+    subgraph Edge Device
+        CAT2[workflow_core catalog - vendor mirror<br/>+ ARAVIS_CAMERA_SOURCE]
+        ARV[aravis_functions.getCameras]
+        DISC[camera_discovery<br/>+ aravis.py enumeration]
+        INV[camera_sync build_inventory<br/>+ cameraId merge]
+        ESA[Edge_Sync_Agent<br/>unchanged transport]
+        RES[camera_binding.resolve_bindings<br/>+ aravis assignments]
+        EXE[WorkflowExecutor<br/>+ resolution provider + Aravis frame feed]
+        CM[camera_manager<br/>get_camera_frame]
+    end
+
+    ARV --> DISC --> INV --> ESA
+    ESA -.dda-camera-registry shadow.-> REG
+    REG --> NCP
+    NCP -->|cameraBindingHint| PKG
+    PKG -->|compiled_pipeline.json + bindingPoints| RES
+    DEP -.dda-camera-bindings shadow.-> RES
+    RES --> EXE --> CM
+    CAT1 -.byte-identical mirror.- CAT2
+```
+
+### Aravis node end-to-end flow
+
+```mermaid
+sequenceDiagram
+    participant WB as Workflow_Builder
+    participant PKG as Component_Packager
+    participant DEP as Deployment_Service
+    participant WE as Workflow_Engine (watcher)
+    participant EX as WorkflowExecutor
+    participant CM as Camera_Manager
+
+    WB->>WB: user adds aravis_camera_source,<br/>picker offers Aravis-compatible registry entries (3.2)
+    WB->>WB: selection populates camera_id/gain/exposure,<br/>records cameraBindingHint (3.3)
+    WB->>PKG: package workflow version
+    PKG->>PKG: emit bindingPoints entry per aravis node:<br/>aravisBinding true, empty slots, rendered params (4.1, 4.2)
+    DEP->>DEP: validate bindings: aravis node ↔<br/>{Camera, AravisDiscovered} only (5.2)
+    DEP->>WE: dda-camera-bindings shadow (unchanged, 5.5)
+    WE->>WE: resolve_bindings: cameraSourceId -> local inventory<br/>-> aravis assignment {camera_id, gain, exposure} (6.1)
+    Note over WE: missing id -> registration invalid,<br/>triggers rejected (6.3)
+    EX->>WE: binding_resolution(registration_id)
+    EX->>EX: effective camera id = assignment else rendered params (6.4)
+    EX->>CM: get_camera_frame(camera_id, {gain, exposure})
+    CM-->>EX: {data, height, width}
+    EX->>EX: run_pipeline(launch_string, frame_data) — appsrc push (6.4)
+```
+
+## Components and Interfaces
+
+### 1. Node_Catalog: `ARAVIS_CAMERA_SOURCE` (both catalog copies)
+
+Added to `workflow_core/catalog/nodes.py` in `edge-cv-portal/backend/layers/workflow_core/python/workflow_core/` and mirrored byte-identically to `src/backend/workflow_engine/vendor/workflow_core/`:
+
+```python
+ARAVIS_CAMERA_SOURCE = NodeTypeDescriptor(
+    type_id="aravis_camera_source",
+    category=CATEGORY_INPUT,
+    display_name="Aravis Camera Source",
+    inputs=[],
+    outputs=[PortDescriptor("out", PORT_TYPE_VIDEO_FRAMES)],
+    parameters=[
+        ParameterDescriptor("camera_id", "string", required=True, default=None,
+                            constraints={"min_length": 1},
+                            description="Aravis (GenICam) camera identifier as "
+                                        "enumerated on the edge device, e.g. "
+                                        "Aravis-Fake-GV01 or Basler-12345678.",
+                            examples=["Aravis-Fake-GV01", "Basler-12345678"]),
+        ParameterDescriptor("gain", "int", required=False, default=4,
+                            constraints={"min": 0, "max": 100}, ...),
+        ParameterDescriptor("exposure", "int", required=False, default=5000000,
+                            constraints={"min": 0}, ...),
+    ],
+    mappings=_same_on_device_archs(
+        element_chain=[
+            _element("appsrc", name="appsrc_{nodeId}"),
+            _element("videoconvert"),
+        ],
+        plugin_dependencies=["app", "videoconvertscale"],
+    ) + [_dataset_fed_sim_source()],
+    hardware_dependent=True,
+)
+```
+
+- Appended to `NODE_CATALOG` next to `CAMERA_SOURCE`. Every generic consumer — validator, compiler, serializer, the `/workflows/node-catalog` route, the Node_Palette, `merged_catalog`, the test sandbox — picks the node up from the descriptor with no special-casing (Requirement 1.5).
+- The appsrc element name is compile-time-rendered per node (the compiler resolves `{nodeId}` the same way other templates resolve node parameters) so multi-camera documents stay addressable; the executor's Frame_Feed locates the appsrc by the binding point's node id.
+- The `camera_id` parameter never appears in any `args_template`, so `binding_point_slots` naturally yields no slots — consistent with the `aravisBinding` marker.
+- The sim mapping is the shared `_dataset_fed_sim_source()` stub, exactly like `camera_source`, so designer test runs feed the node from the Test_Dataset (Requirement 1.4).
+- Mirror discipline: the change is made in the portal layer copy and copied verbatim to the vendor mirror; the existing baseline expectation is `diff -r` cleanliness of the two source trees (Requirement 1.6).
+
+### 2. Edge Aravis discovery (`src/backend/camera_discovery/aravis.py`)
+
+```python
+@dataclass(frozen=True)
+class DiscoveredAravisCamera:
+    stable_id: str        # arv-{sha1(vendor|model|serial)[:12]}
+    camera_id: str        # the Aravis runtime id camera_manager connects by
+    model: str
+    address: str
+    physical_id: str
+    protocol: str         # "GigEVision" | "USB3Vision" | "Fake"
+    serial: str
+    vendor: str
+
+@dataclass(frozen=True)
+class AravisDiscoveryResult:
+    cameras: list[DiscoveredAravisCamera]
+    failures: list[dict]   # [{"error": str}] — enumeration-level failures
+
+def enumerate_aravis(enumerator=None) -> AravisDiscoveryResult
+```
+
+- `enumerator` is injectable (tests pass fakes); the default lazily imports `edge_ml1_p_camera_management.aravis_functions` and calls `getCameras()`, mapping each returned `model.Camera` object to a `DiscoveredAravisCamera`. Import failure (no `gi`/Aravis stack) or enumeration failure yields `AravisDiscoveryResult([], [{"error": ...}])` — never an exception (Requirements 2.6, 2.7).
+- `CameraDiscovery` (`discovery.py`) gains the Aravis enumerator alongside the V4L2 layer: each periodic pass runs both, and the tracked-snapshot diff (present/absent, `absent_since`, `on_change` only on change) treats Aravis stable ids identically to V4L2 stable ids — same absence semantics, same cadence, no second timer (Requirements 2.2, 2.5). The `InventorySnapshot` entries carry the camera object; downstream code distinguishes families by the entry type.
+- Stable id derivation is a pure function `aravis_stable_id(vendor, model, serial)`; when serial is empty it falls back to including `physical_id` so two serial-less cameras of the same model do not collide.
+
+### 3. Inventory merge extension (`src/backend/camera_sync/inventory.py`)
+
+`build_inventory` gains the Aravis branch, structurally parallel to the existing device-path merge:
+
+- **Configured merge (2.4)**: an Image_Source of type `Camera` whose `cameraId` equals a tracked Aravis camera's `camera_id` yields ONE entry — id `cfg-{imageSourceId}`, name/type/params from the configured record (params already include `cameraId`, `gain`, `exposure` via the existing `_configured_params`), plus `capabilities.aravis = {model, address, physicalId, protocol, serial, vendor}` from discovery, `discovered: True`, and the tracked absent state. Each tracked Aravis camera contributes to exactly one entry.
+- **Discovered-only (2.1, 2.3)**: an unmerged Aravis camera yields `CameraSourceState(camera_source_id=stable_id, name=f"{vendor} {model}", type="AravisDiscovered", origin="edge-discovered", params={"cameraId": camera_id, "serial": serial, "protocol": protocol, "address": address}, capabilities={"aravis": {...}}, discovered=True, absent=..., absent_since=...)`.
+- The function stays pure and deterministic (sorted output); on inputs containing no Aravis cameras its output is unchanged from today (Requirement 7.2). The Edge_Sync_Agent, shadow document shape, sync reducer, and registry storage need no changes — `AravisDiscovered` flows through as one more type string (Requirement 7.3).
+
+### 4. Workflow_Builder Aravis picker (frontend `cameraReference.ts` + `NodeConfigPanel.tsx`)
+
+Pure extensions in `cameraReference.ts`:
+
+```typescript
+// Control selection: aravis_camera_source's camera_id joins the rule (3.1)
+export function isCameraReferenceParameter(typeId, parameterName): boolean;
+// -> true for ('camera_source','device') and ('aravis_camera_source','camera_id')
+
+// Aravis compatibility filter for the picker's option list (3.2)
+export function isAravisCompatibleCamera(camera: CameraSourceEntry): boolean;
+// type === 'AravisDiscovered', or type === 'Camera' with a non-empty
+// string params.cameraId
+
+// The camera id a Camera_Source resolves to (3.3, 3.5 display)
+export function cameraIdValue(camera: CameraSourceEntry): string | null;
+
+// Selection application for the Aravis node (3.3; mirrors applyCameraSelection)
+export function applyAravisCameraSelection(
+  parameters, camera, sourceDeviceId
+): CameraSelectionResult;
+// populates camera_id from cameraIdValue(camera), copies numeric
+// gain/exposure when present, returns the standard CameraBindingHint
+```
+
+- `NodeConfigPanel` keys the control off the extended `isCameraReferenceParameter`; for `aravis_camera_source` it filters the fetched device cameras through `isAravisCompatibleCamera`, displays name, type, camera id, sync status, and staleness badge per option (3.5), applies selections through `applyAravisCameraSelection`, and retains the manual-entry toggle exactly as the existing control does (3.4). The hint storage (`data.cameraBindingHint`), advisory semantics, and `defaultManualEntry` logic are reused unchanged.
+- `camera_source`'s picker path is untouched (Requirement 7.4).
+
+### 5. Component_Packager extension (`workflow_packaging.py`)
+
+```python
+ARAVIS_CAMERA_SOURCE_TYPE_ID = 'aravis_camera_source'
+```
+
+- `gather_camera_input_nodes` includes nodes of type `aravis_camera_source` (Requirement 4.1); the version item's `camera_input_nodes` records them with `has_binding_points: true` through the existing recording path.
+- `build_binding_points`: an `aravis_camera_source` node's entry carries `'aravisBinding': True` with empty slots on every physical device architecture (the sim document is never packaged), and `parameters` holds the rendered `camera_id` / `gain` / `exposure` defaults-overlaid values (Requirement 4.2). All other node types' entries are produced exactly as before.
+- Workflows without Aravis nodes serialize byte-identically to pre-feature output — guaranteed structurally because the only behavior change is gated on the new type id (Requirement 4.3).
+
+### 6. Deployment_Service extension (`deployments.py`)
+
+```python
+_CAMERA_COMPATIBLE_SOURCE_TYPES = {
+    'camera_source': frozenset({'Camera', 'ICam', 'NvidiaCSI',
+                                'V4L2Discovered', 'AravisDiscovered'}),   # 5.3
+    'aravis_camera_source': frozenset({'Camera', 'AravisDiscovered'}),   # 5.2
+}
+```
+
+- `validate_camera_bindings` needs no other change: unbound-node errors, missing-source errors, degraded-source warnings, override constraint checking (now resolving the `aravis_camera_source` descriptor from the catalog for 5.4), hint pre-selection, and never-synced handling all apply to the new node through the existing generic code paths (Requirement 5.1).
+- The binding-context endpoint and `CameraBindingMatrix` already carry `node_type` per node; the matrix's option list for an `aravis_camera_source` row is filtered through the same Aravis compatibility predicate (shared from `cameraReference.ts`) so users are not offered bindings the validator would reject.
+- Binding delivery over `dda-camera-bindings` is unchanged (Requirement 5.5).
+
+### 7. Workflow_Engine resolution extension (`src/backend/workflow_engine/camera_binding.py`)
+
+- `resolve_bindings` treats `aravisBinding: true` binding points the same way it treats `adapterBinding` points — no slot substitution; a resolved binding contributes an assignment — but records them in a dedicated `aravis_assignments: Dict[str, Dict]` field on `ResolutionResult` (`{node_id: {"cameraSourceId": ..., "params": {...}}}`), keeping JP4/5 camera-adapter assignments and Aravis feed assignments distinct for the executor (Requirements 6.1, 6.2).
+- A `cameraSourceId` binding resolves through the local inventory exactly as today; the resolved params for an Aravis-backed entry carry `cameraId` (from `build_inventory`), which the feed planner maps to the node's `camera_id`. `_PARAM_ALIASES` gains `"cameraId" -> "camera_id"` so overrides and resolved values line up with the descriptor's parameter name.
+- Missing ids follow the existing path: `missing` entry + `missing camera source {csid}` error → watcher marks the registration invalid → triggers rejected → re-resolution on discovery change / shadow delta flips it back (Requirement 6.3). No watcher changes are needed beyond the enlarged `ResolutionResult`.
+
+### 8. WorkflowExecutor Aravis frame feed (`src/backend/workflow_engine/`)
+
+New pure module `src/backend/workflow_engine/aravis_feed.py`:
+
+```python
+@dataclass(frozen=True)
+class AravisFeed:
+    node_id: str
+    camera_id: str
+    config: dict           # {"gain": int, "exposure": int} when present
+
+def plan_aravis_feeds(document: dict,
+                      resolution: Optional[ResolutionResult]) -> list[AravisFeed]
+```
+
+- Pure over its inputs: for each binding point with `aravisBinding: true`, the effective values are the resolution's `aravis_assignments[node_id]["params"]` when present, else the binding point's rendered `parameters` (Requirement 6.4). A feed without a non-empty `camera_id` value is a planning error surfaced as an execution failure attributed to the node.
+- `WorkflowExecutor` changes:
+  - Gains an injectable `binding_resolution_provider: Callable[[str], Optional[ResolutionResult]]`, wired at engine startup to the watcher's existing `binding_resolution()` accessor. When the provider returns a resolution, the executor runs the resolution's substituted document (closing the existing gap where slot-substituted documents were computed but never executed) — otherwise the disk document, as today.
+  - Before starting the pipeline, for each planned `AravisFeed` the executor grabs one frame through `camera_manager.get_camera_frame(feed.camera_id, feed.config)` (lazily imported, exactly like `GstPipelineManager`). The grab happens before `run_pipeline` so a camera failure fails fast with `failing_node_id = feed.node_id` (Requirement 6.5).
+  - The frame is pushed through the existing Frame_Feed: `run_pipeline(launch_string, frame_data)` locates the appsrc, wraps the buffer, pushes, and sends EOS — the classic `Camera`-type execution model. The appsrc caps are set from the grabbed frame's width/height, mirroring the caps handling the classic camera processing pipeline performs.
+  - Documents with no Aravis binding points plan zero feeds and take the exact pre-feature call path (`run_pipeline(launch_string, latency_metrics=...)`, no frame_data) (Requirement 6.6). Initial scope executes one Aravis feed per run (matching the single-appsrc Frame_Feed contract); a document with multiple Aravis nodes fails registration-side validation with a clear reason rather than undefined behavior.
+
+## Data Models
+
+### Catalog descriptor (both workflow_core copies)
+
+New `NodeTypeDescriptor` as specified in Component 1; `NODE_CATALOG` tuple gains one member. No changes to `models.py` shapes, the serializer schema, or the compiler.
+
+### Camera_Source inventory / registry entry (extended values only, no schema change)
+
+| Field | Aravis discovered-only entry | Configured `Camera` merged entry |
+|---|---|---|
+| `camera_source_id` | `arv-{sha1(vendor\|model\|serial)[:12]}` | `cfg-{imageSourceId}` (unchanged) |
+| `type` | `AravisDiscovered` (new value) | `Camera` (unchanged) |
+| `origin` | `edge-discovered` | `edge-configured` |
+| `params` | `{cameraId, serial, protocol, address}` | existing configured params (already include `cameraId`, `gain`, `exposure`) |
+| `capabilities` | `{aravis: {model, address, physicalId, protocol, serial, vendor}}` | existing + `aravis: {...}` |
+| `discovered` / `absent` / `absent_since` | standard tracking | standard tracking |
+
+The `dda-camera-registry` shadow document, `reduce_report`, the DynamoDB registry table, and the camera routes carry these entries with zero changes — types and params are opaque strings/maps to all of them.
+
+### Binding point entry (compiled_pipeline.json)
+
+```jsonc
+{
+  "nodeId": "n2",
+  "nodeType": "aravis_camera_source",
+  "bindingHint": { "cameraSourceId": "arv-3fe9c0d21ab4", ... },   // when present
+  "parameters": { "camera_id": "Aravis-Fake-GV01", "gain": 4, "exposure": 5000000 },
+  "slots": [],
+  "aravisBinding": true
+}
+```
+
+### ResolutionResult (edge)
+
+Gains `aravis_assignments: Dict[str, Dict[str, Any]] = field(default_factory=dict)` — same shape as `adapter_assignments`. Existing consumers are unaffected (dataclass field addition with a default).
+
+### Camera_Binding shadow / deployment record
+
+Unchanged: `{node_id: {"cameraSourceId": id} | {"override": {"camera_id": ..., "gain": ..., "exposure": ...}}}` — the override keys are just the new node's parameter names.
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Aravis node definitions round-trip and compile through generic catalog paths
+
+*For any* valid workflow definition containing `aravis_camera_source` nodes, serializing then parsing the definition SHALL produce an equivalent graph, and validating then compiling it for a device architecture SHALL succeed and render the node's appsrc-headed element chain.
+
+**Validates: Requirements 1.5**
+
+### Property 2: Aravis discovery enumeration completeness with identity capture
+
+*For any* set of enumerated Aravis cameras, every camera SHALL contribute to exactly one inventory entry, and every discovered-only entry SHALL have type `AravisDiscovered`, origin `edge-discovered`, and parameters/capabilities carrying all of the camera's identity fields (id, model, address, physical id, protocol, serial, vendor).
+
+**Validates: Requirements 2.1, 2.3**
+
+### Property 3: Aravis stable id determinism
+
+*For any* Aravis camera identity (vendor, model, serial), the derived stable id SHALL be a pure function of those fields — invariant under bus enumeration order, runtime id changes, and address changes — and distinct identities within an enumeration SHALL derive distinct stable ids.
+
+**Validates: Requirements 2.2**
+
+### Property 4: Configured/discovered Aravis merge by camera id
+
+*For any* combination of configured Image_Sources and discovered Aravis cameras, each `Camera`-type Image_Source whose `cameraId` equals a discovered camera's id SHALL yield exactly one inventory entry under the configured identifier combining configured parameters with discovered identity metadata, and no discovered Aravis camera SHALL contribute to more than one entry.
+
+**Validates: Requirements 2.4**
+
+### Property 5: Aravis absence marking on re-enumeration
+
+*For any* sequence of Aravis enumeration results, a stable id present in an earlier result and missing from a later one SHALL be marked absent with an absence timestamp and SHALL never be dropped from the tracked inventory.
+
+**Validates: Requirements 2.5**
+
+### Property 6: Aravis failure isolation and no-Aravis identity
+
+*For any* configured and V4L2-discovered inventory, building the inventory with a failing or unavailable Aravis enumerator SHALL produce entries identical to the pre-feature output for the same inputs, record the failure, and raise no exception.
+
+**Validates: Requirements 2.6, 7.2**
+
+### Property 7: Aravis picker compatibility filter
+
+*For any* list of Camera_Registry entries, the Aravis picker option list SHALL contain exactly the entries that are Aravis-compatible (type `AravisDiscovered`, or type `Camera` carrying a non-empty camera id parameter) — no incompatible entry offered, no compatible entry omitted.
+
+**Validates: Requirements 3.2**
+
+### Property 8: Aravis selection populates the node and records the hint
+
+*For any* Aravis-compatible Camera_Source and any prior parameter record, applying the selection SHALL set `camera_id` to the source's camera id, copy `gain` and `exposure` exactly when the source's params carry them as numbers, leave all other parameters untouched, and produce a binding hint carrying the source id, display name, and reference device id.
+
+**Validates: Requirements 3.3**
+
+### Property 9: Packaging emits Aravis binding points
+
+*For any* workflow definition containing `aravis_camera_source` nodes, packaging SHALL emit exactly one `bindingPoints` entry per Aravis node per architecture carrying `aravisBinding: true`, empty slots, and the node's rendered `camera_id`/`gain`/`exposure` parameter values, and SHALL record each node in the version item's `camera_input_nodes` with `has_binding_points: true`.
+
+**Validates: Requirements 4.1, 4.2**
+
+### Property 10: Aravis-free packaging identity
+
+*For any* workflow definition containing no `aravis_camera_source` node, the packaged compiled document SHALL be byte-identical to the pre-feature packaging output for the same definition.
+
+**Validates: Requirements 4.3**
+
+### Property 11: Aravis type-compatibility validation
+
+*For any* workflow version with Camera_Input_Nodes, target registry snapshot, and binding set, `validate_camera_bindings` SHALL produce a type-incompatibility error for a binding exactly when the bound Camera_Source's type is outside the node type's declared compatible set — `{Camera, AravisDiscovered}` for `aravis_camera_source`, the existing set plus `AravisDiscovered` for `camera_source`.
+
+**Validates: Requirements 5.2, 5.3**
+
+### Property 12: Aravis override constraint validation
+
+*For any* manual override submitted for an `aravis_camera_source` node, validation SHALL accept the override exactly when every value satisfies the descriptor's declared constraints (non-empty string `camera_id`, `gain` within 0–100, `exposure` non-negative, no undeclared parameter names).
+
+**Validates: Requirements 5.4**
+
+### Property 13: Device-side Aravis binding resolution
+
+*For any* compiled document with Aravis binding points, binding map, and local inventory: a `cameraSourceId` binding matching an inventory entry SHALL yield an Aravis assignment whose `camera_id` is the entry's camera id and SHALL leave the document's segments unchanged; a constraint-valid override binding SHALL yield an assignment from the override values; a `cameraSourceId` with no inventory entry SHALL mark the resolution invalid recording the missing id; and a constraint-violating override SHALL mark the resolution invalid with a reason.
+
+**Validates: Requirements 6.1, 6.2, 6.3**
+
+### Property 14: Aravis feed plan precedence
+
+*For any* compiled document with Aravis binding points and any optional resolution result, the planned feed for each node SHALL use the resolution's Aravis assignment values when present and the binding point's rendered parameters otherwise.
+
+**Validates: Requirements 6.4**
+
+### Property 15: Aravis-free execution identity
+
+*For any* compiled document containing no Aravis binding point (including legacy documents without `bindingPoints`), the feed planner SHALL plan zero feeds and the executor SHALL invoke the pipeline run without a frame feed, exactly as before this feature.
+
+**Validates: Requirements 6.6**
+
+## Error Handling
+
+| Failure | Handling |
+|---|---|
+| Aravis runtime (`gi`/Aravis) unavailable or `getCameras()` raises | `enumerate_aravis` returns an empty result with a failure record; `build_inventory` output equals the pre-feature output; discovery loop and Edge_Sync_Agent continue untouched (Requirements 2.6, 7.2) |
+| Individual Aravis camera with missing/empty identity fields | Stable id derivation falls back to including `physical_id`; entries with no usable identity are recorded in the discovery failures list and skipped, never crashing the pass |
+| Registry read fails while the picker is open | Existing Camera_Picker error handling unchanged: the control surfaces the fetch error and the manual-entry path remains usable (Requirement 3.4) |
+| Binding submitted against a non-Aravis source type | `validate_camera_bindings` rejects with the existing `CAMERA_TYPE_INCOMPATIBLE` error naming the node, device, and source type (Requirement 5.2) |
+| Aravis `cameraSourceId` missing from device inventory at resolution time | Resolution invalid with `missing camera source {csid}`; registration invalid, triggers rejected; re-resolution on discovery change / bindings delta flips it back (Requirement 6.3) |
+| Multiple Aravis binding points in one document | Registration-side validation marks the registration invalid with a clear reason (single Frame_Feed contract) rather than undefined multi-appsrc behavior |
+| `get_camera_frame` raises or returns no frame during a run | Execution marked failed with `failing_node_id` set to the Aravis node and the camera error message; nothing propagates (existing contained-failure discipline, Requirement 6.5) |
+| Binding resolution provider unavailable/raises at execution time | Executor falls back to the disk document and rendered binding-point parameters (the unbound behavior), logged — a provider failure never takes a run down for documents that don't need it |
+
+## Testing Strategy
+
+**Dual approach**: property-based tests for the pure cores (catalog round trip, discovery/merge, id derivation, picker filter/application, packaging binding points, binding validation, resolution, feed planning) and example-based unit/component tests for static catalog content, UI wiring, and failure paths. Integration behavior (shadow transport, GStreamer, real Aravis hardware) is exercised through the existing injectable fakes; no test requires a physical camera.
+
+- **Python property tests** use `hypothesis` with no hardcoded `max_examples` (project default ≥100 iterations), tagged `**Feature: aravis-camera-input, Property {number}: {property_text}**`:
+  - Portal backend: `edge-cv-portal/backend/tests/test_property_*.py` against the moto-backed conftest stack (Properties 1, 9, 10, 11, 12).
+  - Edge LocalServer: `test/backend-test/camera_discovery`, `test/backend-test/camera_sync`, and `test/backend-test/workflow_engine` run with `PYTHONPATH=src/backend:test/backend-test` (Properties 2–6, 13, 14, 15).
+- **TypeScript property tests** use `fast-check` (`numRuns: 100`) beside the existing picker property test in `edge-cv-portal/frontend/src/pages/workflows/` (Properties 7, 8).
+- **Unit/component tests**: catalog content assertions mirroring `test_catalog_content.py` (1.1–1.4), catalog mirror diff check (1.6), injectable-enumerator construction (2.7), NodeConfigPanel control rendering / manual entry / display fields (3.1, 3.4, 3.5), binding matrix option filtering and hint pre-selection for Aravis rows (5.1), binding delivery with an Aravis node (5.5), executor grab/push with fake camera manager and fake pipeline manager including the failure path (6.4, 6.5), reducer ingestion of `AravisDiscovered` reports (7.3), and `camera_source` descriptor unchanged (7.4).
+- **Baselines that must stay green**: portal backend pytest suite, frontend vitest + `npm run build`, and the edge `test/backend-test` workflow_engine / camera_discovery / camera_sync suites that pass on this host — pre-feature behavior identity (Requirement 7.1) is enforced by Properties 6, 10, 15 plus these unchanged baselines.

--- a/.kiro/specs/aravis-camera-input/requirements.md
+++ b/.kiro/specs/aravis-camera-input/requirements.md
@@ -1,0 +1,119 @@
+# Requirements Document
+
+## Introduction
+
+The DDA edge application's primary camera input sources are Aravis (GenICam / GigE Vision / USB3 Vision) cameras: the LocalServer enumerates the Aravis bus through `edge_ml1_p_camera_management/aravis_functions.py` (each camera carrying an id, model, address, physical id, protocol, serial, and vendor), acquires frames through the camera manager (`utils/camera_manager.py`), and stores camera-backed Image_Sources of type `Camera` whose `cameraId` references an Aravis device. The Edge CV Portal's flow designer, however, has no node that speaks this language. Its only camera input node, `camera_source`, is shaped around a V4L2 device path (`device=/dev/video0`), and the camera-registry-sync feature that synchronizes edge camera inventory to the Portal discovers only V4L2 hardware — the Aravis bus inventory that the edge app and camera manager actually work with never reaches the Portal's Camera_Registry, and a designer user cannot express "this workflow's input is that GenICam camera".
+
+This feature adds an Aravis camera input sub-type to the flow designer that stays in sync with the edge. It introduces an `aravis_camera_source` node type in the shared workflow_core catalog whose parameters mirror the edge's Aravis camera identity (camera id, plus gain/exposure acquisition settings), extends the edge's camera discovery and sync agent to report Aravis bus cameras (merged with configured `Camera`-type Image_Sources by camera id) into the existing Camera_Registry, and wires the node through the whole existing binding pipeline: the Workflow_Builder camera picker offers the synced Aravis inventory for the node's camera id parameter, the Component_Packager emits Aravis-typed binding points, deploy-time validation enforces Aravis type compatibility, and the LocalServer resolves bindings to a local Aravis camera and executes the node by feeding frames grabbed through the existing camera manager into the compiled pipeline's appsrc. The workflow_core catalog exists in two mirrored copies (the portal layer and the edge vendor mirror), and both must stay identical.
+
+## Glossary
+
+- **Portal**: The edge-cv-portal cloud web application (React frontend, Lambda backend, DynamoDB storage) used to manage DDA use cases, models, workflows, deployments, and devices.
+- **LocalServer**: The Greengrass component running on an Edge_Device. It owns the device-local Image_Source configuration, the Aravis camera stack, and executes GStreamer pipelines and deployed Workflow_Components.
+- **Edge_Device**: A Greengrass core device registered in the Portal's devices table that runs LocalServer.
+- **Aravis_Camera**: A GenICam-protocol camera (GigE Vision, USB3 Vision, or the Aravis Fake interface) visible to LocalServer through the Aravis library, identified by the identity fields the Aravis bus enumeration reports: id, model, address, physical id, protocol, serial number, and vendor.
+- **Aravis_Enumeration**: The existing LocalServer capability (`aravis_functions.getCameras()` / `rescan_cameras()`) that lists the Aravis_Cameras currently visible on the device's GenICam bus.
+- **Camera_Manager**: The existing LocalServer subsystem (`utils/camera_manager.py`) that connects, configures (gain, exposure, GenICam features), and grabs frames from Aravis_Cameras by camera id.
+- **Image_Source**: The device-local input-source record managed by LocalServer's image_source DAO and accessors. An Image_Source of type `Camera` is Aravis-backed: its `cameraId` field references an Aravis_Camera and Camera_Manager acquires its frames.
+- **Camera_Registry**: The existing Portal-side store and API (`dda-portal-camera-registry` table, `camera_registry.py` Lambda) holding, per Edge_Device, the Camera_Sources known for that device, introduced by the camera-registry-sync feature.
+- **Camera_Source**: A per-device entry in the Camera_Registry (and in the edge-reported inventory) carrying a stable identifier, name, type, parameters, capability metadata, origin, version, and sync metadata.
+- **Camera_Discovery**: The existing LocalServer subsystem (`src/backend/camera_discovery/`) that enumerates physical capture hardware for the inventory. Today it enumerates V4L2 devices only.
+- **Edge_Sync_Agent**: The existing LocalServer component (`src/backend/camera_sync/`) that merges configured Image_Sources with Camera_Discovery results (`build_inventory`) and reports the inventory to the Portal over the `dda-camera-registry` named IoT shadow.
+- **Aravis_Camera_Source**: A Camera_Source entry representing an Aravis_Camera: either a discovered-only bus camera (type `AravisDiscovered`, origin edge-discovered) or a configured `Camera`-type Image_Source merged with its discovered bus identity.
+- **Node_Catalog**: The shared workflow_core node type catalog (`workflow_core/catalog/nodes.py`), maintained as two mirrored copies: the Portal layer (`edge-cv-portal/backend/layers/workflow_core/python/workflow_core/`) and the edge vendor mirror (`src/backend/workflow_engine/vendor/workflow_core/`).
+- **Aravis_Camera_Source_Node**: The new input node type (`aravis_camera_source`) added to the Node_Catalog by this feature, whose parameters carry an Aravis camera id and acquisition settings and whose output port emits VideoFrames.
+- **Workflow_Builder**: The graphical canvas UI within the Portal where users compose workflow definitions from Node_Catalog nodes.
+- **Camera_Picker**: The existing Workflow_Builder camera reference control (`cameraReference.ts` + NodeConfigPanel) that offers a device's Camera_Registry entries for a Camera_Input_Node parameter and records a `cameraBindingHint` on the node.
+- **Component_Packager**: The existing Portal packaging Lambda (`workflow_packaging.py`) that compiles workflow definitions into per-architecture `compiled_pipeline.json` documents and emits `bindingPoints` entries for Camera_Input_Nodes.
+- **Camera_Input_Node**: A workflow node whose frames come from a device camera; today the `camera_source` node type and camera-backed custom node types, extended by this feature to include the Aravis_Camera_Source_Node.
+- **Camera_Binding**: The existing per-deployment, per-device mapping from a Camera_Input_Node to a Camera_Source identifier or manual override, validated by `validate_camera_bindings` in `deployments.py` and delivered over the `dda-camera-bindings` shadow.
+- **Workflow_Engine**: The LocalServer subsystem (`src/backend/workflow_engine/`) that discovers deployed Workflow_Components, resolves Camera_Bindings (`camera_binding.resolve_bindings`), and executes triggered workflow runs (`pipeline_executor.WorkflowExecutor`).
+- **Workflow_Executor**: The Workflow_Engine component that runs a registered workflow's compiled pipeline through a GstPipelineManager instance.
+- **Frame_Feed**: The existing single-frame appsrc feed mechanism of `GstPipelineManager.run_pipeline` (its `frame_data` argument), used today by classic Camera-type pipelines to push a Camera_Manager frame into an appsrc-headed pipeline.
+
+## Requirements
+
+### Requirement 1: Aravis Camera Source Node Type in the Catalog
+
+**User Story:** As a computer vision engineer building a workflow, I want a dedicated Aravis camera input node in the flow designer, so that I can declare a GenICam camera input with the same identity the edge application uses instead of faking it with a V4L2 device path.
+
+#### Acceptance Criteria
+
+1. THE Node_Catalog SHALL include an Aravis_Camera_Source_Node with type id `aravis_camera_source`, category input, display name "Aravis Camera Source", no input ports, and exactly one output port of type VideoFrames.
+2. THE Aravis_Camera_Source_Node SHALL declare a required string parameter `camera_id` with a minimum length of 1, carrying the Aravis camera identifier the Camera_Manager connects by, with a description and at least one working example.
+3. THE Aravis_Camera_Source_Node SHALL declare optional parameters `gain` (int, constraints min 0 and max 100, default 4) and `exposure` (int, constraint min 0, default 5000000) matching the acquisition settings the Camera_Manager applies, each with a description and at least one working example.
+4. THE Aravis_Camera_Source_Node SHALL be marked hardware dependent, and its architecture mappings SHALL render an appsrc-headed element chain (appsrc followed by videoconvert, with the app and videoconvertscale plugin dependencies) on every physical device architecture, and the shared dataset-fed simulation stub on the sim architecture.
+5. WHEN a workflow definition containing an Aravis_Camera_Source_Node is validated, compiled, or serialized through workflow_core, THE Node_Catalog SHALL process the node through the same generic descriptor-driven paths as existing catalog nodes, with parsing then serializing a definition containing the node producing an equivalent definition.
+6. THE Node_Catalog SHALL carry the Aravis_Camera_Source_Node identically in both copies (the Portal layer and the edge vendor mirror), with the two catalog source trees remaining byte-identical.
+
+### Requirement 2: Edge Aravis Camera Discovery in the Inventory
+
+**User Story:** As an operator, I want the edge device's Aravis bus cameras to appear in the Portal's camera registry, so that the Portal inventory reflects the GenICam cameras the edge application actually manages.
+
+#### Acceptance Criteria
+
+1. WHEN the Edge_Sync_Agent builds the device inventory, THE Camera_Discovery SHALL include the Aravis_Cameras reported by Aravis_Enumeration, each as a Camera_Source with type `AravisDiscovered` and origin edge-discovered.
+2. THE Camera_Discovery SHALL derive each discovered Aravis_Camera's stable Camera_Source identifier deterministically from bus-stable identity fields (vendor, model, and serial number), remaining stable across device reboots and bus re-enumerations.
+3. WHEN Camera_Discovery records a discovered Aravis_Camera, THE Camera_Discovery SHALL capture the Aravis identity fields (id, model, address, physical id, protocol, serial number, vendor) as the Camera_Source's parameters and capability metadata.
+4. WHEN a configured Image_Source of type `Camera` carries a `cameraId` equal to a discovered Aravis_Camera's id, THE Edge_Sync_Agent SHALL report the configured Image_Source and the discovered Aravis_Camera as one Camera_Source under the configured identifier, combining the configured parameters with the discovered identity metadata.
+5. WHEN a re-enumeration detects that a previously discovered Aravis_Camera is no longer present on the bus, THE Camera_Discovery SHALL mark the corresponding Camera_Source as absent rather than deleting the record.
+6. IF Aravis_Enumeration fails or the Aravis runtime is unavailable, THEN THE Camera_Discovery SHALL record the failure, report the remaining (V4L2 and configured) inventory unchanged, and continue operation.
+7. THE Camera_Discovery SHALL enumerate the Aravis bus through an injectable enumeration layer, leaving the existing V4L2 enumeration, absence tracking, and reporting cadence unchanged for V4L2 Camera_Sources.
+
+### Requirement 3: Aravis Camera Picker in the Workflow Builder
+
+**User Story:** As a computer vision engineer, I want to pick an Aravis camera from a device's synced registry when configuring the Aravis camera input node, so that the node's camera identity matches a camera that actually exists on the edge.
+
+#### Acceptance Criteria
+
+1. WHEN a user configures an Aravis_Camera_Source_Node's `camera_id` parameter in the Workflow_Builder, THE Camera_Picker SHALL render the camera reference control for that parameter.
+2. WHEN the Camera_Picker presents Camera_Sources for an Aravis_Camera_Source_Node, THE Camera_Picker SHALL offer only Aravis-compatible Camera_Sources (type `AravisDiscovered`, or type `Camera` entries carrying a camera id parameter) from the selected reference device's Camera_Registry entries.
+3. WHEN a user selects an Aravis_Camera_Source for an Aravis_Camera_Source_Node, THE Camera_Picker SHALL populate the node's `camera_id` parameter from the Camera_Source's camera id parameter, populate `gain` and `exposure` when the Camera_Source's parameters carry them, and record the selection as a `cameraBindingHint` on the node's advisory data.
+4. WHERE a user prefers manual entry, THE Camera_Picker SHALL continue to accept a directly typed camera id value for the Aravis_Camera_Source_Node.
+5. WHEN the Camera_Picker presents Aravis_Camera_Sources, THE Camera_Picker SHALL display each entry's name, type, camera id, sync status, and staleness indication.
+
+### Requirement 4: Packaging Aravis Binding Points
+
+**User Story:** As an operator, I want workflows containing the Aravis camera node to package with binding points, so that deploy-time camera binding works for Aravis inputs the same way it works for existing camera inputs.
+
+#### Acceptance Criteria
+
+1. WHEN the Component_Packager packages a workflow containing an Aravis_Camera_Source_Node, THE Component_Packager SHALL treat the node as a Camera_Input_Node: it SHALL emit a `bindingPoints` entry for the node in every architecture's compiled document and record the node in the version item's `camera_input_nodes` with `has_binding_points: true`.
+2. THE Component_Packager SHALL mark each Aravis_Camera_Source_Node binding point as adapter-fed on every physical device architecture (carrying `aravisBinding: true` with empty slots), with the binding point's parameters carrying the node's rendered `camera_id`, `gain`, and `exposure` values.
+3. WHEN the Component_Packager packages a workflow containing no Aravis_Camera_Source_Node, THE Component_Packager SHALL produce output byte-identical to its pre-feature output for that workflow.
+
+### Requirement 5: Deploy-Time Binding for Aravis Nodes
+
+**User Story:** As an operator deploying a workflow with an Aravis camera input, I want to bind the node to an Aravis camera registered on each target device with type mismatches rejected, so that the deployed workflow references a GenICam camera the device actually has.
+
+#### Acceptance Criteria
+
+1. WHEN a deployment of a workflow containing an Aravis_Camera_Source_Node is created, THE Portal SHALL present the target device's Aravis-compatible Camera_Sources as binding options for that node in the existing binding matrix, pre-selecting an entry matching the node's `cameraBindingHint` when present.
+2. WHEN a Camera_Binding for an Aravis_Camera_Source_Node references a Camera_Source whose type is neither `AravisDiscovered` nor `Camera`, THE Portal SHALL reject the binding with a message identifying the type mismatch.
+3. WHEN a Camera_Binding for a `camera_source` node references a Camera_Source of type `AravisDiscovered`, THE Portal SHALL accept the binding under the existing camera-type compatibility rule for camera-backed sources.
+4. WHERE a user chooses manual override for an Aravis_Camera_Source_Node, THE Portal SHALL validate the override values against the Aravis_Camera_Source_Node's declared parameter constraints and record the override as the Camera_Binding.
+5. WHEN a deployment containing Aravis_Camera_Source_Node bindings is submitted successfully, THE Portal SHALL deliver the bindings to target devices through the existing `dda-camera-bindings` shadow mechanism, leaving the packaged artifact unchanged.
+
+### Requirement 6: Device-Side Resolution and Execution
+
+**User Story:** As an operator, I want the edge device to resolve an Aravis node's binding to a local Aravis camera and execute the workflow by grabbing frames from that camera, so that the deployed workflow runs against the bound GenICam camera and fails visibly when the camera is missing.
+
+#### Acceptance Criteria
+
+1. WHEN the Workflow_Engine resolves Camera_Bindings for a document containing an Aravis binding point, THE Workflow_Engine SHALL resolve a `cameraSourceId` binding against the device-local inventory and produce an Aravis assignment (node id mapped to the resolved camera id and acquisition parameters) instead of substituting element arguments.
+2. WHEN an Aravis binding point carries a manual override, THE Workflow_Engine SHALL produce the Aravis assignment from the override values after constraint-checking them against the vendored catalog descriptor.
+3. IF an Aravis binding's `cameraSourceId` has no matching entry in the device-local inventory at resolution time, THEN THE Workflow_Engine SHALL mark the registration invalid with a reason identifying the missing Camera_Source, and the existing invalid-registration path SHALL reject trigger requests until re-resolution succeeds.
+4. WHEN the Workflow_Executor runs a registered workflow whose document contains an Aravis binding point, THE Workflow_Executor SHALL determine the effective camera id and acquisition parameters (the resolved Aravis assignment when bindings were applied, otherwise the binding point's rendered parameters), grab a frame through the Camera_Manager for that camera id, and push the frame into the compiled pipeline's appsrc through the Frame_Feed.
+5. IF the Camera_Manager frame grab fails for an Aravis_Camera_Source_Node during a workflow run, THEN THE Workflow_Executor SHALL mark the execution failed with the failing node id set to the Aravis_Camera_Source_Node and an error describing the camera failure.
+6. WHEN the Workflow_Executor runs a workflow containing no Aravis binding point, THE Workflow_Executor SHALL execute it exactly as before this feature.
+
+### Requirement 7: Backward Compatibility
+
+**User Story:** As an operator, I want existing workflows, registry entries, and deployments to keep working exactly as they do today, so that adding the Aravis node type does not disrupt anything in production.
+
+#### Acceptance Criteria
+
+1. WHEN a workflow definition, compiled document, or deployment created before this feature is processed by the Portal or the LocalServer, THE Portal and LocalServer SHALL validate, compile, package, register, bind, and execute it with behavior identical to before this feature.
+2. WHEN the Edge_Sync_Agent reports an inventory on a device with no Aravis_Cameras and no Aravis runtime, THE Edge_Sync_Agent SHALL produce a report identical in shape and content to its pre-feature report for the same configured and V4L2-discovered sources.
+3. THE Camera_Registry SHALL accept and store `AravisDiscovered` Camera_Sources through the existing sync reducer without changes to the handling of existing Camera_Source types.
+4. THE existing `camera_source` node type SHALL keep its current parameters, mappings, compatibility rules, and Camera_Picker behavior unchanged.

--- a/.kiro/specs/aravis-camera-input/tasks.md
+++ b/.kiro/specs/aravis-camera-input/tasks.md
@@ -1,0 +1,214 @@
+# Implementation Plan: Aravis Camera Input
+
+## Overview
+
+Implementation follows the data flow the design threads through the existing camera-registry-sync seams: the catalog descriptor first (both mirrored workflow_core copies — everything downstream consumes it), then the edge Aravis discovery and inventory merge (pure cores with injectable enumeration), then the Portal surfaces (picker, packaging, deployment validation), and finally the edge resolution and executor frame feed. Property tests sit directly beside the code they validate.
+
+Test baselines that must stay green throughout: portal backend pytest under `edge-cv-portal/backend/tests` (moto-backed conftest stack), frontend vitest + `npm run build` under `edge-cv-portal/frontend`, and the edge LocalServer suites that pass on this host, run with `PYTHONPATH=src/backend:test/backend-test` scoped to `test/backend-test/workflow_engine test/backend-test/camera_discovery test/backend-test/camera_sync`. Python property tests use `hypothesis` (no hardcoded `max_examples`; the project default provides ≥100 iterations) as `test_property_*.py`; TypeScript property tests use `fast-check` with `numRuns: 100`. Each property test is tagged `**Feature: aravis-camera-input, Property {number}: {property_text}**`.
+
+## Task Dependency Graph
+
+```mermaid
+graph TD
+    T1[1. Catalog: ARAVIS_CAMERA_SOURCE in both copies] --> T2[2. Checkpoint]
+    T2 --> T3[3. Edge Aravis discovery]
+    T2 --> T6[6. Workflow_Builder Aravis picker]
+    T2 --> T7[7. Component_Packager binding points]
+    T3 --> T4[4. Inventory merge + sync compatibility]
+    T4 --> T5[5. Checkpoint - edge inventory]
+    T7 --> T8[8. Deployment validation + binding matrix]
+    T6 --> T9[9. Checkpoint - portal]
+    T8 --> T9
+    T5 --> T10[10. Edge resolution + executor frame feed]
+    T9 --> T10
+    T10 --> T11[11. Final checkpoint]
+```
+
+```json
+{
+  "waves": [
+    { "wave": 1, "tasks": ["1"], "description": "Catalog descriptor in the portal workflow_core layer, mirrored byte-identically to the edge vendor copy, with content tests and the definition round-trip/compile property" },
+    { "wave": 2, "tasks": ["2"], "description": "Checkpoint: catalog tests pass in both trees" },
+    { "wave": 3, "tasks": ["3", "6", "7"], "description": "Independent consumers of the descriptor: edge Aravis enumeration, the frontend picker, and packaging binding points (can proceed in parallel)" },
+    { "wave": 4, "tasks": ["4", "8"], "description": "Inventory merge on the edge; deployment type-compatibility validation and binding matrix on the portal" },
+    { "wave": 5, "tasks": ["5", "9"], "description": "Checkpoints: edge inventory suites and portal suites pass" },
+    { "wave": 6, "tasks": ["10"], "description": "Edge binding resolution (aravis assignments), feed planning, and the WorkflowExecutor frame feed wiring" },
+    { "wave": 7, "tasks": ["11"], "description": "Final checkpoint: all baselines pass" }
+  ]
+}
+```
+
+## Tasks
+
+- [ ] 1. Add the `aravis_camera_source` node type to the Node_Catalog
+  - [ ] 1.1 Add the `ARAVIS_CAMERA_SOURCE` descriptor to the portal workflow_core catalog
+    - In `edge-cv-portal/backend/layers/workflow_core/python/workflow_core/catalog/nodes.py`: type id `aravis_camera_source`, category input, display name "Aravis Camera Source", no inputs, one `out` port of type VideoFrames; parameters `camera_id` (string, required, `min_length: 1`, description, examples), `gain` (int, optional, default 4, min 0 max 100), `exposure` (int, optional, default 5000000, min 0), each with description and examples; `hardware_dependent=True`; device-arch mappings `appsrc name=appsrc_{nodeId} ! videoconvert` with plugin dependencies `app`, `videoconvertscale`; sim mapping `_dataset_fed_sim_source()`; appended to `NODE_CATALOG`
+    - Ensure the compiler resolves the `{nodeId}` token in the appsrc name (reuse or extend the existing template resolution so multi-node documents render unique appsrc names)
+    - _Requirements: 1.1, 1.2, 1.3, 1.4_
+
+  - [ ] 1.2 Mirror the catalog change to the edge vendor copy
+    - Copy the modified catalog source verbatim to `src/backend/workflow_engine/vendor/workflow_core/` so the two source trees stay byte-identical (`diff -r` clean, ignoring `__pycache__`)
+    - _Requirements: 1.6_
+
+  - [ ]* 1.3 Write catalog content unit tests
+    - Extend `edge-cv-portal/backend/layers/workflow_core/tests/test_catalog_content.py` conventions: descriptor identity (type id, category, display name, ports), parameter declarations and constraints, hardware_dependent flag, per-arch appsrc element chains and plugin dependencies, sim mapping equal to `camera_source`'s sim stub, `EXPECTED_TYPE_IDS` updated; assert `camera_source`'s descriptor is unchanged; add a mirror-equality check diffing the two catalog files
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.6, 7.4_
+
+  - [ ]* 1.4 Write property test for Aravis node definition round trip and compilation
+    - **Feature: aravis-camera-input, Property 1: Aravis node definitions round-trip and compile through generic catalog paths**
+    - **Validates: Requirements 1.5**
+    - hypothesis over generated definitions containing `aravis_camera_source` nodes (extend `tests/generators.py` video-input types): serialize → parse equivalence; validate + compile succeed per device arch with the node's appsrc chain rendered
+
+- [ ] 2. Checkpoint - catalog complete in both trees
+  - Ensure the workflow_core test suite and the edge-scoped suites pass, ask the user if questions arise.
+
+- [ ] 3. Implement edge Aravis discovery (`src/backend/camera_discovery/aravis.py`)
+  - [ ] 3.1 Implement the injectable Aravis enumeration module
+    - Frozen `DiscoveredAravisCamera` dataclass (stable_id, camera_id, model, address, physical_id, protocol, serial, vendor) and `AravisDiscoveryResult` (cameras, failures); `enumerate_aravis(enumerator=None)` defaulting to a lazy import of `aravis_functions.getCameras()`, mapping each returned Camera object; import or enumeration failure yields an empty result with a failure record, never an exception
+    - Pure `aravis_stable_id(vendor, model, serial, physical_id)` deriving `arv-{sha1(vendor|model|serial)[:12]}` with the empty-serial fallback including `physical_id`
+    - _Requirements: 2.1, 2.3, 2.6, 2.7_
+
+  - [ ]* 3.2 Write property test for stable id determinism
+    - **Feature: aravis-camera-input, Property 3: Aravis stable id determinism**
+    - **Validates: Requirements 2.2**
+    - hypothesis over identity tuples in `test/backend-test/camera_discovery`: pure-function invariance under bus order / runtime-id / address changes; distinctness within generated enumerations
+
+  - [ ] 3.3 Wire Aravis enumeration into the CameraDiscovery loop and snapshot
+    - `CameraDiscovery` accepts an injectable Aravis enumerator alongside the V4L2 layer; each periodic pass runs both; the tracked-snapshot diff treats Aravis stable ids identically to V4L2 ids (present/absent, `absent_since`, `on_change` only on change); no second timer; V4L2 behavior unchanged
+    - _Requirements: 2.1, 2.5, 2.7_
+
+  - [ ]* 3.4 Write property test for Aravis absence marking
+    - **Feature: aravis-camera-input, Property 5: Aravis absence marking on re-enumeration**
+    - **Validates: Requirements 2.5**
+    - hypothesis over sequences of fake Aravis enumeration results driven through the discovery diff
+
+  - [ ]* 3.5 Write property test for enumeration completeness with identity capture
+    - **Feature: aravis-camera-input, Property 2: Aravis discovery enumeration completeness with identity capture**
+    - **Validates: Requirements 2.1, 2.3**
+    - hypothesis over generated fake Aravis buses (unicode names, duplicate models, empty serials); every camera contributes exactly one entry with type `AravisDiscovered`, origin `edge-discovered`, and all identity fields captured
+
+- [ ] 4. Extend the inventory merge (`src/backend/camera_sync/inventory.py`)
+  - [ ] 4.1 Implement the Aravis branch of build_inventory
+    - Configured `Camera`-type Image_Source with `cameraId` equal to a tracked Aravis camera's id merges into ONE entry under `cfg-{imageSourceId}` (configured params + `capabilities.aravis` identity metadata, `discovered: True`, tracked absent state); unmerged Aravis cameras yield `AravisDiscovered` / `edge-discovered` entries with params `{cameraId, serial, protocol, address}` and `capabilities.aravis`; each tracked camera contributes to exactly one entry; output stays sorted and deterministic; inputs with no Aravis cameras produce output identical to today
+    - _Requirements: 2.1, 2.3, 2.4, 7.2_
+
+  - [ ]* 4.2 Write property test for the configured/discovered Aravis merge
+    - **Feature: aravis-camera-input, Property 4: Configured/discovered Aravis merge by camera id**
+    - **Validates: Requirements 2.4**
+    - hypothesis in `test/backend-test/camera_sync` over configured sources and discovered cameras with random cameraId overlap
+
+  - [ ]* 4.3 Write property test for Aravis failure isolation and no-Aravis identity
+    - **Feature: aravis-camera-input, Property 6: Aravis failure isolation and no-Aravis identity**
+    - **Validates: Requirements 2.6, 7.2**
+    - hypothesis over configured + V4L2 inventories with a raising/unavailable Aravis enumerator; output equals the pre-feature output for the same inputs, a failure record is present, nothing raises
+
+  - [ ]* 4.4 Write unit test for registry ingestion of AravisDiscovered reports
+    - Ingest a report containing `AravisDiscovered` entries through the portal `reduce_report`/handler path (moto conftest stack); entries stored verbatim with existing types unaffected
+    - _Requirements: 7.3_
+
+- [ ] 5. Checkpoint - edge inventory complete
+  - Ensure the edge-scoped suites pass (`PYTHONPATH=src/backend:test/backend-test`, camera_discovery + camera_sync + workflow_engine), ask the user if questions arise.
+
+- [ ] 6. Implement the Workflow_Builder Aravis picker (frontend)
+  - [ ] 6.1 Extend cameraReference.ts with the pure Aravis helpers
+    - `isCameraReferenceParameter` returns true for (`aravis_camera_source`, `camera_id`); new `isAravisCompatibleCamera` (type `AravisDiscovered`, or type `Camera` with non-empty string `params.cameraId`), `cameraIdValue`, and `applyAravisCameraSelection` (populates `camera_id`, copies numeric gain/exposure, returns the standard `CameraBindingHint`, leaves other parameters untouched)
+    - _Requirements: 3.1, 3.2, 3.3_
+
+  - [ ] 6.2 Wire the Aravis control into NodeConfigPanel
+    - The `aravis_camera_source` node's `camera_id` renders the camera reference control; option list filtered through `isAravisCompatibleCamera`; options display name, type, camera id, sync status, and staleness badge; selection applied through `applyAravisCameraSelection` storing `data.cameraBindingHint`; manual-entry toggle retained; `camera_source`'s control path untouched
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 7.4_
+
+  - [ ]* 6.3 Write property test for the Aravis compatibility filter
+    - **Feature: aravis-camera-input, Property 7: Aravis picker compatibility filter**
+    - **Validates: Requirements 3.2**
+    - fast-check (`numRuns: 100`) over generated `CameraSourceEntry` lists: filter soundness and completeness
+
+  - [ ]* 6.4 Write property test for Aravis selection application
+    - **Feature: aravis-camera-input, Property 8: Aravis selection populates the node and records the hint**
+    - **Validates: Requirements 3.3**
+    - fast-check over Aravis-compatible entries and prior parameter records through `applyAravisCameraSelection`
+
+  - [ ]* 6.5 Write component tests for the Aravis picker
+    - Control renders for the Aravis node's `camera_id` (and not for unrelated parameters); manual entry toggle accepts a typed camera id; option display fields including stale/pending badges
+    - _Requirements: 3.1, 3.4, 3.5_
+
+- [ ] 7. Extend the Component_Packager (`edge-cv-portal/backend/functions/workflow_packaging.py`)
+  - [ ] 7.1 Emit Aravis binding points and version-item records
+    - `ARAVIS_CAMERA_SOURCE_TYPE_ID = 'aravis_camera_source'` joins `gather_camera_input_nodes`; `build_binding_points` marks Aravis nodes' entries `aravisBinding: true` with empty slots on every device architecture, parameters carrying the rendered `camera_id`/`gain`/`exposure`; version item records the nodes in `camera_input_nodes` with `has_binding_points: true`; all other node types' output unchanged
+    - _Requirements: 4.1, 4.2, 4.3_
+
+  - [ ]* 7.2 Write property test for Aravis binding point emission
+    - **Feature: aravis-camera-input, Property 9: Packaging emits Aravis binding points**
+    - **Validates: Requirements 4.1, 4.2**
+    - hypothesis in `edge-cv-portal/backend/tests` over definitions with 1..n Aravis (and mixed camera) nodes through the binding-point builder
+
+  - [ ]* 7.3 Write property test for Aravis-free packaging identity
+    - **Feature: aravis-camera-input, Property 10: Aravis-free packaging identity**
+    - **Validates: Requirements 4.3**
+    - hypothesis over Aravis-free definitions; `compiled_document_json` byte-equal to the pre-feature serialization
+
+- [ ] 8. Extend the Deployment_Service and binding matrix
+  - [ ] 8.1 Add the Aravis type-compatibility rule and matrix filtering
+    - `_CAMERA_COMPATIBLE_SOURCE_TYPES` gains `aravis_camera_source: {Camera, AravisDiscovered}` and adds `AravisDiscovered` to `camera_source`'s set; override constraint checking resolves the `aravis_camera_source` descriptor through the existing catalog lookup; frontend `CameraBindingMatrix` filters an `aravis_camera_source` row's options through the shared Aravis compatibility predicate with hint pre-selection unchanged
+    - _Requirements: 5.1, 5.2, 5.3, 5.4_
+
+  - [ ]* 8.2 Write property test for Aravis type-compatibility validation
+    - **Feature: aravis-camera-input, Property 11: Aravis type-compatibility validation**
+    - **Validates: Requirements 5.2, 5.3**
+    - hypothesis over version items with Aravis and camera_source nodes, registries with arbitrary source types, and binding sets; `CAMERA_TYPE_INCOMPATIBLE` exactly per the compatibility-map oracle
+
+  - [ ]* 8.3 Write property test for Aravis override constraint validation
+    - **Feature: aravis-camera-input, Property 12: Aravis override constraint validation**
+    - **Validates: Requirements 5.4**
+    - hypothesis over valid and violating overrides (`camera_id` emptiness, gain/exposure bounds, undeclared keys)
+
+  - [ ]* 8.4 Write unit and component tests for matrix presentation and delivery
+    - Component test: Aravis node row offers only compatible sources with hint pre-selection; unit test: a submission with an Aravis binding writes the expected `dda-camera-bindings` desired document and leaves the artifact bytes untouched
+    - _Requirements: 5.1, 5.5_
+
+- [ ] 9. Checkpoint - portal surfaces complete
+  - Ensure the portal backend suite, frontend vitest, and `npm run build` pass, ask the user if questions arise.
+
+- [ ] 10. Implement edge resolution and the executor Aravis frame feed
+  - [ ] 10.1 Extend resolve_bindings with Aravis assignments
+    - `camera_binding.py`: binding points with `aravisBinding: true` never substitute slots; resolved `cameraSourceId` and constraint-valid override bindings contribute to a new `aravis_assignments` field on `ResolutionResult` (default empty — existing consumers unaffected); `_PARAM_ALIASES` gains `cameraId → camera_id`; missing ids and override violations follow the existing invalid path with reasons
+    - _Requirements: 6.1, 6.2, 6.3_
+
+  - [ ]* 10.2 Write property test for device-side Aravis binding resolution
+    - **Feature: aravis-camera-input, Property 13: Device-side Aravis binding resolution**
+    - **Validates: Requirements 6.1, 6.2, 6.3**
+    - hypothesis in `test/backend-test/workflow_engine` over documents with Aravis binding points, binding maps (cameraSourceId / override / missing / violating), and inventories
+
+  - [ ] 10.3 Implement the aravis_feed planning module
+    - New pure `src/backend/workflow_engine/aravis_feed.py`: `AravisFeed` dataclass and `plan_aravis_feeds(document, resolution)` — assignment values when present, else the binding point's rendered parameters; empty-camera-id plans surface as node-attributed errors; more than one Aravis feed per document is a registration-side validation error (single Frame_Feed contract)
+    - _Requirements: 6.4_
+
+  - [ ]* 10.4 Write property test for feed plan precedence
+    - **Feature: aravis-camera-input, Property 14: Aravis feed plan precedence**
+    - **Validates: Requirements 6.4**
+    - hypothesis over documents with Aravis points and optional resolution results
+
+  - [ ] 10.5 Wire the resolution provider and frame feed into the WorkflowExecutor
+    - `WorkflowExecutor` gains an injectable `binding_resolution_provider`; engine startup (`runtime.py`) wires it to the watcher's `binding_resolution()` accessor; when a resolution exists the executor runs its substituted document; before pipeline start, each planned `AravisFeed` grabs one frame via `camera_manager.get_camera_frame(camera_id, config)` (lazy import) and the run goes through `run_pipeline(launch_string, frame_data)` with appsrc caps derived from the frame; grab failure fails the execution with `failing_node_id` set to the Aravis node; provider failure falls back to the disk document; documents with no Aravis points take the exact pre-feature call path
+    - _Requirements: 6.4, 6.5, 6.6_
+
+  - [ ]* 10.6 Write property test for Aravis-free execution identity
+    - **Feature: aravis-camera-input, Property 15: Aravis-free execution identity**
+    - **Validates: Requirements 6.6**
+    - hypothesis over Aravis-free documents (including legacy documents without `bindingPoints`): zero feeds planned and the executor invokes the fake pipeline manager without frame_data
+
+  - [ ]* 10.7 Write executor unit tests for the frame feed
+    - Fake camera manager + fake pipeline manager: successful grab/push call shape with resolved and rendered-default camera ids; raising camera manager → execution failed with the Aravis node id and camera error; multiple Aravis points → registration-side invalid reason; provider raising → disk-document fallback
+    - _Requirements: 6.4, 6.5_
+
+- [ ] 11. Final checkpoint
+  - Ensure all baselines pass: portal backend pytest, frontend vitest + `npm run build`, and the edge-scoped suites (`PYTHONPATH=src/backend:test/backend-test` over workflow_engine, camera_discovery, camera_sync); verify the two workflow_core catalog trees are byte-identical; ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional test tasks and can be skipped for a faster MVP
+- Each task references specific requirements for traceability; all 15 design properties are covered by tasks 1.4, 3.2, 3.4, 3.5, 4.2, 4.3, 6.3, 6.4, 7.2, 7.3, 8.2, 8.3, 10.2, 10.4, 10.6
+- Python property tests use hypothesis with no hardcoded `max_examples` (project default ≥100 iterations); TypeScript property tests use fast-check with `numRuns: 100`; each tagged `**Feature: aravis-camera-input, Property {number}: {property_text}**`
+- The catalog change lands first and is mirrored byte-identically (portal layer + edge vendor copy) before any consumer work begins; the mirror diff check in task 1.3 guards it for the rest of the implementation
+- Aravis hardware, the `gi`/Aravis runtime, GStreamer, and IoT shadow transport are exercised through injectable fakes everywhere; no test requires a physical GenICam camera
+- No shadow document, sync reducer, registry table, or `dda-camera-bindings` schema changes: `AravisDiscovered` is one more opaque type string to the existing transport and storage

--- a/.kiro/specs/aravis-camera-input/tasks.md
+++ b/.kiro/specs/aravis-camera-input/tasks.md
@@ -40,168 +40,168 @@ graph TD
 
 ## Tasks
 
-- [ ] 1. Add the `aravis_camera_source` node type to the Node_Catalog
-  - [ ] 1.1 Add the `ARAVIS_CAMERA_SOURCE` descriptor to the portal workflow_core catalog
+- [x] 1. Add the `aravis_camera_source` node type to the Node_Catalog
+  - [x] 1.1 Add the `ARAVIS_CAMERA_SOURCE` descriptor to the portal workflow_core catalog
     - In `edge-cv-portal/backend/layers/workflow_core/python/workflow_core/catalog/nodes.py`: type id `aravis_camera_source`, category input, display name "Aravis Camera Source", no inputs, one `out` port of type VideoFrames; parameters `camera_id` (string, required, `min_length: 1`, description, examples), `gain` (int, optional, default 4, min 0 max 100), `exposure` (int, optional, default 5000000, min 0), each with description and examples; `hardware_dependent=True`; device-arch mappings `appsrc name=appsrc_{nodeId} ! videoconvert` with plugin dependencies `app`, `videoconvertscale`; sim mapping `_dataset_fed_sim_source()`; appended to `NODE_CATALOG`
     - Ensure the compiler resolves the `{nodeId}` token in the appsrc name (reuse or extend the existing template resolution so multi-node documents render unique appsrc names)
     - _Requirements: 1.1, 1.2, 1.3, 1.4_
 
-  - [ ] 1.2 Mirror the catalog change to the edge vendor copy
+  - [x] 1.2 Mirror the catalog change to the edge vendor copy
     - Copy the modified catalog source verbatim to `src/backend/workflow_engine/vendor/workflow_core/` so the two source trees stay byte-identical (`diff -r` clean, ignoring `__pycache__`)
     - _Requirements: 1.6_
 
-  - [ ]* 1.3 Write catalog content unit tests
+  - [x]* 1.3 Write catalog content unit tests
     - Extend `edge-cv-portal/backend/layers/workflow_core/tests/test_catalog_content.py` conventions: descriptor identity (type id, category, display name, ports), parameter declarations and constraints, hardware_dependent flag, per-arch appsrc element chains and plugin dependencies, sim mapping equal to `camera_source`'s sim stub, `EXPECTED_TYPE_IDS` updated; assert `camera_source`'s descriptor is unchanged; add a mirror-equality check diffing the two catalog files
     - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.6, 7.4_
 
-  - [ ]* 1.4 Write property test for Aravis node definition round trip and compilation
+  - [x]* 1.4 Write property test for Aravis node definition round trip and compilation
     - **Feature: aravis-camera-input, Property 1: Aravis node definitions round-trip and compile through generic catalog paths**
     - **Validates: Requirements 1.5**
     - hypothesis over generated definitions containing `aravis_camera_source` nodes (extend `tests/generators.py` video-input types): serialize → parse equivalence; validate + compile succeed per device arch with the node's appsrc chain rendered
 
-- [ ] 2. Checkpoint - catalog complete in both trees
+- [x] 2. Checkpoint - catalog complete in both trees
   - Ensure the workflow_core test suite and the edge-scoped suites pass, ask the user if questions arise.
 
-- [ ] 3. Implement edge Aravis discovery (`src/backend/camera_discovery/aravis.py`)
-  - [ ] 3.1 Implement the injectable Aravis enumeration module
+- [x] 3. Implement edge Aravis discovery (`src/backend/camera_discovery/aravis.py`)
+  - [x] 3.1 Implement the injectable Aravis enumeration module
     - Frozen `DiscoveredAravisCamera` dataclass (stable_id, camera_id, model, address, physical_id, protocol, serial, vendor) and `AravisDiscoveryResult` (cameras, failures); `enumerate_aravis(enumerator=None)` defaulting to a lazy import of `aravis_functions.getCameras()`, mapping each returned Camera object; import or enumeration failure yields an empty result with a failure record, never an exception
     - Pure `aravis_stable_id(vendor, model, serial, physical_id)` deriving `arv-{sha1(vendor|model|serial)[:12]}` with the empty-serial fallback including `physical_id`
     - _Requirements: 2.1, 2.3, 2.6, 2.7_
 
-  - [ ]* 3.2 Write property test for stable id determinism
+  - [x]* 3.2 Write property test for stable id determinism
     - **Feature: aravis-camera-input, Property 3: Aravis stable id determinism**
     - **Validates: Requirements 2.2**
     - hypothesis over identity tuples in `test/backend-test/camera_discovery`: pure-function invariance under bus order / runtime-id / address changes; distinctness within generated enumerations
 
-  - [ ] 3.3 Wire Aravis enumeration into the CameraDiscovery loop and snapshot
+  - [x] 3.3 Wire Aravis enumeration into the CameraDiscovery loop and snapshot
     - `CameraDiscovery` accepts an injectable Aravis enumerator alongside the V4L2 layer; each periodic pass runs both; the tracked-snapshot diff treats Aravis stable ids identically to V4L2 ids (present/absent, `absent_since`, `on_change` only on change); no second timer; V4L2 behavior unchanged
     - _Requirements: 2.1, 2.5, 2.7_
 
-  - [ ]* 3.4 Write property test for Aravis absence marking
+  - [x]* 3.4 Write property test for Aravis absence marking
     - **Feature: aravis-camera-input, Property 5: Aravis absence marking on re-enumeration**
     - **Validates: Requirements 2.5**
     - hypothesis over sequences of fake Aravis enumeration results driven through the discovery diff
 
-  - [ ]* 3.5 Write property test for enumeration completeness with identity capture
+  - [x]* 3.5 Write property test for enumeration completeness with identity capture
     - **Feature: aravis-camera-input, Property 2: Aravis discovery enumeration completeness with identity capture**
     - **Validates: Requirements 2.1, 2.3**
     - hypothesis over generated fake Aravis buses (unicode names, duplicate models, empty serials); every camera contributes exactly one entry with type `AravisDiscovered`, origin `edge-discovered`, and all identity fields captured
 
-- [ ] 4. Extend the inventory merge (`src/backend/camera_sync/inventory.py`)
-  - [ ] 4.1 Implement the Aravis branch of build_inventory
+- [x] 4. Extend the inventory merge (`src/backend/camera_sync/inventory.py`)
+  - [x] 4.1 Implement the Aravis branch of build_inventory
     - Configured `Camera`-type Image_Source with `cameraId` equal to a tracked Aravis camera's id merges into ONE entry under `cfg-{imageSourceId}` (configured params + `capabilities.aravis` identity metadata, `discovered: True`, tracked absent state); unmerged Aravis cameras yield `AravisDiscovered` / `edge-discovered` entries with params `{cameraId, serial, protocol, address}` and `capabilities.aravis`; each tracked camera contributes to exactly one entry; output stays sorted and deterministic; inputs with no Aravis cameras produce output identical to today
     - _Requirements: 2.1, 2.3, 2.4, 7.2_
 
-  - [ ]* 4.2 Write property test for the configured/discovered Aravis merge
+  - [x]* 4.2 Write property test for the configured/discovered Aravis merge
     - **Feature: aravis-camera-input, Property 4: Configured/discovered Aravis merge by camera id**
     - **Validates: Requirements 2.4**
     - hypothesis in `test/backend-test/camera_sync` over configured sources and discovered cameras with random cameraId overlap
 
-  - [ ]* 4.3 Write property test for Aravis failure isolation and no-Aravis identity
+  - [x]* 4.3 Write property test for Aravis failure isolation and no-Aravis identity
     - **Feature: aravis-camera-input, Property 6: Aravis failure isolation and no-Aravis identity**
     - **Validates: Requirements 2.6, 7.2**
     - hypothesis over configured + V4L2 inventories with a raising/unavailable Aravis enumerator; output equals the pre-feature output for the same inputs, a failure record is present, nothing raises
 
-  - [ ]* 4.4 Write unit test for registry ingestion of AravisDiscovered reports
+  - [x]* 4.4 Write unit test for registry ingestion of AravisDiscovered reports
     - Ingest a report containing `AravisDiscovered` entries through the portal `reduce_report`/handler path (moto conftest stack); entries stored verbatim with existing types unaffected
     - _Requirements: 7.3_
 
-- [ ] 5. Checkpoint - edge inventory complete
+- [x] 5. Checkpoint - edge inventory complete
   - Ensure the edge-scoped suites pass (`PYTHONPATH=src/backend:test/backend-test`, camera_discovery + camera_sync + workflow_engine), ask the user if questions arise.
 
-- [ ] 6. Implement the Workflow_Builder Aravis picker (frontend)
-  - [ ] 6.1 Extend cameraReference.ts with the pure Aravis helpers
+- [x] 6. Implement the Workflow_Builder Aravis picker (frontend)
+  - [x] 6.1 Extend cameraReference.ts with the pure Aravis helpers
     - `isCameraReferenceParameter` returns true for (`aravis_camera_source`, `camera_id`); new `isAravisCompatibleCamera` (type `AravisDiscovered`, or type `Camera` with non-empty string `params.cameraId`), `cameraIdValue`, and `applyAravisCameraSelection` (populates `camera_id`, copies numeric gain/exposure, returns the standard `CameraBindingHint`, leaves other parameters untouched)
     - _Requirements: 3.1, 3.2, 3.3_
 
-  - [ ] 6.2 Wire the Aravis control into NodeConfigPanel
+  - [x] 6.2 Wire the Aravis control into NodeConfigPanel
     - The `aravis_camera_source` node's `camera_id` renders the camera reference control; option list filtered through `isAravisCompatibleCamera`; options display name, type, camera id, sync status, and staleness badge; selection applied through `applyAravisCameraSelection` storing `data.cameraBindingHint`; manual-entry toggle retained; `camera_source`'s control path untouched
     - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 7.4_
 
-  - [ ]* 6.3 Write property test for the Aravis compatibility filter
+  - [x]* 6.3 Write property test for the Aravis compatibility filter
     - **Feature: aravis-camera-input, Property 7: Aravis picker compatibility filter**
     - **Validates: Requirements 3.2**
     - fast-check (`numRuns: 100`) over generated `CameraSourceEntry` lists: filter soundness and completeness
 
-  - [ ]* 6.4 Write property test for Aravis selection application
+  - [x]* 6.4 Write property test for Aravis selection application
     - **Feature: aravis-camera-input, Property 8: Aravis selection populates the node and records the hint**
     - **Validates: Requirements 3.3**
     - fast-check over Aravis-compatible entries and prior parameter records through `applyAravisCameraSelection`
 
-  - [ ]* 6.5 Write component tests for the Aravis picker
+  - [x]* 6.5 Write component tests for the Aravis picker
     - Control renders for the Aravis node's `camera_id` (and not for unrelated parameters); manual entry toggle accepts a typed camera id; option display fields including stale/pending badges
     - _Requirements: 3.1, 3.4, 3.5_
 
-- [ ] 7. Extend the Component_Packager (`edge-cv-portal/backend/functions/workflow_packaging.py`)
-  - [ ] 7.1 Emit Aravis binding points and version-item records
+- [x] 7. Extend the Component_Packager (`edge-cv-portal/backend/functions/workflow_packaging.py`)
+  - [x] 7.1 Emit Aravis binding points and version-item records
     - `ARAVIS_CAMERA_SOURCE_TYPE_ID = 'aravis_camera_source'` joins `gather_camera_input_nodes`; `build_binding_points` marks Aravis nodes' entries `aravisBinding: true` with empty slots on every device architecture, parameters carrying the rendered `camera_id`/`gain`/`exposure`; version item records the nodes in `camera_input_nodes` with `has_binding_points: true`; all other node types' output unchanged
     - _Requirements: 4.1, 4.2, 4.3_
 
-  - [ ]* 7.2 Write property test for Aravis binding point emission
+  - [x]* 7.2 Write property test for Aravis binding point emission
     - **Feature: aravis-camera-input, Property 9: Packaging emits Aravis binding points**
     - **Validates: Requirements 4.1, 4.2**
     - hypothesis in `edge-cv-portal/backend/tests` over definitions with 1..n Aravis (and mixed camera) nodes through the binding-point builder
 
-  - [ ]* 7.3 Write property test for Aravis-free packaging identity
+  - [x]* 7.3 Write property test for Aravis-free packaging identity
     - **Feature: aravis-camera-input, Property 10: Aravis-free packaging identity**
     - **Validates: Requirements 4.3**
     - hypothesis over Aravis-free definitions; `compiled_document_json` byte-equal to the pre-feature serialization
 
-- [ ] 8. Extend the Deployment_Service and binding matrix
-  - [ ] 8.1 Add the Aravis type-compatibility rule and matrix filtering
+- [x] 8. Extend the Deployment_Service and binding matrix
+  - [x] 8.1 Add the Aravis type-compatibility rule and matrix filtering
     - `_CAMERA_COMPATIBLE_SOURCE_TYPES` gains `aravis_camera_source: {Camera, AravisDiscovered}` and adds `AravisDiscovered` to `camera_source`'s set; override constraint checking resolves the `aravis_camera_source` descriptor through the existing catalog lookup; frontend `CameraBindingMatrix` filters an `aravis_camera_source` row's options through the shared Aravis compatibility predicate with hint pre-selection unchanged
     - _Requirements: 5.1, 5.2, 5.3, 5.4_
 
-  - [ ]* 8.2 Write property test for Aravis type-compatibility validation
+  - [x]* 8.2 Write property test for Aravis type-compatibility validation
     - **Feature: aravis-camera-input, Property 11: Aravis type-compatibility validation**
     - **Validates: Requirements 5.2, 5.3**
     - hypothesis over version items with Aravis and camera_source nodes, registries with arbitrary source types, and binding sets; `CAMERA_TYPE_INCOMPATIBLE` exactly per the compatibility-map oracle
 
-  - [ ]* 8.3 Write property test for Aravis override constraint validation
+  - [x]* 8.3 Write property test for Aravis override constraint validation
     - **Feature: aravis-camera-input, Property 12: Aravis override constraint validation**
     - **Validates: Requirements 5.4**
     - hypothesis over valid and violating overrides (`camera_id` emptiness, gain/exposure bounds, undeclared keys)
 
-  - [ ]* 8.4 Write unit and component tests for matrix presentation and delivery
+  - [x]* 8.4 Write unit and component tests for matrix presentation and delivery
     - Component test: Aravis node row offers only compatible sources with hint pre-selection; unit test: a submission with an Aravis binding writes the expected `dda-camera-bindings` desired document and leaves the artifact bytes untouched
     - _Requirements: 5.1, 5.5_
 
-- [ ] 9. Checkpoint - portal surfaces complete
+- [x] 9. Checkpoint - portal surfaces complete
   - Ensure the portal backend suite, frontend vitest, and `npm run build` pass, ask the user if questions arise.
 
-- [ ] 10. Implement edge resolution and the executor Aravis frame feed
-  - [ ] 10.1 Extend resolve_bindings with Aravis assignments
+- [x] 10. Implement edge resolution and the executor Aravis frame feed
+  - [x] 10.1 Extend resolve_bindings with Aravis assignments
     - `camera_binding.py`: binding points with `aravisBinding: true` never substitute slots; resolved `cameraSourceId` and constraint-valid override bindings contribute to a new `aravis_assignments` field on `ResolutionResult` (default empty — existing consumers unaffected); `_PARAM_ALIASES` gains `cameraId → camera_id`; missing ids and override violations follow the existing invalid path with reasons
     - _Requirements: 6.1, 6.2, 6.3_
 
-  - [ ]* 10.2 Write property test for device-side Aravis binding resolution
+  - [x]* 10.2 Write property test for device-side Aravis binding resolution
     - **Feature: aravis-camera-input, Property 13: Device-side Aravis binding resolution**
     - **Validates: Requirements 6.1, 6.2, 6.3**
     - hypothesis in `test/backend-test/workflow_engine` over documents with Aravis binding points, binding maps (cameraSourceId / override / missing / violating), and inventories
 
-  - [ ] 10.3 Implement the aravis_feed planning module
+  - [x] 10.3 Implement the aravis_feed planning module
     - New pure `src/backend/workflow_engine/aravis_feed.py`: `AravisFeed` dataclass and `plan_aravis_feeds(document, resolution)` — assignment values when present, else the binding point's rendered parameters; empty-camera-id plans surface as node-attributed errors; more than one Aravis feed per document is a registration-side validation error (single Frame_Feed contract)
     - _Requirements: 6.4_
 
-  - [ ]* 10.4 Write property test for feed plan precedence
+  - [x]* 10.4 Write property test for feed plan precedence
     - **Feature: aravis-camera-input, Property 14: Aravis feed plan precedence**
     - **Validates: Requirements 6.4**
     - hypothesis over documents with Aravis points and optional resolution results
 
-  - [ ] 10.5 Wire the resolution provider and frame feed into the WorkflowExecutor
+  - [x] 10.5 Wire the resolution provider and frame feed into the WorkflowExecutor
     - `WorkflowExecutor` gains an injectable `binding_resolution_provider`; engine startup (`runtime.py`) wires it to the watcher's `binding_resolution()` accessor; when a resolution exists the executor runs its substituted document; before pipeline start, each planned `AravisFeed` grabs one frame via `camera_manager.get_camera_frame(camera_id, config)` (lazy import) and the run goes through `run_pipeline(launch_string, frame_data)` with appsrc caps derived from the frame; grab failure fails the execution with `failing_node_id` set to the Aravis node; provider failure falls back to the disk document; documents with no Aravis points take the exact pre-feature call path
     - _Requirements: 6.4, 6.5, 6.6_
 
-  - [ ]* 10.6 Write property test for Aravis-free execution identity
+  - [x]* 10.6 Write property test for Aravis-free execution identity
     - **Feature: aravis-camera-input, Property 15: Aravis-free execution identity**
     - **Validates: Requirements 6.6**
     - hypothesis over Aravis-free documents (including legacy documents without `bindingPoints`): zero feeds planned and the executor invokes the fake pipeline manager without frame_data
 
-  - [ ]* 10.7 Write executor unit tests for the frame feed
+  - [x]* 10.7 Write executor unit tests for the frame feed
     - Fake camera manager + fake pipeline manager: successful grab/push call shape with resolved and rendered-default camera ids; raising camera manager → execution failed with the Aravis node id and camera error; multiple Aravis points → registration-side invalid reason; provider raising → disk-document fallback
     - _Requirements: 6.4, 6.5_
 
-- [ ] 11. Final checkpoint
+- [x] 11. Final checkpoint
   - Ensure all baselines pass: portal backend pytest, frontend vitest + `npm run build`, and the edge-scoped suites (`PYTHONPATH=src/backend:test/backend-test` over workflow_engine, camera_discovery, camera_sync); verify the two workflow_core catalog trees are byte-identical; ask the user if questions arise.
 
 ## Notes

--- a/.kiro/specs/custom-python-frames/.config.kiro
+++ b/.kiro/specs/custom-python-frames/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "d107061e-32ed-4bda-a91c-f96a823ff1e7", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/custom-python-frames/design.md
+++ b/.kiro/specs/custom-python-frames/design.md
@@ -1,0 +1,344 @@
+# Design Document: Custom Python Frames
+
+## Overview
+
+This feature adds a Custom Python **preprocessing** node type (`custom_python_preprocess`, VideoFrames in → VideoFrames out) to the workflow node catalog and upgrades the shared Custom Python edge runtime into a practical OpenCV frame-processing environment:
+
+- a new ndarray-based handler contract `process_frame(frame, metadata)` alongside the existing raw-bytes `handle(frame_bytes, metadata)` contract,
+- `cv2`, `np`, and `numpy` pre-bound in the handler module's namespace,
+- a `dda_frames` helper module (injected by the runner, no extra artifact files) with `to_array` / `to_bytes` conversion, `frame_info()`, and `load_image()` for local paths and `s3://` URIs,
+- frame width/height/format delivered to every handler via `metadata["frame"]`.
+
+The design deliberately reuses the entire existing Custom Python delivery chain — the `emlpython` element mapping, the compiler's per-node `{python_handler_path}` derivation, the packager's `python/{nodeId}/handler.py` layout, and the Python_Bridge subprocess isolation — so the new node type requires **no compiler changes, no new edge wire format, and no frontend code changes** (the palette, code editor, port compatibility, and inline validation are all generic over the catalog descriptor). The work concentrates in two files: the catalog (`workflow_core/catalog/nodes.py`, both copies) and the Python_Bridge runner (`src/backend/workflow_engine/python_bridge.py`), plus a one-line predicate change in the packager.
+
+### Key findings from investigation
+
+- **Catalog** (`edge-cv-portal/backend/layers/workflow_core/python/workflow_core/catalog/nodes.py`): `custom_python` is post-processing category with per-instance `input_port_type`/`output_port_type` enum parameters; it maps on all architectures to a single `emlpython` element with `handler-path: {python_handler_path}` and plugin dependency `dda-emlpython`. Its `code` parameter description advertises `process(data, metadata)` — a contract that does not exist in the runtime (Requirement 8 fixes this).
+- **Compiler** (`workflow_core/compiler/compiler.py`): `python_handler_path` is derived per node id for *every* node (`_derived_values`), so any node type whose mapping uses the `emlpython` template compiles correctly with zero compiler changes.
+- **Packager** (`edge-cv-portal/backend/functions/workflow_packaging.py`): `gather_custom_python_nodes` filters `node.type == 'custom_python'` — the only place the node type id is hardcoded on the portal side. It must also accept `custom_python_preprocess`.
+- **Edge bridge** (`src/backend/workflow_engine/python_bridge.py`): the framed protocol header already carries `width`, `height`, `format` from the appsink caps, but the runner never exposes them to the handler (`run_bridged_pipeline` passes `metadata={}`). The runner (`RUNNER_SOURCE`, executed via `python -c` in the subprocess) loads `handler.py` with `importlib` and calls `handle(frame_bytes, metadata)`. All new runtime behavior lands inside `RUNNER_SOURCE`; the bridge (parent) side needs no protocol change.
+- **Frontend** (`edge-cv-portal/frontend/src/pages/workflows/`): NodePalette groups by descriptor category; NodeConfigPanel renders a code editor for `paramType === 'code'`; connection acceptance and inline checks key off parameter names (`input_port_type`) and declared ports generically. A fixed-port VideoFrames node needs no frontend changes — only test coverage.
+- **Vendored mirror**: `src/backend/workflow_engine/vendor/workflow_core/` is a byte-identical copy of the portal layer package (verified with diff); the test sandbox Docker image COPYies the portal layer copy, so only the two copies exist.
+- **Device environment**: `opencv-python` is in `src/backend/requirements.txt` and the handler subprocess runs the executor's interpreter (`sys.executable`), so `cv2`/`numpy` are importable on devices; `boto3` is available via the LocalServer environment and Greengrass provides AWS credentials through the environment, which the bridge already passes through to the subprocess.
+
+## Architecture
+
+```mermaid
+graph LR
+    subgraph Portal
+        CAT[Node_Catalog nodes.py<br/>+ custom_python_preprocess] --> API[node-catalog API]
+        API --> PAL[Node_Palette / NodeConfigPanel<br/>no code changes]
+        CAT --> VAL[Workflow_Validator<br/>generic port checks]
+        CAT --> CMP[Workflow_Compiler<br/>emlpython + python_handler_path]
+        CMP --> PKG[Component_Packager<br/>gather predicate widened]
+    end
+    PKG -->|"artifact zip: python/{nodeId}/handler.py + requirements.txt"| EDGE
+    subgraph EDGE[LocalServer edge device]
+        VEN[vendored workflow_core mirror<br/>byte-identical catalog] --- EXE[WorkflowExecutor]
+        EXE --> BR[Python_Bridge<br/>appsink/appsrc pair per node]
+        BR -->|framed stdin/stdout<br/>width/height/format in header| RUN[Python_Runner subprocess]
+        RUN --> HLP[dda_frames Frame_Helpers<br/>to_array / to_bytes / frame_info / load_image]
+        RUN --> USR[handler.py<br/>process_frame or handle<br/>cv2 / np pre-bound]
+        HLP -->|load_image| S3[(local disk / S3)]
+    end
+```
+
+Frame flow on the edge for a `process_frame` handler:
+
+1. The bridge's appsink pulls a sample, reads caps (`width`, `height`, `format`), and sends one framed message (header + raw frame bytes) to the subprocess — unchanged from today.
+2. The runner merges `{"frame": {"width": w, "height": h, "format": f}}` into the metadata dict and publishes the same triple to the `dda_frames` per-frame context.
+3. If the handler defines `process_frame`, the runner converts the raw bytes to a NumPy uint8 array (handling row padding by slicing each stride-sized row to `width × channels` bytes), invokes `process_frame(frame, metadata)`, verifies the returned array's shape and dtype, and writes the pixels back into a copy of the original byte buffer (preserving padding and total byte length so the appsrc caps stay valid).
+4. If the handler defines only `handle`, the existing raw-bytes path runs unchanged (with metadata now carrying the `frame` key).
+5. The response message travels back over the existing protocol; the bridge pushes the output buffer with the input buffer's timestamps — unchanged.
+
+### Design decisions
+
+- **New node type, not a category flag.** A separate `custom_python_preprocess` descriptor with fixed VideoFrames ports gives users an unambiguous frames-in/frames-out node in the preprocessing palette section, while `custom_python` keeps its flexible per-instance port typing for post-processing. Both share the `emlpython` mapping, so downstream behavior is identical.
+- **All runtime additions live in `RUNNER_SOURCE`.** The runner is self-contained by design (the subprocess must not import LocalServer). Embedding the `dda_frames` module source in the runner (registered in `sys.modules` before the handler loads) keeps artifacts unchanged (Requirement 5.1) and works for already-deployed workflows the moment LocalServer updates.
+- **`process_frame` output must match input shape/dtype.** The appsrc caps are fixed from the first input sample, so emitting frames of a different size or format would corrupt the pipeline. The runner enforces the constraint and produces a descriptive per-node error instead (Requirement 3.4).
+- **Row padding preserved by write-back.** GStreamer buffers may carry row stride padding. `to_array` slices rows by stride; the `process_frame` path writes returned pixels back into a copy of the original buffer bytes, so output byte length always equals input byte length (Requirement 3.2).
+- **Pre-imports are best-effort bindings.** `cv2`/`np`/`numpy` are set as module attributes on the handler module *before* `exec_module`, so top-level handler code can use them; import failures leave the binding absent without failing handlers that do not reference it (Requirement 4.3).
+- **`load_image` decodes via `cv2.imdecode`** for both local files and S3 objects (uniform behavior, BGR order, honors any format OpenCV can decode). The S3 client is created lazily with boto3 and is injectable for tests.
+- **No compiler/serializer/schema changes.** The workflow definition schema stores node `type` as an open string; validation resolves it against the catalog. Adding a descriptor is sufficient.
+- **Test sandbox unchanged.** The sandbox inherits whatever behavior `custom_python` has today for the `emlpython` element; the new node type compiles to the identical element chain, so sandbox behavior is identical by construction. Extending sandbox simulation of Custom Python handlers is out of scope.
+
+## Components and Interfaces
+
+### 1. Catalog descriptor (portal layer + vendored mirror)
+
+`workflow_core/catalog/nodes.py` — add after `FORMAT_CONVERT`:
+
+```python
+CUSTOM_PYTHON_PREPROCESS = NodeTypeDescriptor(
+    type_id="custom_python_preprocess",
+    category=CATEGORY_PREPROCESSING,
+    display_name="Custom Python (Frames)",
+    inputs=[PortDescriptor("in", PORT_TYPE_VIDEO_FRAMES)],
+    outputs=[PortDescriptor("out", PORT_TYPE_VIDEO_FRAMES)],
+    parameters=[
+        ParameterDescriptor("code", "code", required=True, default=None,
+                            constraints={"min_length": 1},
+                            description="Python run for every video frame. Define "
+                                        "process_frame(frame, metadata) and return the "
+                                        "processed frame; frame is a NumPy uint8 array "
+                                        "(rows x cols x channels) and cv2/np are "
+                                        "pre-imported. Return None to pass the frame "
+                                        "through. Helpers: import dda_frames for "
+                                        "frame_info(), load_image(path or s3:// URI), "
+                                        "to_array(), to_bytes().",
+                            examples=["def process_frame(frame, metadata):\n"
+                                      "    return cv2.GaussianBlur(frame, (5, 5), 0)"]),
+        ParameterDescriptor("requirements", "string", required=False, default="",
+                            constraints={},
+                            description="Extra pip packages the code needs, one per "
+                                        "line in requirements.txt form.",
+                            examples=["scikit-image==0.24.0"]),
+    ],
+    mappings=_same_on_all_archs(
+        element_chain=[_element("emlpython", **{"handler-path": "{python_handler_path}"})],
+        plugin_dependencies=["dda-emlpython"],
+    ),
+    hardware_dependent=False,
+)
+```
+
+`CUSTOM_PYTHON_PREPROCESS` is inserted into `NODE_CATALOG` with the other preprocessing types (after `FORMAT_CONVERT`), so `nodes_by_category()` places it in the preprocessing palette section. The `custom_python` descriptor's `code` description/examples are rewritten to state the real contract (Requirement 8):
+
+```
+description: "Python run for every item passing through the node. Define
+              process_frame(frame, metadata) to work with video frames as NumPy
+              arrays (cv2/np pre-imported; import dda_frames for helpers), or
+              handle(frame_bytes, metadata) -> (frame_bytes, metadata) to work
+              with raw bytes."
+examples:    ["def process_frame(frame, metadata):\n    return frame",
+              "def handle(frame_bytes, metadata):\n    return frame_bytes, metadata"]
+```
+
+The vendored copy `src/backend/workflow_engine/vendor/workflow_core/catalog/nodes.py` is updated to stay byte-identical (Requirement 1.6).
+
+### 2. Component_Packager (`edge-cv-portal/backend/functions/workflow_packaging.py`)
+
+```python
+CUSTOM_PYTHON_NODE_TYPES = ('custom_python', 'custom_python_preprocess')
+
+def gather_custom_python_nodes(graph) -> List[Dict]:
+    ...
+    if node.type in CUSTOM_PYTHON_NODE_TYPES:
+```
+
+Everything downstream (`build_arch_zip` writing `python/{nodeId}/handler.py` + `requirements.txt`, `build_manifest` emitting `customPythonNodeIds`) is already generic over the gathered list (Requirements 2.4, 2.5).
+
+### 3. Python_Runner (`src/backend/workflow_engine/python_bridge.py`, `RUNNER_SOURCE`)
+
+The runner script gains three pieces. The bridge (parent process) and the framed protocol are untouched.
+
+**(a) `dda_frames` helper module** — embedded as a separate module-level constant `HELPERS_SOURCE` in `python_bridge.py` and prepended into the assembled runner source. Registered before the handler loads:
+
+```python
+_helpers = types.ModuleType("dda_frames")
+exec(HELPERS_SOURCE, _helpers.__dict__)
+sys.modules["dda_frames"] = _helpers
+```
+
+Helper API (all functions raise `ValueError` with descriptive messages on bad input):
+
+```python
+FORMAT_CHANNELS = {"RGB": 3, "BGR": 3, "RGBA": 4, "GRAY8": 1}
+
+def to_array(frame_bytes, width, height, format):
+    """Raw frame bytes -> NumPy uint8 array (H x W x C; H x W for GRAY8).
+    Row stride = len(frame_bytes) // height; each row's first
+    width*channels bytes are taken, tolerating stride padding."""
+
+def to_bytes(array):
+    """NumPy uint8 array -> contiguous raw frame bytes (no padding)."""
+
+def frame_info():
+    """{'width': int, 'height': int, 'format': str} for the frame whose
+    handler invocation is in progress; None outside an invocation."""
+
+def load_image(source, s3_client=None):
+    """Local path or s3://bucket/key -> BGR uint8 array via cv2.imdecode.
+    Raises ValueError naming the source on missing file, malformed URI,
+    fetch failure, or undecodable content. s3_client is injectable for
+    tests; by default a lazily created boto3 client using the device's
+    ambient AWS credentials."""
+```
+
+`load_image` reads local files with `open(..., 'rb')` (so missing-file errors are uniform) and S3 objects with `get_object`, then decodes with `cv2.imdecode(np.frombuffer(data, np.uint8), cv2.IMREAD_UNCHANGED)`; a 3-channel result stays BGR, 4-channel input is reduced with `cv2.cvtColor(..., cv2.COLOR_BGRA2BGR)` only when decoded via IMREAD_COLOR — the design uses `cv2.IMREAD_COLOR` for multi-channel sources and `IMREAD_UNCHANGED` yields 2-D arrays for grayscale PNGs, satisfying Requirement 6.1's BGR/2-D contract. PNG round-trip equality (Requirement 6.3) holds for 3-channel BGR arrays written with `cv2.imwrite`.
+
+**(b) Pre-imports and handler resolution** — in the runner's `main()` after `module_from_spec` and before `exec_module`:
+
+```python
+for name, binding in (("cv2", "cv2"), ("numpy", "np"), ("numpy", "numpy")):
+    try:
+        setattr(module, binding, importlib.import_module(name))
+    except Exception:
+        pass  # absent binding; handlers not using it are unaffected
+```
+
+After `exec_module`, entry-point resolution (Requirements 3.6–3.8):
+
+```python
+process_frame = getattr(module, "process_frame", None)
+handle = getattr(module, "handle", None)
+if not callable(process_frame) and not callable(handle):
+    error: "handler.py defines neither process_frame(frame, metadata) "
+           "nor handle(frame_bytes, metadata)"
+```
+
+`process_frame` wins when both are defined (Requirement 3.7).
+
+**(c) Frame loop changes** — per message, before invocation:
+
+```python
+metadata = header.get("metadata") or {}
+info = {"width": header.get("width"), "height": header.get("height"),
+        "format": header.get("format")}
+metadata["frame"] = info          # Requirement 3.9
+dda_frames._set_current(info)     # Requirement 5.6 (cleared in finally)
+```
+
+`process_frame` invocation path:
+
+- format not in `FORMAT_CHANNELS` or width/height missing → error naming the node's unsupported format (Requirement 3.5); numpy unimportable → error naming the missing library.
+- `arr = dda_frames.to_array(frame, w, h, fmt)`; `result = process_frame(arr, metadata)`.
+- `result is None` → emit input bytes unchanged (Requirement 3.3).
+- ndarray with `result.shape == arr.shape and result.dtype == arr.dtype` → write rows back into `bytearray(frame)` at the original stride, emit (Requirement 3.2).
+- anything else → error describing expected vs. actual shape/dtype (Requirement 3.4); the runner reports `status: error` and the bridge raises `CustomPythonNodeError` naming the node, exactly like today's handler exceptions.
+
+`handle` invocation is unchanged apart from the enriched metadata. Handler-returned metadata continues to flow back in the response header for both contracts.
+
+### 4. Frontend (no code changes; test coverage only)
+
+- NodePalette test fixture gains the new descriptor and asserts it renders in the Preprocessing section (Requirement 7.1).
+- NodeConfigPanel test asserts the code editor renders for the new type's `code` parameter (Requirement 7.2).
+- connectionAcceptance property test domain extended with a fixed-VideoFrames-port node shape (Requirement 7.3).
+- inlineChecks test asserts a missing `code` yields a required-parameter marker (Requirement 7.4) — generic behavior, pinned by an example.
+
+## Data Models
+
+**Catalog descriptor** — one new `NodeTypeDescriptor` record (shape above); no schema changes to `serializer/schema.py` (node `type` is an open string resolved against the catalog).
+
+**Framed protocol** — unchanged. Executor → runner header: `{nodeId, width, height, format, metadata, frameSize}`; runner → executor: `{status, metadata, frameSize}` or `{status: "error", error}`.
+
+**Metadata frame info** (new, runner-side): `metadata["frame"] = {"width": int|None, "height": int|None, "format": str|None}` delivered to every handler invocation.
+
+**Frame array convention**: NumPy uint8, shape `(height, width, channels)` for RGB/BGR (3) and RGBA (4); shape `(height, width)` for GRAY8. Row stride handling: input bytes of length `L` for height `h` have stride `s = L // h`; row `i` pixels are bytes `[i*s, i*s + width*channels)`.
+
+**Manifest**: `customPythonNodeIds` (existing key) now lists node ids of both Custom Python node types.
+
+**Artifact layout** (existing, now also for the new type): `python/{nodeId}/handler.py`, `python/{nodeId}/requirements.txt`.
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Validator acceptance of preprocessing node connections
+
+*For any* workflow graph wiring a source node's output port into a `custom_python_preprocess` node's input port, the Workflow_Validator accepts the connection exactly when `are_port_types_compatible(source_type, VideoFrames)` holds under the catalog's declared coercion rules (VideoFrames exactly, and InferenceMeta via the declared coercion), and otherwise reports a port type compatibility error identifying that connection.
+
+**Validates: Requirements 2.1, 2.2**
+
+### Property 2: Legacy handle contract is preserved
+
+*For any* frame bytes and metadata dict, a handler defining only `handle(frame_bytes, metadata)` invoked through the CustomPythonBridge receives the frame bytes unchanged, receives the metadata enriched with the `frame` info key, and its returned `(frame_bytes, metadata)` round-trips back to the bridge caller exactly as under the pre-existing contract.
+
+**Validates: Requirements 3.6, 3.9**
+
+### Property 3: Custom Python node gathering and manifest membership
+
+*For any* workflow graph containing an arbitrary mix of `custom_python` nodes, `custom_python_preprocess` nodes, and other node types with arbitrary node ids, code strings, and requirements strings, `gather_custom_python_nodes` returns exactly the Custom Python nodes of both types with their code and requirements preserved, and `build_manifest`'s `customPythonNodeIds` equals exactly those nodes' ids.
+
+**Validates: Requirements 2.4, 2.5**
+
+### Property 4: process_frame contract round trip
+
+*For any* frame dimensions, supported Pixel_Format, pixel content, and row padding, a `process_frame` handler invoked through the CustomPythonBridge receives a NumPy uint8 array of the shape implied by the caps (rows × columns × channels; 2-D for GRAY8); returning that array unchanged emits output bytes equal to the input bytes (padding included); returning None emits the input bytes unchanged; and returning a deterministic transformation (bitwise inversion) emits bytes whose pixel regions are the transformed pixels while padding bytes and total byte length are preserved.
+
+**Validates: Requirements 3.1, 3.2, 3.3**
+
+### Property 5: process_frame contract violations fail the node identifiably
+
+*For any* frame and any non-compliant `process_frame` outcome — a returned array of different shape, a returned array of different dtype, a non-array non-None return, or an input frame whose Pixel_Format is outside the supported set — the CustomPythonBridge raises `CustomPythonNodeError` carrying the node id and a message describing the mismatch or the unsupported format.
+
+**Validates: Requirements 3.4, 3.5**
+
+### Property 6: Frame info delivery
+
+*For any* frame width, height, and supported Pixel_Format dispatched by the bridge, the handler observes that exact triple both in `metadata["frame"]` and from `dda_frames.frame_info()` during the invocation.
+
+**Validates: Requirements 3.9, 5.6**
+
+### Property 7: Frame/array conversion round trip
+
+*For any* frame dimensions, supported Pixel_Format, and pixel content, `to_bytes(to_array(frame_bytes, width, height, format))` equals the original unpadded frame bytes, and `to_array` of padded frame bytes returns the same array as `to_array` of the unpadded bytes; *for any* unsupported format string or byte string shorter than the dimensions require, `to_array` raises an error describing the format or size problem.
+
+**Validates: Requirements 5.2, 5.3, 5.4, 5.5**
+
+### Property 8: Disk image load round trip
+
+*For any* uint8 BGR image array written losslessly to a PNG file with `cv2.imwrite`, `dda_frames.load_image` of that path returns an array equal to the original.
+
+**Validates: Requirements 6.1, 6.3**
+
+### Property 9: S3 image load round trip
+
+*For any* bucket name, object key, and uint8 BGR image array PNG-encoded and served by an injected fake S3 client, `dda_frames.load_image("s3://bucket/key", s3_client=fake)` requests exactly that bucket and key and returns an array equal to the original.
+
+**Validates: Requirements 6.2**
+
+### Property 10: load_image failures identify the source
+
+*For any* failing source — a non-existent local path, a malformed `s3://` URI, an S3 client raising on fetch, or existing content that does not decode as an image — `dda_frames.load_image` raises an error whose message contains the source.
+
+**Validates: Requirements 6.4**
+
+### Property 11: Designer connection acceptance for fixed VideoFrames ports
+
+*For any* generated pair of nodes where the target is a `custom_python_preprocess`-shaped descriptor (fixed VideoFrames ports, no port type override parameters), the Workflow_Builder connection acceptance function accepts the connection exactly when the source output port type is compatible with VideoFrames under the declared coercion rules (VideoFrames exactly, or InferenceMeta via the declared coercion — mirroring the backend validator per Requirement 2.1) and otherwise rejects it with a reason.
+
+**Validates: Requirements 7.3**
+
+### Property 12: Compiled emlpython element per Custom Python preprocessing node
+
+*For any* valid workflow graph embedding `custom_python_preprocess` nodes with arbitrary node ids, compiling for any architecture yields exactly one `emlpython` element per such node carrying `handler-path` equal to `python/{nodeId}/handler.py` and tagged with that node's id.
+
+**Validates: Requirements 2.3**
+
+## Error Handling
+
+All new failure modes flow through the existing containment path: the runner reports `{status: "error", error: <traceback or message>}`, the bridge raises `CustomPythonNodeError(node_id, message)`, and the executor fails only that workflow run with the node identified (workflow-manager Requirements 9.8/13.7 behavior, unchanged).
+
+| Failure | Where detected | Behavior |
+|---|---|---|
+| Handler defines neither `process_frame` nor `handle` | Runner, at module load | Error names both accepted entry points; subprocess exits; bridge raises `CustomPythonNodeError` before the pipeline goes to PLAYING |
+| `process_frame` with unsupported Pixel_Format (e.g. NV12) or missing caps dims | Runner, per frame | Error names the format; run fails with node identified |
+| `process_frame` defined but NumPy unimportable | Runner, per frame | Error names the missing library |
+| Returned array shape/dtype mismatch, or non-array non-None return | Runner, per frame | Error describes expected vs. actual; run fails with node identified |
+| `to_array`/`to_bytes` misuse from handler code | Frame_Helpers (`ValueError`) | Propagates as a handler exception → existing error path |
+| `load_image`: missing file, malformed URI, S3 fetch failure, undecodable bytes | Frame_Helpers (`ValueError` naming the source) | Propagates as a handler exception → existing error path |
+| `cv2`/`numpy` import failure at pre-import | Runner, module load | Binding silently absent; only handlers referencing it fail (with a normal NameError traceback) |
+| boto3 unavailable when `load_image` gets an `s3://` URI | Frame_Helpers | `ValueError` naming the source and the missing boto3 dependency |
+
+Existing failure modes (wall-clock timeout, memory limit, protocol violations, subprocess death) are untouched.
+
+## Testing Strategy
+
+The feature is covered by a dual approach: property-based tests for the universal contracts above and example-based tests for fixed catalog content, dispatch rules, and UI rendering. Property tests use **hypothesis** (Python) and **fast-check** (TypeScript), inherit each suite's iteration profile from its conftest/setup (no hardcoded `max_examples`; the CI profile runs ≥100 iterations), and each carries a comment tag in the form **Feature: custom-python-frames, Property {number}: {property_text}**. Each correctness property is implemented by a single property-based test.
+
+**Portal backend** (`pytest` + `hypothesis`):
+- `edge-cv-portal/backend/layers/workflow_core/tests/` — catalog content examples (descriptor shape, mapping parity with `custom_python`, description/example contract checks: Requirements 1.1–1.5, 8.1, 8.2), Property 1 (validator), Property 12 (compiler).
+- `edge-cv-portal/backend/tests/` — Property 3 as `test_property_*.py` over the pure `gather_custom_python_nodes` + `build_manifest`; one example extension of `test_workflow_packaging_deployment_integration.py` covering the new node type's files in the arch zips (Requirements 2.4, 2.5 integration).
+
+**Edge LocalServer** (`pytest` + `hypothesis`, run as `PYTHONPATH=src/backend:test/backend-test pytest test/backend-test/workflow_engine/...` — scoped to the workflow_engine suites; the broader edge suite has pre-existing environment-dependent failures on this host):
+- `test/backend-test/workflow_engine/` — Properties 2, 4, 5, 6, 7, 8, 9, 10 against the real `CustomPythonBridge` (real subprocesses, as the existing `test_workflow_python_bridge.py` does) and against `dda_frames` executed from `HELPERS_SOURCE`; example tests for entry-point dispatch (both defined → `process_frame` wins; neither → error naming both), pre-imported `cv2`/`np` usage, sibling-module import regression, missing-cv2 resilience, and `load_image` failure containment through the bridge (Requirements 3.7, 3.8, 4.1–4.5, 5.1, 6.5).
+- Host prerequisites verified: numpy 2.0.2, cv2 4.13.0, boto3, hypothesis are importable with the system interpreter that spawns the handler subprocesses.
+
+**Frontend** (`vitest` + RTL + `fast-check`, `edge-cv-portal/frontend/src/pages/workflows/`):
+- Property 11 as an extension of the existing `connectionAcceptance.property.test.ts` domain.
+- Example tests: palette section rendering, code editor rendering, inline required-`code` marker (Requirements 7.1, 7.2, 7.4).
+
+**Vendored mirror** (Requirement 1.6): a byte-equality check between the two `nodes.py` copies executed as part of the edge test additions (smoke).
+
+Baselines to keep green: portal backend tests (moto-backed conftest), workflow_core layer tests, frontend vitest + `npm run build`, and the edge `test/backend-test/workflow_engine` suites that pass on this host.

--- a/.kiro/specs/custom-python-frames/requirements.md
+++ b/.kiro/specs/custom-python-frames/requirements.md
@@ -1,0 +1,128 @@
+# Requirements Document
+
+## Introduction
+
+The workflow designer's Custom Python support today consists of a single post-processing node type (`custom_python`) whose user code runs on the edge device inside a subprocess bridge (`emlpython` → executor-managed appsink/appsrc pair) with a raw-bytes contract: `handle(frame_bytes, metadata) -> (frame_bytes, metadata)`. Writing image-processing code against raw bytes is impractical — the handler receives no frame dimensions, has no conversion helpers, and the catalog's own parameter description advertises a `process(data, metadata)` function that does not exist in the runtime.
+
+This feature adds a Custom Python **preprocessing** node type that takes video frames in and emits processed frames out, and upgrades the Custom Python runtime (shared by the preprocessing and post-processing node types) into a practical OpenCV frame-processing environment: an ndarray-based `process_frame` handler contract, OpenCV and NumPy pre-imported into the handler namespace, helper functions for converting frames to and from NumPy arrays, current-frame dimension/format access, and an image loader that reads a JPEG/PNG from local disk or from S3 into an OpenCV array. Existing `handle`-based handlers keep working unchanged.
+
+The feature spans the Portal (node catalog, packaging) and the LocalServer edge runtime (the Python bridge runner), with the vendored `workflow_core` catalog mirror kept in sync.
+
+## Glossary
+
+- **Portal**: The edge-cv-portal cloud web application (React frontend, Lambda backend) used to design, package, and deploy workflows.
+- **LocalServer**: The Greengrass component running on an edge device that executes compiled workflow pipelines through GStreamer.
+- **Node_Catalog**: The data catalog of node type descriptors in `workflow_core.catalog.nodes` (`NODE_CATALOG`), maintained in the Portal Lambda layer at `edge-cv-portal/backend/layers/workflow_core/` and mirrored verbatim in the LocalServer vendored copy at `src/backend/workflow_engine/vendor/workflow_core/`.
+- **Workflow_Builder**: The graphical canvas UI (Node_Palette, canvas, NodeConfigPanel) where users compose workflows.
+- **Node_Palette**: The categorized node type list in the Workflow_Builder, populated from the Node_Catalog via the node-catalog API.
+- **Workflow_Validator**: The `workflow_core.validator` component checking graph structure and port type compatibility.
+- **Workflow_Compiler**: The `workflow_core.compiler` component translating a workflow definition into per-architecture compiled pipeline documents.
+- **Component_Packager**: The Portal backend packaging Lambda (`workflow_packaging.py`) that assembles per-architecture Workflow_Component artifact zips, including `python/{nodeId}/handler.py` and `python/{nodeId}/requirements.txt` for Custom Python nodes.
+- **Custom_Python_Node**: The existing post-processing node type (`custom_python`) with per-instance input/output port type parameters, executed on the edge through the Python_Bridge.
+- **Custom_Python_Preprocess_Node**: The new preprocessing node type (`custom_python_preprocess`) added by this feature, with fixed VideoFrames input and output ports.
+- **Python_Bridge**: The LocalServer component (`src/backend/workflow_engine/python_bridge.py`) that replaces each `emlpython` element with an executor-managed appsink/appsrc pair and pumps frames through a handler subprocess over a framed stdin/stdout protocol.
+- **Python_Runner**: The self-contained script (`RUNNER_SOURCE` in the Python_Bridge) executed inside the handler subprocess; it loads the user's `handler.py` and invokes the handler function once per frame.
+- **Frame_Helpers**: The helper module added by this feature, importable from handler code as `dda_frames`, providing frame/array conversion, current-frame info, and image loading functions.
+- **Pixel_Format**: The GStreamer video format string carried in the stream caps (this feature supports array conversion for RGB, BGR, RGBA, and GRAY8).
+
+## Requirements
+
+### Requirement 1: Custom Python Preprocessing Node Type
+
+**User Story:** As a computer vision engineer, I want a Custom Python preprocessing node that takes video frames in and emits processed frames out, so that I can apply OpenCV transformations to the video stream before inference.
+
+#### Acceptance Criteria
+
+1. THE Node_Catalog SHALL provide a node type with type id `custom_python_preprocess`, display name "Custom Python (Frames)", and the preprocessing category.
+2. THE Custom_Python_Preprocess_Node descriptor SHALL declare exactly one input port and one output port, both of Pixel_Format-carrying type VideoFrames, without per-instance port type override parameters.
+3. THE Custom_Python_Preprocess_Node descriptor SHALL declare a required `code` parameter of parameter type `code` and an optional `requirements` parameter accepting extra pip packages in requirements.txt form.
+4. THE Custom_Python_Preprocess_Node descriptor SHALL map on every architecture to the same `emlpython` element chain (carrying the `{python_handler_path}` argument) and `dda-emlpython` plugin dependency as the Custom_Python_Node.
+5. THE Custom_Python_Preprocess_Node descriptor's `code` parameter description and examples SHALL document the `process_frame(frame, metadata)` contract with OpenCV, where `frame` is a NumPy array.
+6. THE Node_Catalog copy in the LocalServer vendored mirror (`src/backend/workflow_engine/vendor/workflow_core/catalog/nodes.py`) SHALL be byte-identical to the Portal layer copy after the change.
+
+### Requirement 2: Validation, Compilation, and Packaging
+
+**User Story:** As a computer vision engineer, I want workflows containing the new preprocessing node to validate, compile, and package exactly like other Custom Python nodes, so that I can deploy them to devices without special handling.
+
+#### Acceptance Criteria
+
+1. WHEN a workflow connects an output port whose type is compatible with VideoFrames under the Node_Catalog's declared coercion rules (VideoFrames, or InferenceMeta via the declared coercion) to a Custom_Python_Preprocess_Node input port, THE Workflow_Validator SHALL accept the connection.
+2. WHEN a workflow connects an EventSignal output port to a Custom_Python_Preprocess_Node input port, THE Workflow_Validator SHALL report a port type compatibility error identifying the connection.
+3. WHEN a workflow containing a Custom_Python_Preprocess_Node is compiled for any architecture, THE Workflow_Compiler SHALL emit an `emlpython` element for that node carrying handler path `python/{nodeId}/handler.py`.
+4. WHEN a workflow containing Custom_Python_Preprocess_Nodes is packaged, THE Component_Packager SHALL write each such node's `code` to `python/{nodeId}/handler.py` and its `requirements` to `python/{nodeId}/requirements.txt` in every architecture artifact zip.
+5. WHEN the per-architecture manifest is built, THE Component_Packager SHALL list the node ids of Custom_Python_Nodes and Custom_Python_Preprocess_Nodes together in `customPythonNodeIds`.
+
+### Requirement 3: Frame-Based Handler Contract
+
+**User Story:** As a computer vision engineer, I want to write my per-frame code as `process_frame(frame, metadata)` receiving a NumPy array, so that I can use OpenCV operations directly instead of decoding raw bytes myself.
+
+#### Acceptance Criteria
+
+1. WHEN a handler file defines a callable `process_frame`, THE Python_Runner SHALL invoke `process_frame(frame, metadata)` once per frame with `frame` as a NumPy uint8 array whose shape is derived from the stream's width, height, and Pixel_Format (rows × columns × channels; single-channel formats yield a rows × columns array).
+2. WHEN `process_frame` returns a NumPy array with the same shape and dtype as the input array, THE Python_Runner SHALL emit the returned array's pixels as the node's output frame, preserving the frame's byte length including any row padding present in the input buffer.
+3. WHEN `process_frame` returns None, THE Python_Runner SHALL emit the input frame unchanged.
+4. IF `process_frame` returns a value whose shape or dtype differs from the input array, THEN THE Python_Bridge SHALL fail the workflow run with an error identifying the node and describing the mismatch.
+5. IF a handler file defines `process_frame` and the frame's Pixel_Format is outside the supported conversion set (RGB, BGR, RGBA, GRAY8), THEN THE Python_Bridge SHALL fail the workflow run with an error identifying the node and the unsupported Pixel_Format.
+6. WHEN a handler file defines a callable `handle` and no `process_frame`, THE Python_Runner SHALL invoke `handle(frame_bytes, metadata)` under the existing raw-bytes contract, unchanged in behavior.
+7. WHEN a handler file defines both `process_frame` and `handle`, THE Python_Runner SHALL invoke `process_frame` and ignore `handle`.
+8. IF a handler file defines neither `process_frame` nor `handle`, THEN THE Python_Bridge SHALL fail the workflow run with an error identifying the node and naming both accepted entry points.
+9. WHEN THE Python_Bridge dispatches a frame to the handler subprocess, THE Python_Runner SHALL deliver the frame's width, height, and Pixel_Format to the handler inside the `metadata` dict under the key `frame`.
+10. THE frame-based handler contract SHALL apply identically to handlers of Custom_Python_Nodes and Custom_Python_Preprocess_Nodes.
+
+### Requirement 4: Pre-Imported OpenCV and Device Library Imports
+
+**User Story:** As a computer vision engineer, I want OpenCV available in my handler code without boilerplate and the freedom to import other Python libraries installed on the device, so that I can write concise processing code.
+
+#### Acceptance Criteria
+
+1. WHEN a handler module is loaded and OpenCV is importable in the handler subprocess, THE Python_Runner SHALL bind `cv2` in the handler module's global namespace before the handler code executes.
+2. WHEN a handler module is loaded and NumPy is importable in the handler subprocess, THE Python_Runner SHALL bind `np` and `numpy` in the handler module's global namespace before the handler code executes.
+3. IF OpenCV or NumPy is not importable in the handler subprocess, THEN THE Python_Runner SHALL still load handler modules whose code does not reference the missing binding.
+4. THE Python_Runner SHALL execute handler code with the device Python interpreter, so that a standard `import` statement in handler code resolves any Python library installed on the device.
+5. WHEN handler code imports a Python module shipped beside `handler.py` in the node's artifact directory, THE Python_Runner SHALL resolve the import.
+
+### Requirement 5: Frame Input and Output Helper Functions
+
+**User Story:** As a computer vision engineer, I want helper functions for getting frames into and out of NumPy arrays, so that I can also work with frames from the raw-bytes `handle` contract or convert data explicitly.
+
+#### Acceptance Criteria
+
+1. THE Frame_Helpers module SHALL be importable from handler code as `dda_frames` without the node shipping additional files in its artifacts.
+2. THE Frame_Helpers module SHALL provide `to_array(frame_bytes, width, height, format)` converting raw frame bytes to a NumPy uint8 array for the RGB, BGR, RGBA, and GRAY8 Pixel_Formats, tolerating row padding in the frame bytes.
+3. THE Frame_Helpers module SHALL provide `to_bytes(array)` converting a NumPy uint8 array to raw frame bytes.
+4. FOR ALL frames in the supported Pixel_Formats without row padding, `to_bytes(to_array(frame_bytes, width, height, format))` SHALL equal the original frame bytes (round-trip property).
+5. IF `to_array` is called with a Pixel_Format outside the supported set or with frame bytes too short for the stated dimensions, THEN THE Frame_Helpers SHALL raise an error describing the format or size problem.
+6. WHILE a handler invocation is in progress, THE Frame_Helpers module SHALL return the current frame's width, height, and Pixel_Format from a `frame_info()` function.
+7. THE Frame_Helpers module SHALL be available to handlers of Custom_Python_Nodes and Custom_Python_Preprocess_Nodes alike.
+
+### Requirement 6: Image Loading from Disk or S3
+
+**User Story:** As a computer vision engineer, I want to load a reference image (for example a golden-sample JPEG) from the device file system or from S3 into an OpenCV array, so that my handler can compare or combine it with live frames.
+
+#### Acceptance Criteria
+
+1. WHEN `dda_frames.load_image(source)` is called with a local file path of a decodable image file, THE Frame_Helpers SHALL return the decoded image as a NumPy uint8 array in OpenCV BGR channel order (single-channel images decode to a two-dimensional array).
+2. WHEN `dda_frames.load_image(source)` is called with an `s3://bucket/key` URI, THE Frame_Helpers SHALL download the object using the device's AWS credentials and return the decoded image as a NumPy uint8 array in OpenCV BGR channel order.
+3. FOR ALL image arrays written losslessly to disk as PNG, `load_image` of the written file SHALL return an array equal to the original array (round-trip property).
+4. IF the local file does not exist, the S3 object cannot be fetched, the URI is malformed, or the content cannot be decoded as an image, THEN THE Frame_Helpers SHALL raise an error identifying the source and describing the failure.
+5. WHEN a handler raises the `load_image` error, THE Python_Bridge SHALL fail only that workflow run with the node identified, consistent with existing handler failure containment.
+
+### Requirement 7: Workflow Designer Support
+
+**User Story:** As a computer vision engineer, I want the new preprocessing node to appear and behave correctly in the workflow designer, so that I can place, configure, and connect it like any other node.
+
+#### Acceptance Criteria
+
+1. WHEN a user opens the Node_Palette, THE Workflow_Builder SHALL display the Custom_Python_Preprocess_Node in the preprocessing section.
+2. WHEN a user selects a Custom_Python_Preprocess_Node, THE Workflow_Builder SHALL render a code editor for the `code` parameter.
+3. WHEN a user attempts to connect an output port whose type is not compatible with VideoFrames under the declared coercion rules (VideoFrames exactly, or InferenceMeta via the declared coercion, consistent with Requirement 2.1) to a Custom_Python_Preprocess_Node input port, THE Workflow_Builder SHALL reject the connection and display the reason.
+4. WHILE a Custom_Python_Preprocess_Node has no `code` value, THE Workflow_Builder SHALL display an inline required-parameter validation marker on the node.
+
+### Requirement 8: Accurate Custom Python Contract Documentation
+
+**User Story:** As a computer vision engineer, I want the Custom Python node's in-designer documentation to match the actual runtime contract, so that code I write from the parameter description runs on the device.
+
+#### Acceptance Criteria
+
+1. THE Custom_Python_Node descriptor's `code` parameter description SHALL state the actual runtime entry points (`process_frame(frame, metadata)` for NumPy-array processing and `handle(frame_bytes, metadata)` for raw bytes) in place of the current non-existent `process(data, metadata)` contract.
+2. THE Custom_Python_Node descriptor's `code` parameter examples SHALL contain at least one example that is a valid handler under the runtime contract.

--- a/.kiro/specs/custom-python-frames/tasks.md
+++ b/.kiro/specs/custom-python-frames/tasks.md
@@ -1,0 +1,161 @@
+# Implementation Plan: Custom Python Frames
+
+## Overview
+
+Work proceeds along two independent tracks that meet at the vendored-mirror sync: the Portal track (catalog descriptor + documentation fixes, then packaging) and the Edge track (the `dda_frames` helper module, then the runner contract changes), followed by the mirror sync, frontend coverage, and a final full-suite checkpoint. There are no compiler, serializer, schema, or frontend production-code changes — the compiler already derives `python_handler_path` per node, and the designer UI is generic over the catalog descriptor.
+
+Test baselines that must stay green: portal backend `edge-cv-portal/backend/tests` and `edge-cv-portal/backend/layers/workflow_core/tests` (pytest + hypothesis, moto-backed conftest), frontend vitest (`edge-cv-portal/frontend`, vitest + RTL + fast-check) plus `npm run build`, and the edge suites run as `PYTHONPATH=src/backend:test/backend-test pytest test/backend-test/workflow_engine/` (scoped to the workflow_engine suites — the broader edge suite has pre-existing environment-dependent failures on this host). Python property tests use `hypothesis` and TypeScript property tests use `fast-check`; iteration counts come from each suite's registered profile (no hardcoded `max_examples`; the CI profile runs ≥100 iterations) and every property test is tagged `**Feature: custom-python-frames, Property {number}: {property_text}**`.
+
+## Task Dependency Graph
+
+```mermaid
+graph TD
+    T1[1. Catalog descriptor + contract docs] --> T2[2. Packaging gather + manifest]
+    T4[4. dda_frames Frame_Helpers] --> T5[5. Runner contract changes]
+    T2 --> T3[3. Checkpoint: portal backend]
+    T5 --> T6[6. Edge examples + vendored mirror sync]
+    T1 --> T6
+    T3 --> T7[7. Frontend designer coverage]
+    T1 --> T7
+    T6 --> T8[8. Final checkpoint]
+    T7 --> T8
+```
+
+```json
+{
+  "waves": [
+    { "wave": 1, "tasks": ["1", "4"], "description": "Independent foundations: the catalog descriptor with its validator/compiler properties (portal), and the dda_frames helper module with its conversion/load properties (edge)" },
+    { "wave": 2, "tasks": ["2", "5"], "description": "Consumers of the foundations: packaging gather/manifest (portal), and the runner contract changes with their bridge-level properties (edge)" },
+    { "wave": 3, "tasks": ["3"], "description": "Checkpoint: portal backend and workflow_core layer suites pass" },
+    { "wave": 4, "tasks": ["6"], "description": "Edge example tests, load_image failure containment, and the vendored workflow_core mirror sync with byte-equality smoke test" },
+    { "wave": 5, "tasks": ["7"], "description": "Frontend designer coverage (palette, code editor, inline marker examples; connection acceptance property)" },
+    { "wave": 6, "tasks": ["8"], "description": "Final checkpoint: all suites pass" }
+  ]
+}
+```
+
+## Tasks
+
+- [x] 1. Add the Custom Python preprocessing node type to the catalog (portal layer)
+  - [x] 1.1 Add the `custom_python_preprocess` descriptor and fix the Custom Python contract documentation
+    - In `edge-cv-portal/backend/layers/workflow_core/python/workflow_core/catalog/nodes.py`: add `CUSTOM_PYTHON_PREPROCESS` (type id `custom_python_preprocess`, category `CATEGORY_PREPROCESSING`, display name "Custom Python (Frames)", fixed `in`/`out` VideoFrames ports, required `code` parameter of type `code` documenting `process_frame(frame, metadata)` with a cv2 example, optional `requirements` parameter, `_same_on_all_archs` mapping to the `emlpython` element with `handler-path: {python_handler_path}` and plugin dependency `dda-emlpython`, `hardware_dependent=False`); insert it into `NODE_CATALOG` after `FORMAT_CONVERT`
+    - Rewrite the `custom_python` descriptor's `code` parameter description and examples to state the actual runtime entry points (`process_frame(frame, metadata)` and `handle(frame_bytes, metadata) -> (frame_bytes, metadata)`) in place of the non-existent `process(data, metadata)` contract
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 8.1, 8.2_
+
+  - [x] 1.2 Write catalog content unit tests for the new descriptor and documentation
+    - In `edge-cv-portal/backend/layers/workflow_core/tests/test_catalog_content.py`: descriptor present with preprocessing category and display name; exactly one VideoFrames input and one VideoFrames output with no `input_port_type`/`output_port_type` parameters; required `code` + optional `requirements` parameters; per-architecture mappings identical to `custom_python`'s (same element chain and plugin dependencies); `code` descriptions of both Custom Python types name `process_frame` (and `handle` for `custom_python`) and not `process(data, metadata)`; every `code` example of both types exec's to a module defining a callable `process_frame` or `handle`
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 8.1, 8.2_
+
+  - [x] 1.3 Write property test for validator acceptance of preprocessing node connections
+    - **Feature: custom-python-frames, Property 1: Validator acceptance of preprocessing node connections**
+    - **Validates: Requirements 2.1, 2.2**
+    - New `test_property_*` module in `edge-cv-portal/backend/layers/workflow_core/tests/`: hypothesis-generated graphs wiring a random source node type's output into a `custom_python_preprocess` input; `validate` accepts exactly when `are_port_types_compatible(source_port_type, VideoFrames)` holds under the catalog's declared coercion rules (VideoFrames, and InferenceMeta via the declared coercion), otherwise reports a V2 port-compatibility finding identifying the connection
+
+  - [x] 1.4 Write property test for the compiled emlpython element
+    - **Feature: custom-python-frames, Property 12: Compiled emlpython element per Custom Python preprocessing node**
+    - **Validates: Requirements 2.3**
+    - Hypothesis-generated valid workflows embedding `custom_python_preprocess` nodes with random node ids, compiled per architecture; exactly one `emlpython` element per node, tagged with the node id, carrying `handler-path` = `python/{nodeId}/handler.py`
+
+- [x] 2. Include the new node type in packaging
+  - [x] 2.1 Widen the Custom Python gather predicate
+    - In `edge-cv-portal/backend/functions/workflow_packaging.py`: introduce `CUSTOM_PYTHON_NODE_TYPES = ('custom_python', 'custom_python_preprocess')` and use it in `gather_custom_python_nodes`; no other packaging changes (`build_arch_zip` and `build_manifest` are generic over the gathered list)
+    - _Requirements: 2.4, 2.5_
+
+  - [x] 2.2 Write property test for gathering and manifest membership
+    - **Feature: custom-python-frames, Property 3: Custom Python node gathering and manifest membership**
+    - **Validates: Requirements 2.4, 2.5**
+    - New `test_property_*` module in `edge-cv-portal/backend/tests/`: hypothesis-generated graphs mixing both Custom Python node types and other types with random ids/code/requirements; `gather_custom_python_nodes` returns exactly the Custom Python nodes with code and requirements preserved; `build_manifest`'s `customPythonNodeIds` equals exactly those ids
+
+  - [x] 2.3 Extend the packaging integration test with the new node type
+    - In `edge-cv-portal/backend/tests/test_workflow_packaging_deployment_integration.py`: a definition containing one `custom_python_preprocess` node packages `python/{nodeId}/handler.py` and `python/{nodeId}/requirements.txt` into every architecture zip with the node id in the manifest's `customPythonNodeIds`
+    - _Requirements: 2.3, 2.4, 2.5_
+
+- [x] 3. Checkpoint — portal backend suites pass
+  - Run `edge-cv-portal/backend/layers/workflow_core/tests` and `edge-cv-portal/backend/tests`; ensure all tests pass, ask the user if questions arise.
+
+- [x] 4. Implement the `dda_frames` Frame_Helpers module (edge)
+  - [x] 4.1 Add `HELPERS_SOURCE` to the Python bridge
+    - In `src/backend/workflow_engine/python_bridge.py`: a new module-level constant `HELPERS_SOURCE` containing the `dda_frames` module source — `FORMAT_CHANNELS` (RGB/BGR 3, RGBA 4, GRAY8 1), `to_array(frame_bytes, width, height, format)` (uint8 array `(h, w, c)`, 2-D for GRAY8, row stride = `len(frame_bytes) // height` with per-row slicing to tolerate padding; `ValueError` naming the unsupported format or the size shortfall), `to_bytes(array)` (contiguous bytes; `ValueError` on non-uint8/non-array input), `frame_info()` returning the per-invocation `{'width', 'height', 'format'}` context (set/cleared via a private `_set_current`), and `load_image(source, s3_client=None)` (local path via `open(..., 'rb')`, `s3://bucket/key` via a lazily created boto3 client or the injected one; decode with `cv2.imdecode` — `IMREAD_COLOR` for color sources yielding BGR, grayscale PNGs yielding 2-D arrays; `ValueError` containing the source string on missing file, malformed URI, fetch failure, undecodable content, or missing boto3)
+    - Keep `HELPERS_SOURCE` dependency-free of LocalServer imports (it executes inside the handler subprocess) and importable standalone for direct unit/property testing via `exec`
+    - _Requirements: 5.1, 5.2, 5.3, 5.5, 6.1, 6.2, 6.4_
+
+  - [x] 4.2 Write property test for the frame/array conversion round trip
+    - **Feature: custom-python-frames, Property 7: Frame/array conversion round trip**
+    - **Validates: Requirements 5.2, 5.3, 5.4, 5.5**
+    - New `test_property_*` module in `test/backend-test/workflow_engine/` exec'ing `HELPERS_SOURCE`; hypothesis over dims × supported formats × pixel bytes × padding: `to_bytes(to_array(...))` equals unpadded input; padded and unpadded inputs decode to equal arrays; unsupported formats and short buffers raise `ValueError` describing the problem
+
+  - [x] 4.3 Write property test for the disk image load round trip
+    - **Feature: custom-python-frames, Property 8: Disk image load round trip**
+    - **Validates: Requirements 6.1, 6.3**
+    - Hypothesis over uint8 `(h, w, 3)` arrays written to tmp PNGs with `cv2.imwrite`; `load_image(path)` returns an equal array
+
+  - [x] 4.4 Write property test for the S3 image load round trip
+    - **Feature: custom-python-frames, Property 9: S3 image load round trip**
+    - **Validates: Requirements 6.2**
+    - Hypothesis over bucket/key names and image arrays; injected fake S3 client serving PNG bytes records the requested bucket/key; `load_image("s3://...", s3_client=fake)` returns an equal array and requested exactly that bucket and key
+
+  - [x] 4.5 Write property test for load_image failure identification
+    - **Feature: custom-python-frames, Property 10: load_image failures identify the source**
+    - **Validates: Requirements 6.4**
+    - Hypothesis over missing paths, malformed `s3://` URIs, raising fake clients, and non-image byte content; every case raises `ValueError` whose message contains the source
+
+- [x] 5. Implement the runner contract changes (edge)
+  - [x] 5.1 Extend `RUNNER_SOURCE` with helpers injection, pre-imports, entry-point dispatch, and the process_frame path
+    - In `src/backend/workflow_engine/python_bridge.py` `RUNNER_SOURCE` (assembled with `HELPERS_SOURCE`): register `dda_frames` in `sys.modules` before the handler loads; best-effort bind `cv2`, `np`, and `numpy` on the handler module before `exec_module` (import failures leave the binding absent); resolve the entry point after `exec_module` — `process_frame` preferred, `handle` fallback, neither → error naming both entry points reported through the existing `status: error` path
+    - Per frame: merge `{"frame": {"width", "height", "format"}}` into the metadata dict and set the `dda_frames` per-invocation context (cleared in `finally`); for `process_frame`: unsupported/missing format or unimportable numpy → descriptive error; convert bytes via `to_array`; `None` return → emit input bytes; matching shape/dtype array → write rows back into a `bytearray` copy of the input at the original stride (byte length preserved); any other return → error describing expected vs. actual shape/dtype; for `handle`: existing raw-bytes behavior unchanged apart from the enriched metadata
+    - No changes to the framed protocol, the bridge (parent) class, `rewrite_document`, or `run_bridged_pipeline`
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.1, 4.2, 4.3, 4.4, 5.1, 5.6_
+
+  - [x] 5.2 Write property test for the process_frame contract round trip
+    - **Feature: custom-python-frames, Property 4: process_frame contract round trip**
+    - **Validates: Requirements 3.1, 3.2, 3.3**
+    - Hypothesis over dims × formats × pixels × padding through a real `CustomPythonBridge.process_frame`: an identity handler asserts received shape/dtype and output bytes equal input bytes; a None-returning handler passes bytes through; a `bitwise inversion` handler inverts pixel regions while padding bytes and byte length are preserved
+
+  - [x] 5.3 Write property test for process_frame contract violations
+    - **Feature: custom-python-frames, Property 5: process_frame contract violations fail the node identifiably**
+    - **Validates: Requirements 3.4, 3.5**
+    - Hypothesis over frames and violation kinds (wrong-shape array, wrong-dtype array, non-array return, unsupported Pixel_Format input); each raises `CustomPythonNodeError` carrying the node id and a message describing the mismatch or format
+
+  - [x] 5.4 Write property test for frame info delivery
+    - **Feature: custom-python-frames, Property 6: Frame info delivery**
+    - **Validates: Requirements 3.9, 5.6**
+    - Hypothesis over (width, height, format); a handler returning `metadata["frame"]` and `dda_frames.frame_info()` through its response metadata; both equal the dispatched caps triple
+
+  - [x] 5.5 Write property test for legacy handle contract preservation
+    - **Feature: custom-python-frames, Property 2: Legacy handle contract is preserved**
+    - **Validates: Requirements 3.6, 3.9**
+    - Hypothesis over frame bytes and metadata dicts; a `handle`-only handler receives the bytes unchanged and metadata enriched with the `frame` key, and its returned `(frame_bytes, metadata)` round-trips to the bridge caller; the existing `test_workflow_python_bridge.py` suite passes unchanged
+
+- [x] 6. Edge example tests and vendored mirror sync
+  - [x] 6.1 Write example tests for dispatch, pre-imports, and library imports
+    - In `test/backend-test/workflow_engine/test_workflow_python_bridge.py` (or a sibling module): both entry points defined → `process_frame` output wins; neither defined → `CustomPythonNodeError` naming `process_frame` and `handle`; handler using `cv2` and `np` without import statements processes successfully; handler importing a stdlib module and a sibling module shipped beside `handler.py` succeeds; a subprocess where `cv2` import is blocked (import-raising stub on `PYTHONPATH`) still runs a `handle`-only handler; `import dda_frames` succeeds with only `handler.py` shipped
+    - _Requirements: 3.7, 3.8, 4.1, 4.2, 4.3, 4.4, 4.5, 5.1, 5.7_
+
+  - [x] 6.2 Write example test for load_image failure containment through the bridge
+    - A handler calling `dda_frames.load_image` on a missing path raises through the bridge as `CustomPythonNodeError` carrying the node id and the source in its message
+    - _Requirements: 6.5_
+
+  - [x] 6.3 Sync the vendored workflow_core mirror and add the byte-equality smoke test
+    - Copy the changed catalog file to `src/backend/workflow_engine/vendor/workflow_core/catalog/nodes.py` so the mirror is byte-identical to the portal layer copy; add a smoke test in `test/backend-test/workflow_engine/` asserting byte equality of the two `nodes.py` files
+    - _Requirements: 1.6, 3.10_
+
+- [x] 7. Frontend designer coverage (no production code changes)
+  - [x] 7.1 Write example tests for palette, code editor, and inline marker
+    - `NodePalette.test.tsx`: catalog fixture including the `custom_python_preprocess` descriptor renders it in the Preprocessing section; `NodeConfigPanel.test.tsx`: selecting the node renders the code editor for the `code` parameter; `inlineChecks.test.ts`: a node instance without `code` yields a required-parameter marker
+    - _Requirements: 7.1, 7.2, 7.4_
+
+  - [x] 7.2 Write property test for connection acceptance with fixed VideoFrames ports
+    - **Feature: custom-python-frames, Property 11: Designer connection acceptance for fixed VideoFrames ports**
+    - **Validates: Requirements 7.3**
+    - Extend `connectionAcceptance.property.test.ts`'s fast-check domain with a fixed-VideoFrames-port descriptor shape (no port type override parameters); acceptance exactly when the source output port type is VideoFrames, rejection carries a reason otherwise
+
+- [x] 8. Final checkpoint — all suites pass
+  - Run the portal backend suites (`edge-cv-portal/backend/tests`, `edge-cv-portal/backend/layers/workflow_core/tests`), the frontend suite (`npx vitest run` in `edge-cv-portal/frontend`) plus `npm run build`, and the edge suites (`PYTHONPATH=src/backend:test/backend-test pytest test/backend-test/workflow_engine/`); ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- No compiler, serializer, schema, or frontend production-code changes are required: the compiler already derives `python_handler_path` per node, the workflow definition schema stores node `type` as an open string, and the designer UI (palette grouping, code editor, connection acceptance, inline markers) is generic over the catalog descriptor.
+- The framed stdin/stdout protocol and the bridge (parent) class are unchanged — all runtime additions live in `RUNNER_SOURCE`/`HELPERS_SOURCE`, so already-deployed workflow artifacts gain the new contract when LocalServer updates.
+- Property tests inherit iteration counts from each suite's hypothesis/fast-check profile (CI profile ≥100 iterations); no `max_examples` hardcoding.
+- Edge test runs are scoped to `test/backend-test/workflow_engine/` — the broader edge suite has pre-existing environment-dependent failures on this host.
+- Checkpoints (tasks 3 and 8) validate incrementally; each task references the granular requirements it implements for traceability.

--- a/.kiro/specs/workflow-designer-bugfixes/.config.kiro
+++ b/.kiro/specs/workflow-designer-bugfixes/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "274a7fd2-6800-4369-b820-3d849778d9f4", "workflowType": "requirements-first", "specType": "bugfix"}

--- a/.kiro/specs/workflow-designer-bugfixes/bugfix.md
+++ b/.kiro/specs/workflow-designer-bugfixes/bugfix.md
@@ -1,0 +1,93 @@
+# Bugfix Requirements Document
+
+## Introduction
+
+This spec covers three distinct bugs reported in the edge-cv-portal workflow/node designer:
+
+1. **Generate-workflow temperature handling**: The Bedrock invocations behind workflow generation (`workflow_generator.py`) and node generation (`node_generator.py`, which reuses `get_bedrock_configuration()`) always send a sampling temperature because `DEFAULT_BEDROCK_CONFIG` bakes in `temperature: 0.2`. Newer Anthropic models (e.g. Opus 4.x-class models) reject requests that set temperature at all, failing generation with a "deprecated parameter" style `BEDROCK_INVOCATION_FAILED` error. When no explicit temperature value has been configured by an admin or provided per-request, the temperature parameter must be omitted from the invocation entirely. The PortalAdmin Bedrock settings form (`BedrockConfigurationSettings.tsx`) and its backend validation (`data_accounts.py`) currently refuse a blank temperature, so an admin cannot even unset it.
+
+2. **Input-type custom nodes carry a default input port**: The node-designer create and registration wizards (`CreateWizard.tsx`, `RegistrationWizard.tsx`) seed the port declaration with one input port ("in") and one output port ("out") regardless of the selected palette category. When the category is `input` (a source node), the wizard still presents an input port — contradicting the wizard's own Port_Guidance ("Input nodes typically declare no inputs and one VideoFrames output") and leaving users unable to tell what is actually required for inputs vs outputs per node kind.
+
+3. **Node import selects every plugin by default**: In the import flow (`ImportView.tsx`), when an official module's individual plugin list loads, every plugin is checked by default (`setSelectedModulePlugins(allPluginNames(plugins))`). The user must uncheck everything they do not want instead of opting in to what to import.
+
+## Bug Analysis
+
+### Current Behavior (Defect)
+
+**Bug 1 — Temperature always sent to Bedrock**
+
+1.1 WHEN a workflow generation is invoked and no temperature has been explicitly configured in the portal Bedrock settings and no per-request temperature override is given THEN the system sends the default temperature 0.2 in the Bedrock inference configuration, and models that reject the temperature parameter fail the generation with a deprecated-parameter invocation error
+
+1.2 WHEN a node (plugin scaffold) generation is invoked and no temperature has been explicitly configured and no override is given THEN the system sends the default temperature 0.2 in the Bedrock inference configuration, failing on models that reject the temperature parameter
+
+1.3 WHEN a PortalAdmin clears the Temperature field in the Bedrock configuration settings form THEN the system rejects the save with "Temperature must be between 0 and 1", so the configured temperature cannot be unset
+
+**Bug 2 — Input-category nodes presented with an input port**
+
+1.4 WHEN a user creates or registers a custom node and selects the `input` palette category THEN the system keeps presenting the default input port row ("in"), implying an input port is expected for a source node
+
+1.5 WHEN a user selects a palette category in either wizard THEN the system leaves the untouched default port rows (one "in" input, one "out" output) unchanged, so the presented ports contradict the category's typical arrangement and the user cannot tell what is required for inputs and outputs per node kind
+
+**Bug 3 — Module import checks all plugins by default**
+
+1.6 WHEN an official module's plugin list loads during node import THEN the system checks every enumerated plugin by default, requiring the user to uncheck unwanted plugins instead of opting in
+
+### Expected Behavior (Correct)
+
+**Bug 1 — Omit temperature when no value is given**
+
+2.1 WHEN a workflow generation is invoked and no temperature has been explicitly configured in the portal Bedrock settings and no per-request temperature override is given THEN the system SHALL omit the temperature parameter entirely from the Bedrock inference configuration
+
+2.2 WHEN a node (plugin scaffold) generation is invoked and no temperature has been explicitly configured and no override is given THEN the system SHALL omit the temperature parameter entirely from the Bedrock inference configuration
+
+2.3 WHEN a PortalAdmin clears the Temperature field in the Bedrock configuration settings form and saves THEN the system SHALL accept the save and store the temperature as unset, meaning no temperature is sent at invocation
+
+**Bug 2 — Port defaults and requirements follow the node kind**
+
+2.4 WHEN a user selects the `input` palette category in either wizard and the port rows are still the untouched defaults THEN the system SHALL present no input port rows (and one VideoFrames output), matching the category's typical arrangement
+
+2.5 WHEN a user selects any palette category in either wizard and the port rows are still the untouched defaults THEN the system SHALL adjust the default port rows to that category's typical arrangement, so the presented inputs and outputs reflect what the node kind requires
+
+2.6 WHEN a user views the ports step for a selected category THEN the system SHALL clearly state what is required for inputs and outputs for that node kind (e.g. input nodes: no inputs, one output; output nodes: at least one input, no outputs)
+
+**Bug 3 — Import selection is opt-in**
+
+2.7 WHEN an official module's plugin list loads during node import THEN the system SHALL check no plugins by default, so the user explicitly opts in to what to import
+
+2.8 WHEN the module plugin list is available and the user has selected no plugins THEN the system SHALL require an explicit selection (individual checks or "Select all") before the import proceeds, instead of silently importing the whole module
+
+### Unchanged Behavior (Regression Prevention)
+
+**Bug 1**
+
+3.1 WHEN a temperature has been explicitly configured in the portal Bedrock settings THEN the system SHALL CONTINUE TO send that temperature in the Bedrock inference configuration
+
+3.2 WHEN a valid per-request temperature override (a number in [0, 1]) is supplied to POST /workflows/generate THEN the system SHALL CONTINUE TO send that temperature for that invocation, suppressing top_p
+
+3.3 WHEN an out-of-range or non-numeric per-request temperature is supplied THEN the system SHALL CONTINUE TO reject the request with 400 INVALID_TEMPERATURE
+
+3.4 WHEN both a temperature and a top_p would apply to an invocation THEN the system SHALL CONTINUE TO never send temperature and top_p together (temperature wins when set; top_p is sent only when temperature is explicitly configured as null with a configured top_p)
+
+3.5 WHEN the GenerateChatPanel temperature field is left blank THEN the system SHALL CONTINUE TO omit the temperature key from the generate request payload
+
+**Bug 2**
+
+3.6 WHEN a user has edited the port rows (renamed, retyped, added, or removed any port) and then changes the palette category THEN the system SHALL CONTINUE TO preserve the user-edited port rows without rewriting them
+
+3.7 WHEN a non-input palette category (preprocessing, inference, post_processing, output) is selected THEN the system SHALL CONTINUE TO present that category's expected input and output ports per its typical arrangement
+
+3.8 WHEN a user declares any valid port arrangement, including one diverging from the category's typical arrangement THEN the system SHALL CONTINUE TO accept the declaration (guidance stays advisory, non-blocking)
+
+3.9 WHEN the declared ports diverge from the selected category's typical arrangement THEN the system SHALL CONTINUE TO show the dismissable Port_Guidance divergence advisory
+
+3.10 WHEN a Port_Scan is applied over untouched default port rows THEN the system SHALL CONTINUE TO replace the defaults with the pad-derived suggestions, and over user-edited rows SHALL CONTINUE TO merge additively
+
+**Bug 3**
+
+3.11 WHEN the user checks individual plugins from the module plugin list THEN the system SHALL CONTINUE TO import exactly the selected subset (recorded as selected_plugins)
+
+3.12 WHEN the user selects every plugin (e.g. via "Select all") THEN the system SHALL CONTINUE TO import the whole module (a full selection serializes to no selected_plugins parameter, today's whole-module behavior)
+
+3.13 WHEN the module plugin list fails to load THEN the system SHALL CONTINUE TO proceed with the whole-module import as a non-blocking fallback
+
+3.14 WHEN a plugin-set import lands in pending_selection THEN the system SHALL CONTINUE TO default that selection dialog to no plugins selected and require at least one plugin before submission

--- a/.kiro/specs/workflow-designer-bugfixes/design.md
+++ b/.kiro/specs/workflow-designer-bugfixes/design.md
@@ -1,0 +1,343 @@
+# Workflow Designer Bugfixes Design
+
+## Overview
+
+This design covers three independent bugs in the edge-cv-portal, fixed together under one spec because they were reported together and each is small and well-isolated:
+
+1. **Bug 1 — Temperature always sent to Bedrock**: `DEFAULT_BEDROCK_CONFIG` in `workflow_generator.py` (mirrored in `data_accounts.py`) bakes in `temperature: 0.2` and `top_p: 0.9`. When an admin has never configured a temperature and no per-request override is given, the fallback default is sent to the Bedrock Converse API, and newer Anthropic models that reject the temperature parameter fail generation with `BEDROCK_INVOCATION_FAILED`. Additionally the settings form (`BedrockConfigurationSettings.tsx`) and backend validation (`validate_bedrock_configuration` in `data_accounts.py`) refuse a blank temperature, so the parameter cannot even be unset. The fix makes "unset" the default (no sampling parameter sent unless explicitly configured or overridden) and makes blank/unset a valid stored state end to end.
+
+2. **Bug 2 — Default ports ignore the palette category**: `CreateWizard.tsx` and `RegistrationWizard.tsx` seed the port declaration with one input ("in") and one output ("out") regardless of the selected palette category, so an `input` (source) node is presented with an input port, contradicting the wizard's own Port_Guidance. The fix derives the default port rows from the selected category's typical arrangement (`CATEGORY_ARRANGEMENTS` in `portGuidance.ts`), rewrites untouched default rows when the category changes, and states each kind's input/output requirements on the ports step — while preserving user-edited rows and keeping the guidance advisory.
+
+3. **Bug 3 — Module import selects every plugin by default**: `ImportView.tsx` seeds the module plugin selection with `allPluginNames(plugins)`, so the user must opt out instead of opting in. The fix seeds the selection empty and relies on the already-existing selection gate (`moduleSelectionIncomplete` blocks `formComplete`) so an explicit selection (individual checks or "Select all") is required before the import proceeds. Serialization semantics are untouched: a full selection still serializes to no `selected_plugins` parameter (whole module).
+
+All backend invocation-path logic (`invoke_generation` in both generators) already omits `None` sampling parameters, so Bug 1 is primarily a defaults/validation/settings-round-trip fix, not an invocation-logic fix.
+
+## Glossary
+
+- **Bug_Condition (C)**: The condition under which a bug manifests. Each of the three bugs has its own condition, formalized below (`isBugCondition1/2/3`).
+- **Property (P)**: The desired behavior for inputs where the bug condition holds, formalized in the Correctness Properties section.
+- **Preservation**: Behavior for all inputs where the bug condition does NOT hold, which must be byte-for-byte identical before and after the fix (F(X) = F'(X)).
+- **Bedrock_Configuration**: The settings-table item `{setting_key: 'bedrock_configuration', value: {model_id, region, max_tokens, temperature, top_p, timeout_seconds}}`, written by `data_accounts.update_bedrock_configuration_setting()` and read by `workflow_generator.get_bedrock_configuration()` (reused by `node_generator.py`).
+- **DEFAULT_BEDROCK_CONFIG**: The fallback configuration constant, duplicated (deliberately mirrored) in `edge-cv-portal/backend/functions/workflow_generator.py` and `edge-cv-portal/backend/functions/data_accounts.py`.
+- **inference_config**: The `inferenceConfig` dict passed to `bedrock-runtime.converse()` by `invoke_generation()` in `workflow_generator.py` and `node_generator.py`: `{maxTokens}` plus at most one of `temperature` / `topP`.
+- **Untouched_Defaults**: Port rows exactly equal to the wizard-seeded defaults, never renamed, retyped, added to, or removed from. Today detected by `portScan.isUntouchedDefaults()` as exactly one "in" input + one "out" output, both VideoFrames; generalized by this fix to "the default arrangement of any palette category".
+- **CATEGORY_ARRANGEMENTS**: The per-category typical port arrangement data in `edge-cv-portal/frontend/src/pages/node-designer/portGuidance.ts` (input: no inputs + one VideoFrames output; preprocessing: VideoFrames→VideoFrames; inference: VideoFrames→InferenceMeta; post_processing: InferenceMeta→EventSignal; output: at-least-one input + no outputs).
+- **Port_Scan**: The pad-derived port pre-population in the Registration wizard (`portScan.ts`): suggestions replace Untouched_Defaults wholesale, otherwise merge additively.
+- **Module plugin selection**: The checkbox list in `ImportView.tsx` over `GET /plugin-modules?module=<name>` results; serialized by `selectedPluginsParam()` in `importFlow.ts` (full/empty selection → `undefined` → whole-module import).
+
+## Bug Details
+
+### Bug 1 — Temperature omitted when unset
+
+#### Bug Condition
+
+The bug manifests on any workflow or node generation where no temperature was explicitly stored in the Bedrock settings and no per-request override is supplied: `get_bedrock_configuration()` falls back to `DEFAULT_BEDROCK_CONFIG['temperature'] = 0.2`, so `invoke_generation()` always puts `temperature` into the inference config. It also manifests in the settings path: a PortalAdmin clearing the Temperature field is rejected client-side (`validate()` in `BedrockConfigurationSettings.tsx`: `form.temperature.trim() === ''` → error) and server-side (`validate_bedrock_configuration()`: `not _is_number(temperature)` → error).
+
+**Formal Specification:**
+```
+FUNCTION isBugCondition1(input)
+  INPUT: input of type GenerationRequest | SettingsSave
+  OUTPUT: boolean
+
+  IF input is GenerationRequest THEN
+    RETURN storedBedrockConfig.temperature is ABSENT   // never configured
+           AND input.temperature_override is ABSENT
+    // buggy result: inference_config contains temperature = 0.2
+  ELSE  // SettingsSave
+    RETURN input.temperature_field is BLANK
+    // buggy result: save rejected with "Temperature must be between 0 and 1"
+  END IF
+END FUNCTION
+```
+
+#### Examples
+
+- No Bedrock configuration was ever stored; a user prompts the workflow generator against an Opus 4.x-class model. Expected: invocation succeeds with no `temperature` in `inferenceConfig`. Actual: `inferenceConfig = {maxTokens: 4096, temperature: 0.2}` and the model rejects the request (`BEDROCK_INVOCATION_FAILED`, deprecated-parameter style error).
+- Same store state, node scaffold generation (`node_generator.py` calls `get_bedrock_configuration()` and its own identical `invoke_generation` inference-config logic). Same failure.
+- A PortalAdmin opens the Bedrock settings, clears the Temperature input, saves. Expected: save accepted, temperature stored unset. Actual: client validation error "Temperature must be between 0 and 1"; even bypassing the client, the backend returns 400 "temperature must be a number between 0 and 1".
+- Edge case: existing test `test_default_configuration_sends_temperature_without_top_p` in `edge-cv-portal/backend/tests/test_workflow_generation.py` codifies the buggy behavior (`assert inference_config["temperature"] == 0.2`) and must be inverted by the fix.
+
+### Bug 2 — Input-kind nodes and port defaults
+
+#### Bug Condition
+
+The bug manifests whenever a wizard's port rows are still the seeded defaults (`inputs: [{name: 'in', portType: 'VideoFrames'}]`, `outputs: [{name: 'out', portType: 'VideoFrames'}]` from `initialForm()` in `CreateWizard.tsx` and the detail-load seeding in `RegistrationWizard.tsx`) and the selected palette category's typical arrangement differs from those defaults. Selecting a category only patches `form.category`; the port rows never change.
+
+**Formal Specification:**
+```
+FUNCTION isBugCondition2(input)
+  INPUT: input of type WizardState  // {category, inputs, outputs, portRowsUntouched}
+  OUTPUT: boolean
+
+  RETURN input.portRowsUntouched                        // defaults never edited
+         AND arrangementOf(input.category) != multiset(input.inputs, input.outputs)
+  // buggy result: presented rows stay one "in" input + one "out" output
+  //               instead of the category's typical arrangement
+END FUNCTION
+```
+
+#### Examples
+
+- User selects category `input` in the Create wizard without touching the ports step. Expected: no input port rows, one VideoFrames output. Actual: an "in" input row is presented, contradicting the guidance text "Input nodes typically declare no inputs and one VideoFrames output" rendered by `PortGuidancePanel` directly above it.
+- User selects `inference`. Expected default: one VideoFrames input, one InferenceMeta output. Actual: both ports VideoFrames.
+- User selects `output`. Expected default: at least one input (default one VideoFrames input), no outputs. Actual: an "out" output row is presented.
+- Edge case: user selects `preprocessing` (the initial category). The current defaults happen to equal the preprocessing arrangement, so no visible defect — the fixed defaults must be identical to today's for this category.
+- Edge case: user renames "in" to "video", then changes category. Rows are user-edited; they must be preserved exactly (this already works today and must continue).
+
+### Bug 3 — Import default selection
+
+#### Bug Condition
+
+The bug manifests whenever an official module's plugin list loads in `ImportView.tsx`: the load effect runs `setSelectedModulePlugins(allPluginNames(plugins))`, so every plugin is checked and `formComplete` is immediately true — the import can proceed with zero explicit user selection. Note the serialization subtlety: a full selection and an empty selection both serialize to `selected_plugins = undefined` (whole module) via `selectedPluginsParam()`, so "default all" and "default none without a gate" are behaviorally identical on the wire; the required behavior is default none **plus** the explicit selection gate.
+
+**Formal Specification:**
+```
+FUNCTION isBugCondition3(input)
+  INPUT: input of type ModulePluginListLoad  // non-empty plugin list for the chosen module
+  OUTPUT: boolean
+
+  RETURN input.plugins.length > 0
+  // buggy result: selectedModulePlugins = allPluginNames(input.plugins)
+  //               (every plugin checked; import proceeds with no explicit opt-in)
+END FUNCTION
+```
+
+#### Examples
+
+- User picks `gst-plugins-good` (74 plugins enumerated). Expected: 0 of 74 selected, import blocked until the user checks plugins or clicks "Select all". Actual: 74 of 74 selected, import proceeds immediately as a whole-module import.
+- Edge case: the module plugin list fails to load (`isModuleListingUnavailable`) or is empty. `modulePluginNames.length > 0` is false, so no selection gate applies and the whole-module import proceeds — this fallback must be preserved.
+- Edge case: the `pending_selection` dialog (post-fetch plugin-set selection) already defaults to no selection and requires at least one plugin (`pluginSelectionError`); it is unaffected and must stay that way.
+
+## Expected Behavior
+
+### Preservation Requirements
+
+**Unchanged Behaviors — Bug 1:**
+- An explicitly stored temperature keeps being sent (`inferenceConfig.temperature`), with `topP` suppressed (Req 3.1, 3.4).
+- A valid per-request override (number in [0, 1], booleans excluded) keeps replacing the configured temperature for that invocation only and suppresses `topP` (Req 3.2).
+- Invalid overrides keep rejecting with 400 `INVALID_TEMPERATURE` before any Bedrock call (Req 3.3).
+- `temperature` and `topP` are never sent together; `topP` is sent only when no temperature applies and a top_p is explicitly configured (Req 3.4). Note: after the fix, "never configured" and "explicitly configured as null" both resolve to `temperature = None` in the effective config — both mean "omit temperature", and `topP` flows exactly when a top_p was explicitly stored. This is intentional: the fixed defaults make the two states indistinguishable, and the pre-fix distinction only existed because the buggy 0.2 default masked the unset state.
+- `GenerateChatPanel.tsx` blank-field behavior: a blank temperature input keeps omitting the `temperature` key from the request payload entirely (Req 3.5) — this code is already correct and is not modified.
+- All other Bedrock_Configuration validation rules (model_id, region, max_tokens, timeout clamp ≤ 60 s) and the stored item shape are unchanged.
+
+**Unchanged Behaviors — Bug 2:**
+- User-edited port rows (any rename, retype, addition, removal) survive category changes untouched (Req 3.6).
+- Non-input categories keep presenting their typical arrangements (Req 3.7) — for `preprocessing` the fixed defaults are byte-identical to today's seeds.
+- Any valid port arrangement remains accepted; guidance stays advisory and never gates the wizard (`portsStepErrors` unchanged) (Req 3.8).
+- The dismissable divergence advisory (`guidanceDivergence` + `PortGuidancePanel` alert) keeps firing exactly as before (Req 3.9).
+- Port_Scan semantics: suggestions replace Untouched_Defaults wholesale and merge additively over user-edited rows (Req 3.10). `isUntouchedDefaults` is generalized (see Fix Implementation) so the new category-shaped defaults still count as untouched.
+
+**Unchanged Behaviors — Bug 3:**
+- A checked subset imports exactly that subset (`selected_plugins` recorded) (Req 3.11).
+- Selecting every plugin ("Select all") serializes to no `selected_plugins` parameter — whole-module import, today's wire behavior exactly (Req 3.12); `selectedPluginsParam()` is not modified.
+- Listing-unavailable / empty-list whole-module fallback is non-blocking (Req 3.13); the gate only applies when `modulePluginNames.length > 0`.
+- The `pending_selection` dialog keeps defaulting to no selection with `pluginSelectionError` requiring at least one plugin (Req 3.14); untouched by this fix.
+
+**Scope:**
+All inputs outside the three bug conditions are completely unaffected:
+- Bug 1: any invocation where a temperature applies (stored or overridden), any settings save with a numeric temperature, all non-temperature settings fields, GenerateChatPanel behavior.
+- Bug 2: any wizard interaction after the user edits port rows; every step other than Ports; the divergence alert and Port_Scan behavior over edited rows.
+- Bug 3: manual repository URL imports, the pending_selection dialog, classification/acknowledgment/architecture logic, all `importFlow.ts` helpers.
+
+## Hypothesized Root Cause
+
+These are confirmed root causes — all three were located by reading the code:
+
+1. **Bug 1 — a fallback default that should be "unset" is a concrete value**:
+   - `workflow_generator.DEFAULT_BEDROCK_CONFIG` (line ~125) and its mirror `data_accounts.DEFAULT_BEDROCK_CONFIG` (line ~91) carry `'temperature': 0.2, 'top_p': 0.9`. `get_bedrock_configuration()` starts from `dict(DEFAULT_BEDROCK_CONFIG)`, so with nothing stored the effective temperature is 0.2 and `invoke_generation()` (both generators, logic `if temperature is not None: send it`) sends it.
+   - Downstream, the invocation logic is already correct for `None` — the null-carrying merge in `workflow_generator.get_bedrock_configuration()` (`if key in stored` for temperature/top_p) proves unset was anticipated but the defaults never allowed it to occur without an explicit stored null.
+   - `data_accounts.validate_bedrock_configuration()` requires temperature (and top_p) to be numbers, and `read_stored_bedrock_configuration()` uses `if stored.get(key) is not None` for every key, so a stored null would be hidden behind the 0.2 default on read — the settings API can neither store nor faithfully report "unset".
+   - `BedrockConfigurationSettings.tsx` `validate()` rejects a blank temperature/top_p field, and the loader does `String(config.temperature)` which would render a null as the literal string "null".
+
+2. **Bug 2 — static seeds with no category linkage**: `initialForm()` in `CreateWizard.tsx` and the detail-load form seed in `RegistrationWizard.tsx` hard-code `inputs: [{...emptyPort(), name: 'in'}], outputs: [{...emptyPort(), name: 'out'}]`. The category `Select.onChange` handlers patch only `category`. `CATEGORY_ARRANGEMENTS` already encodes the correct per-category arrangements but is used solely for display/divergence, never for seeding.
+
+3. **Bug 3 — deliberate default-all seeding**: the module plugin load effect in `ImportView.tsx` (line ~258, comment "Default: ALL plugins selected (whole-module import)") seeds the full list. The selection gate infrastructure (`moduleSelectionIncomplete` → `formComplete`, plus the `errorText` on the checkbox FormField) already exists but never triggers because the selection is never empty on load.
+
+## Correctness Properties
+
+Property 1: Bug Condition — Temperature omitted when unset
+
+_For any_ Bedrock configuration store state in which no temperature value was explicitly stored (nothing stored at all, a stored item without the temperature key, or a stored null) and any generation request without a temperature override, the fixed `get_bedrock_configuration()` + `invoke_generation()` pipeline (workflow and node generators alike) SHALL produce an `inferenceConfig` containing no `temperature` key — and no `topP` key unless a top_p was explicitly stored; and _for any_ settings save with a blank/null temperature (or top_p), the fixed validation SHALL accept the save and store the parameter as unset, round-tripping as unset through GET and the settings form.
+
+**Validates: Requirements 2.1, 2.2, 2.3**
+
+Property 2: Preservation — Explicit temperature behavior unchanged
+
+_For any_ input where the bug condition does NOT hold — a temperature explicitly stored as a number in [0, 1], or a per-request override supplied — the fixed pipeline SHALL produce exactly the same result as the original: the applicable temperature sent as `inferenceConfig.temperature` with `topP` suppressed; invalid overrides (out of range, non-numeric, boolean) rejected with 400 `INVALID_TEMPERATURE` before any Bedrock call; `temperature` and `topP` never sent together; a blank GenerateChatPanel field omitting the `temperature` key from the request payload; and all non-temperature settings validation rules unchanged.
+
+**Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5**
+
+Property 3: Bug Condition — Default ports follow the selected category
+
+_For any_ palette category in `CATEGORY_ARRANGEMENTS` selected in either wizard while the port rows are Untouched_Defaults (equal to the default arrangement of any category), the fixed wizards SHALL present default port rows whose port-type multisets exactly match that category's typical arrangement (in particular: category `input` → zero input rows and one VideoFrames output; `output` → one input row and zero outputs), every seeded row SHALL carry a non-empty name (so `portsStepErrors` stays clean), `guidanceDivergence(category, inputs, outputs)` SHALL be null for the seeded rows, and the ports step SHALL state that category's input/output requirements.
+
+**Validates: Requirements 2.4, 2.5, 2.6**
+
+Property 4: Preservation — Edited rows, advisory guidance, and Port_Scan unchanged
+
+_For any_ port rows that are NOT Untouched_Defaults (any rename, retype, addition, or removal), the fixed wizards SHALL leave the rows exactly unchanged across any sequence of category changes; `guidanceDivergence` and `portsStepErrors` SHALL answer identically to the original for all inputs; guidance SHALL remain non-blocking; and `applySuggestions` SHALL preserve its replace-over-untouched-defaults / merge-over-edited semantics, with the generalized untouched detection answering true for exactly the per-category default arrangements (including today's in/out pair, which equals the preprocessing defaults).
+
+**Validates: Requirements 3.6, 3.7, 3.8, 3.9, 3.10**
+
+Property 5: Bug Condition — Import selection defaults to none with an explicit gate
+
+_For any_ non-empty module plugin list loading in the import view (including after switching modules), the fixed view SHALL seed the selection empty (0 of N selected) and SHALL keep the import blocked (`formComplete` false, gate message shown) until the user explicitly selects at least one plugin individually or via "Select all".
+
+**Validates: Requirements 2.7, 2.8**
+
+Property 6: Preservation — Import serialization and fallbacks unchanged
+
+_For any_ selection state, the fixed view SHALL serialize exactly as the original: a proper subset serializes to that subset as `selected_plugins`; a full selection (or, when no list is available, no selection) serializes to no `selected_plugins` parameter (whole-module import); an unavailable or empty plugin list SHALL never block the import; and the post-fetch `pending_selection` dialog SHALL keep its default-none, at-least-one-required behavior.
+
+**Validates: Requirements 3.11, 3.12, 3.13, 3.14**
+
+## Fix Implementation
+
+### Changes Required
+
+#### Bug 1 — Temperature omitted when unset
+
+**File**: `edge-cv-portal/backend/functions/workflow_generator.py`
+
+1. **`DEFAULT_BEDROCK_CONFIG`**: change `'temperature': 0.2` → `'temperature': None` and `'top_p': 0.9` → `'top_p': None`, updating the comment: unset by default; sampling parameters are sent only when explicitly configured (or overridden per-request). Both defaults must change together — leaving `top_p: 0.9` would start sending `topP` on every unconfigured invocation, violating Req 3.4 ("top_p only with an explicitly configured top_p") and re-introducing the same rejection risk.
+2. **No other changes**: `get_bedrock_configuration()` already carries stored nulls for temperature/top_p (`if key in stored`), and `invoke_generation()` already omits `None` values. The temperature-override path in `generate_workflow()` is untouched.
+
+**File**: `edge-cv-portal/backend/functions/node_generator.py`
+
+3. **No changes**: it imports `get_bedrock_configuration` from `workflow_generator` and its `invoke_generation` already omits `None`. Fixed transitively; covered by tests.
+
+**File**: `edge-cv-portal/backend/functions/data_accounts.py`
+
+4. **`DEFAULT_BEDROCK_CONFIG` mirror**: same change as (1) — the two constants must stay identical ("Must mirror workflow_generator.DEFAULT_BEDROCK_CONFIG").
+5. **`read_stored_bedrock_configuration()`**: special-case `temperature` / `top_p` exactly like `workflow_generator.get_bedrock_configuration()` does (`if key in stored: config[key] = stored[key]` instead of `if stored.get(key) is not None`), so a stored null reads back as unset rather than being replaced by the default.
+6. **`validate_bedrock_configuration()`**: accept `None` for `temperature` and `top_p` (`if temperature is not None and (not _is_number(temperature) or not (0 <= temperature <= 1))`). Numbers outside [0, 1] and non-numeric values keep rejecting. All other field validations unchanged.
+7. **`update_bedrock_configuration_setting()`**: no logic change needed — `if key in body: config[key] = body[key]` already carries an explicit JSON `null` through the merge, validation now accepts it, and the written `value` dict stores it as a DynamoDB null. Verify `_native_to_dynamo` passes `None` through (it converts floats to Decimal; `None` must survive).
+
+**File**: `edge-cv-portal/frontend/src/components/BedrockConfigurationSettings.tsx`
+
+8. **`validate()`**: blank temperature and blank top_p become valid (meaning "unset — omitted at invocation"); non-blank values keep requiring a number in [0, 1].
+9. **Load effect**: map a null/undefined `config.temperature` / `config.top_p` to `''` instead of `String(null)`.
+10. **`handleSave()`**: send `temperature: form.temperature.trim() === '' ? null : Number(form.temperature)` (same for `top_p`) — the explicit `null` is required because the backend merges provided keys over the current configuration, so omitting the key would keep the old value instead of unsetting it.
+11. **Constraint text**: Temperature / Top P fields note "0 to 1 — leave blank to let the model use its default (parameter is omitted)".
+
+**Existing tests to update**: `test_workflow_generation.py::test_default_configuration_sends_temperature_without_top_p` asserts the buggy `temperature == 0.2` default and becomes "default configuration sends no sampling parameters"; `test_bedrock_configuration.py` gains blank/null acceptance cases (its invalid-value rejections for 1.5 / -0.1 / non-numbers stay).
+
+#### Bug 2 — Category-driven default ports
+
+**File**: `edge-cv-portal/frontend/src/pages/node-designer/declaration.ts` (new pure helpers; alternatively `portGuidance.ts`, but `declaration.ts` owns `PortForm`)
+
+1. **`defaultPortsForCategory(category: string): { inputs: PortForm[]; outputs: PortForm[] }`**: derived from `CATEGORY_ARRANGEMENTS`:
+   - `input`: `inputs: []`, `outputs: [{name: 'out', portType: 'VideoFrames'}]`
+   - `preprocessing`: `[{name: 'in', portType: 'VideoFrames'}]` / `[{name: 'out', portType: 'VideoFrames'}]` (byte-identical to today's seeds)
+   - `inference`: `[{name: 'in', portType: 'VideoFrames'}]` / `[{name: 'out', portType: 'InferenceMeta'}]`
+   - `post_processing`: `[{name: 'in', portType: 'InferenceMeta'}]` / `[{name: 'out', portType: 'EventSignal'}]`
+   - `output` (`'at-least-one'`): `[{name: 'in', portType: 'VideoFrames'}]` / `[]` — one concrete VideoFrames input as the seeded representative of "at least one input of any type"
+   - unknown category: fall back to the preprocessing shape (today's seeds).
+   Every seeded row has a non-empty name so `portsStepErrors` never fires on defaults, and each concrete arrangement yields `guidanceDivergence === null` (the `output` seed satisfies `'at-least-one'`).
+2. **`isDefaultPortArrangement(inputs: PortForm[], outputs: PortForm[]): boolean`**: true exactly when the rows deep-equal `defaultPortsForCategory(c)` for some category `c`. This is the generalized Untouched_Defaults notion — any rename, retype, addition, or removal makes it false.
+
+**File**: `edge-cv-portal/frontend/src/pages/node-designer/portScan.ts`
+
+3. **`isUntouchedDefaults()`**: delegate to `isDefaultPortArrangement()` (import from `declaration.ts`; `portScan.ts` already imports `PortForm` from there). Today's in/out pair equals the preprocessing defaults, so all current true-cases stay true; the new category defaults additionally count as untouched, keeping Port_Scan's replace-over-defaults semantics coherent with the new seeding (Req 3.10). `applySuggestions()` and `removalBlockReason()` are untouched.
+
+**File**: `edge-cv-portal/frontend/src/pages/node-designer/CreateWizard.tsx`
+
+4. **`initialForm()`**: seed `...defaultPortsForCategory('preprocessing')` instead of the hard-coded rows (no behavioral change for the initial state).
+5. **Palette category `Select.onChange`**: when `isDefaultPortArrangement(form.inputs, form.outputs)` is true, patch `{category, ...defaultPortsForCategory(newCategory)}`; otherwise patch `{category}` only (Req 2.5, 3.6).
+
+**File**: `edge-cv-portal/frontend/src/pages/node-designer/RegistrationWizard.tsx`
+
+6. **Detail-load form seed** (line ~138): seed `...defaultPortsForCategory('preprocessing')`. When the wizard prefills from an existing registered declaration, those rows come from the declaration, not the seeds, and will not match a default arrangement unless coincidentally identical — accepted edge case, consistent with today's `isUntouchedDefaults` semantics.
+7. **Palette category `Select.onChange`**: same untouched-defaults rewrite as (5).
+
+**File**: `edge-cv-portal/frontend/src/pages/node-designer/portGuidance.ts` + `PortGuidancePanel.tsx`
+
+8. **Per-kind requirements statement (Req 2.6)**: add a pure `arrangementRequirements(category)` helper deriving explicit lines from `CATEGORY_ARRANGEMENTS` (e.g. input → "Inputs: none · Outputs: 1 × VideoFrames"; output → "Inputs: at least one (any port type) · Outputs: none") and render it in `PortGuidancePanel` under the existing arrangement summary, clearly labeled as the typical requirement per node kind. The panel stays purely advisory — no contribution to step gating (Req 3.8).
+
+#### Bug 3 — Opt-in import selection
+
+**File**: `edge-cv-portal/frontend/src/pages/node-designer/ImportView.tsx`
+
+1. **Module plugin load effect** (line ~258): `setSelectedModulePlugins([])` instead of `allPluginNames(plugins)`; update the comment ("Default: none selected — the user opts in explicitly"). The effect already resets the selection to `[]` on module change, so switching modules also lands on none-selected.
+2. **Checkbox FormField copy** (line ~859): description becomes opt-in wording, e.g. "Choose which of the module's plugins to import and build. No plugins are selected by default — select individual plugins or use Select all to import the whole module." The existing `errorText` ("Select at least one plugin to import") now shows on the pristine empty state and serves as the visible gate message (Req 2.8).
+3. **No other changes**: the gate (`moduleSelectionIncomplete` → `formComplete`), `selectedPluginsParam()`, `moduleSelectionSummary()`, "Select all"/"Clear" buttons, the listing-unavailable fallback, and the `pending_selection` dialog are all already correct and untouched.
+
+**File**: `edge-cv-portal/frontend/src/pages/node-designer/importFlow.ts`
+
+4. **Optional pure extraction for testability**: `moduleSelectionIncomplete(source, availableNames, selectedNames): boolean` mirroring the inline gate expression, used by the component and property-tested directly. (Small, safe refactor; the inline expression may alternatively stay and be covered by component tests.)
+
+## Testing Strategy
+
+### Validation Approach
+
+Two phases per bug: first run exploratory tests asserting the *correct* behavior against the UNFIXED code to surface counterexamples and confirm the root causes; then implement the fixes and verify fix checking (bug inputs now behave correctly) and preservation checking (non-bug inputs unchanged, F(X) = F'(X)). Backend property tests use **hypothesis** (established convention: `edge-cv-portal/backend/tests/test_property_*.py`, fixtures in `tests/conftest.py` with moto/mocked Bedrock clients as in `test_workflow_generation.py`). Frontend property tests use **fast-check + vitest** (already a devDependency; component behavior via the existing React Testing Library patterns, e.g. `GenerateChatPanel.test.tsx`).
+
+### Exploratory Bug Condition Checking
+
+**Goal**: Surface counterexamples demonstrating each bug BEFORE fixing, confirming the root cause analysis (all three are already confirmed by code reading; the exploratory runs document the failures).
+
+**Test Plan**: Write the fix-checking tests below and run them on the unfixed code.
+
+**Test Cases**:
+1. **Unset temperature omitted (backend)**: with an empty settings table, POST /workflows/generate and assert `converse` received no `temperature` in `inferenceConfig` (will fail on unfixed code: receives 0.2).
+2. **Node generator unset temperature**: same assertion through `node_generator`'s generation turn (will fail on unfixed code).
+3. **Blank temperature save**: PUT bedrock-configuration with `{"temperature": null}` expecting 200 (will fail on unfixed code: 400 validation error).
+4. **Input-category defaults (frontend)**: render CreateWizard, select category `input`, assert zero input rows and one VideoFrames output row (will fail on unfixed code: "in" row present).
+5. **Import default selection (frontend)**: render ImportView with a mocked module plugin list, assert 0 selected and import blocked (will fail on unfixed code: all selected, import enabled).
+
+**Expected Counterexamples**:
+- `inferenceConfig == {maxTokens: 4096, temperature: 0.2}` with nothing stored
+- 400 "temperature must be a number between 0 and 1" for a null temperature save
+- Untouched port rows `in/out` after selecting category `input`; `selectedModulePlugins.length === plugins.length` after list load
+
+### Fix Checking
+
+**Goal**: Verify that for all inputs where a bug condition holds, the fixed code produces the expected behavior.
+
+**Pseudocode:**
+```
+FOR ALL input WHERE isBugCondition1(input) OR isBugCondition2(input) OR isBugCondition3(input) DO
+  result := fixedSystem(input)
+  ASSERT expectedBehavior(result)   // Properties 1, 3, 5
+END FOR
+```
+
+### Preservation Checking
+
+**Goal**: Verify that for all inputs where no bug condition holds, the fixed code produces the same result as the original.
+
+**Pseudocode:**
+```
+FOR ALL input WHERE NOT (isBugCondition1(input) OR isBugCondition2(input) OR isBugCondition3(input)) DO
+  ASSERT originalSystem(input) = fixedSystem(input)   // Properties 2, 4, 6
+END FOR
+```
+
+**Testing Approach**: Property-based testing is recommended for preservation checking because:
+- It generates many test cases automatically across the input domain (arbitrary stored configs, arbitrary port-row edits, arbitrary plugin lists/selections)
+- It catches edge cases manual unit tests miss (temperature 0 vs None vs absent key; port rows coincidentally equal to another category's defaults; full-selection vs empty-selection serialization)
+- It provides strong guarantees that behavior is unchanged for all non-buggy inputs
+
+**Test Plan**: The original behavior for non-bug inputs is already pinned by existing suites — `test_workflow_generation.py` (explicit/override/null-temperature/top_p rules, INVALID_TEMPERATURE), `test_bedrock_configuration.py` (validation and item shape), `GenerateChatPanel.test.tsx` (blank-field omission), the portScan/portGuidance frontend tests, and `test_plugin_import_selection.py` / importFlow tests. Keeping those suites green (with the one inverted default-behavior test noted above) plus the new property tests constitutes preservation checking.
+
+**Test Cases**:
+1. **Explicit temperature preservation (hypothesis)**: for any stored temperature in [0, 1] and optional override, the fixed pipeline sends exactly the temperature the original rules dictate, `topP` suppressed.
+2. **Edited port rows preservation (fast-check)**: for any port rows not equal to any category's defaults and any category-change sequence, rows are returned unchanged.
+3. **Selection serialization preservation (fast-check)**: for any plugin list and selection, `selectedPluginsParam` answers as today (subset → subset; full/empty/unavailable → undefined).
+
+### Unit Tests
+
+- Backend (`edge-cv-portal/backend/tests`): default config omits both sampling parameters; stored-null temperature with stored top_p sends `topP` only; PUT accepts `{"temperature": null}` / `{"top_p": null}` and the value round-trips as null through GET; `read_stored_bedrock_configuration` carries stored nulls; existing invalid-value rejections unchanged; node-generator turn with unset temperature sends no sampling parameters.
+- Frontend (vitest + RTL): `defaultPortsForCategory` per-category shapes; wizard category change rewrites untouched defaults and preserves edited rows (both wizards); `PortGuidancePanel` renders per-kind requirement lines; Bedrock settings form accepts blank temperature/top_p, loads null as blank, saves blank as null; ImportView seeds empty selection, blocks import until selection, "Select all" then import serializes to no `selected_plugins`.
+
+### Property-Based Tests
+
+- **hypothesis** (backend, `edge-cv-portal/backend/tests/test_property_*.py`): generate arbitrary stored-config variants (absent item, missing keys, explicit nulls, numeric values, Decimal-encoded values) × optional request overrides; assert Property 1 (no `temperature`/unexpected `topP` when unset) and Property 2 (exact original inference config and 400 behavior otherwise; `temperature` and `topP` never both present in any generated case).
+- **fast-check** (frontend): generate categories × port-row edit sequences; assert Property 3 (untouched defaults match `CATEGORY_ARRANGEMENTS` multisets, names non-empty, `guidanceDivergence` null) and Property 4 (edited rows invariant under category changes; `isDefaultPortArrangement` true exactly for per-category defaults; `applySuggestions` replace/merge semantics unchanged over both old and new default shapes).
+- **fast-check** (frontend): generate plugin lists × selection actions; assert Property 5 (initial selection empty, gate blocks until non-empty) and Property 6 (`selectedPluginsParam` / `moduleSelectionSummary` unchanged for all selections; empty-or-unavailable list never blocks).
+
+### Integration Tests
+
+- Full generate flow (mock Bedrock, empty settings table): prompt → 200 with a definition, `converse` called with `inferenceConfig = {maxTokens: 4096}` only; then store a temperature via the settings PUT and confirm the next generation sends it; then PUT `{"temperature": null}` and confirm it is omitted again.
+- Create wizard end-to-end: select `input`, keep the seeded ports, submit — declaration posts with `inputs: []` and one VideoFrames output; Registration wizard: edit a port, change category twice, run a Port_Scan — edited rows merge additively.
+- Import flow end-to-end (mocked API): choose a module, verify import blocked at 0 selected; select a subset → request carries `selected_plugins`; "Select all" → request carries no `selected_plugins`; simulate listing failure → import proceeds whole-module.

--- a/.kiro/specs/workflow-designer-bugfixes/tasks.md
+++ b/.kiro/specs/workflow-designer-bugfixes/tasks.md
@@ -1,0 +1,257 @@
+# Implementation Plan
+
+## Overview
+
+The three bugs are independent, so the plan is organized as three parallel streams plus a final checkpoint. Within each stream the order is strict (exploration test → preservation tests → fix → verification), but Stream A (tasks 1–3), Stream B (tasks 4–6), and Stream C (tasks 7–9) have no dependencies on each other and can proceed in parallel.
+
+## Task Dependency Graph
+
+```mermaid
+graph TD
+    T1[Task 1: Bug 1 exploration test] --> T3[Task 3: Bug 1 fix + verify]
+    T2[Task 2: Bug 1 preservation tests] --> T3
+    T4[Task 4: Bug 2 exploration test] --> T6[Task 6: Bug 2 fix + verify]
+    T5[Task 5: Bug 2 preservation tests] --> T6
+    T7[Task 7: Bug 3 exploration test] --> T9[Task 9: Bug 3 fix + verify]
+    T8[Task 8: Bug 3 preservation tests] --> T9
+    T3 --> T10[Task 10: Final checkpoint]
+    T6 --> T10
+    T9 --> T10
+```
+
+Streams A (1→2→3), B (4→5→6), and C (7→8→9) are mutually independent and may proceed in parallel; only task 10 requires all three.
+
+```json
+{
+  "waves": [
+    {
+      "wave": 1,
+      "tasks": ["1", "2", "4", "5", "7", "8"],
+      "description": "Exploration and preservation tests for all three bugs, written and run against the UNFIXED code. All six tasks are mutually independent."
+    },
+    {
+      "wave": 2,
+      "tasks": ["3", "6", "9"],
+      "description": "Implement and verify each fix. Task 3 depends on tasks 1 and 2; task 6 depends on tasks 4 and 5; task 9 depends on tasks 7 and 8. The three fix tasks are mutually independent."
+    },
+    {
+      "wave": 3,
+      "tasks": ["10"],
+      "description": "Final checkpoint: full backend suite, full frontend suite, and TypeScript build. Depends on tasks 3, 6, and 9."
+    }
+  ]
+}
+```
+
+## Tasks
+
+### Stream A — Bug 1: Temperature omitted when unset (backend + settings form)
+
+- [x] 1. Write Bug 1 bug condition exploration test
+  - **Property 1: Bug Condition** - Temperature omitted when unset
+  - **CRITICAL**: This test MUST FAIL on unfixed code - failure confirms the bug exists
+  - **DO NOT attempt to fix the test or the code when it fails**
+  - **NOTE**: This test encodes the expected behavior - it will validate the fix when it passes after implementation
+  - **GOAL**: Surface counterexamples demonstrating the bug (expected: `inferenceConfig == {maxTokens: 4096, temperature: 0.2}` with nothing stored; 400 "temperature must be a number between 0 and 1" for a null-temperature save)
+  - Create `edge-cv-portal/backend/tests/test_property_bedrock_sampling_unset.py` using hypothesis with existing conftest fixtures (moto/mocked Bedrock `converse` as in `test_workflow_generation.py`)
+  - Property over unset-temperature store states from `isBugCondition1` (no stored item at all, stored item without the `temperature` key, stored explicit null) × generation requests without a temperature override: assert the captured `inferenceConfig` contains no `temperature` key, and no `topP` key unless a top_p was explicitly stored (from Property 1 in design)
+  - Cover both pipelines: workflow generation (`workflow_generator.py`) and node scaffold generation (`node_generator.py`, which reuses `get_bedrock_configuration()`)
+  - Settings path: PUT bedrock-configuration with `{"temperature": null}` (and `{"top_p": null}`) expecting 200, with the value round-tripping as unset through GET (`read_stored_bedrock_configuration`)
+  - Run: `python3 -m pytest tests/test_property_bedrock_sampling_unset.py` from `edge-cv-portal/backend` on UNFIXED code
+  - **EXPECTED OUTCOME**: Test FAILS (this is correct - it proves the bug exists)
+  - Document counterexamples found to understand root cause
+  - Mark task complete when test is written, run, and failure is documented
+  - _Requirements: 1.1, 1.2, 1.3, 2.1, 2.2, 2.3_
+
+- [x] 2. Write Bug 1 preservation property tests (BEFORE implementing fix)
+  - **Property 2: Preservation** - Explicit temperature behavior unchanged
+  - **IMPORTANT**: Follow observation-first methodology - observe behavior on UNFIXED code for non-buggy inputs (explicitly stored temperatures, per-request overrides), then encode it
+  - Create `edge-cv-portal/backend/tests/test_property_bedrock_sampling_preservation.py` (hypothesis)
+  - Property over stored temperatures in [0, 1] (numeric and Decimal-encoded) × optional valid overrides: the applicable temperature is sent as `inferenceConfig.temperature` with `topP` suppressed; an override replaces the configured value for that invocation only (from Preservation Requirements in design)
+  - Property over invalid overrides (out of range, non-numeric, boolean): rejected with 400 `INVALID_TEMPERATURE` before any Bedrock call
+  - Invariant across all generated cases: `temperature` and `topP` never both present in an `inferenceConfig`
+  - Non-temperature settings validation unchanged: invalid-value rejections (e.g. 1.5, -0.1, non-numbers) and model_id/region/max_tokens/timeout rules keep rejecting/accepting as today
+  - Run: `python3 -m pytest tests/test_property_bedrock_sampling_preservation.py` from `edge-cv-portal/backend` on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests PASS (this confirms baseline behavior to preserve)
+  - Mark task complete when tests are written, run, and passing on unfixed code
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+- [x] 3. Fix Bug 1 — unset sampling defaults and blank-temperature settings round-trip
+
+  - [x] 3.1 Implement the backend fix
+    - `edge-cv-portal/backend/functions/workflow_generator.py`: change `DEFAULT_BEDROCK_CONFIG` to `'temperature': None` and `'top_p': None` (both together — leaving `top_p: 0.9` would start sending `topP` on every unconfigured invocation, violating Req 3.4); update the comment (unset by default; sampling parameters sent only when explicitly configured or overridden). No changes to `get_bedrock_configuration()` or `invoke_generation()` — they already carry stored nulls and omit `None`
+    - `edge-cv-portal/backend/functions/node_generator.py`: no changes (fixed transitively via `get_bedrock_configuration`)
+    - `edge-cv-portal/backend/functions/data_accounts.py`: mirror the `DEFAULT_BEDROCK_CONFIG` change; `read_stored_bedrock_configuration()` special-cases `temperature`/`top_p` with `if key in stored` so a stored null reads back as unset; `validate_bedrock_configuration()` accepts `None` for `temperature`/`top_p` (non-None values keep requiring a number in [0, 1]); verify `_native_to_dynamo` passes `None` through
+    - Update existing test `test_workflow_generation.py::test_default_configuration_sends_temperature_without_top_p` (it asserts the buggy `temperature == 0.2`) to "default configuration sends no sampling parameters"
+    - _Bug_Condition: isBugCondition1(input) from design — GenerationRequest with no stored temperature and no override, or SettingsSave with blank temperature_
+    - _Expected_Behavior: Property 1 from design — no temperature/topP in inferenceConfig unless explicitly configured; blank/null temperature saves accepted and round-trip as unset_
+    - _Preservation: Property 2 from design — explicit temperature, override, and INVALID_TEMPERATURE behavior unchanged_
+    - _Requirements: 2.1, 2.2, 2.3, 3.1, 3.2, 3.3, 3.4_
+
+  - [x] 3.2 Implement the settings form fix
+    - `edge-cv-portal/frontend/src/components/BedrockConfigurationSettings.tsx`: `validate()` treats blank temperature/top_p as valid (unset); load effect maps null/undefined `config.temperature`/`config.top_p` to `''` (not `String(null)`); `handleSave()` sends explicit `null` for blank fields (`form.temperature.trim() === '' ? null : Number(form.temperature)`) since the backend merges provided keys; constraint text notes "0 to 1 — leave blank to let the model use its default (parameter is omitted)"
+    - `GenerateChatPanel.tsx` is NOT modified — its blank-field omission behavior is already correct (Req 3.5)
+    - Update/extend `BedrockConfigurationSettings` component tests: blank temperature/top_p accepted, null loads as blank, blank saves as null
+    - _Bug_Condition: isBugCondition1(SettingsSave) — blank temperature field rejected client-side_
+    - _Expected_Behavior: Property 1 from design — blank field accepted, stored unset_
+    - _Preservation: non-blank values keep requiring a number in [0, 1]; all other field validations unchanged_
+    - _Requirements: 2.3, 3.5_
+
+  - [x] 3.3 Verify Bug 1 bug condition exploration test now passes
+    - **Property 1: Expected Behavior** - Temperature omitted when unset
+    - **IMPORTANT**: Re-run the SAME test from task 1 - do NOT write a new test
+    - The test from task 1 encodes the expected behavior; when it passes, it confirms the fix
+    - Run: `python3 -m pytest tests/test_property_bedrock_sampling_unset.py` from `edge-cv-portal/backend`
+    - **EXPECTED OUTCOME**: Test PASSES (confirms bug is fixed)
+    - _Requirements: 2.1, 2.2, 2.3_
+
+  - [x] 3.4 Verify Bug 1 preservation tests still pass
+    - **Property 2: Preservation** - Explicit temperature behavior unchanged
+    - **IMPORTANT**: Re-run the SAME tests from task 2 - do NOT write new tests
+    - Run: `python3 -m pytest tests/test_property_bedrock_sampling_preservation.py` from `edge-cv-portal/backend`
+    - **EXPECTED OUTCOME**: Tests PASS (confirms no regressions)
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+  - [x] 3.5 Run affected existing suites for Bug 1
+    - Backend: `python3 -m pytest tests/test_workflow_generation.py tests/test_bedrock_configuration.py tests/test_node_generator.py tests/test_node_generator_integration.py` from `edge-cv-portal/backend` (with the one inverted default-behavior test from 3.1)
+    - Frontend: `npx vitest run src/components/BedrockConfigurationSettings.test.tsx src/components/GenerateChatPanel.test.tsx` from `edge-cv-portal/frontend` (adjust paths to actual test file locations)
+    - Fix any regressions before proceeding
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+### Stream B — Bug 2: Category-driven default ports (node-designer wizards)
+
+- [x] 4. Write Bug 2 bug condition exploration test
+  - **Property 3: Bug Condition** - Default ports follow the selected category
+  - **CRITICAL**: This test MUST FAIL on unfixed code - failure confirms the bug exists
+  - **DO NOT attempt to fix the test or the code when it fails**
+  - **NOTE**: This test encodes the expected behavior - it will validate the fix when it passes after implementation
+  - **GOAL**: Surface counterexamples (expected: untouched port rows stay `in`/`out` after selecting category `input`)
+  - Create `edge-cv-portal/frontend/src/pages/node-designer/categoryDefaultPorts.property.test.ts` (fast-check over categories in `CATEGORY_ARRANGEMENTS`) plus RTL component assertions in/alongside `CreateWizard.test.tsx` and `RegistrationWizard.test.tsx`
+  - From `isBugCondition2`: for every palette category selected while port rows are Untouched_Defaults, the presented default rows' port-type multisets match that category's typical arrangement — in particular `input` → zero input rows and one VideoFrames output; `output` → one input row and zero outputs (from Property 3 in design)
+  - Assert every seeded row has a non-empty name (`portsStepErrors` stays clean) and `guidanceDivergence(category, inputs, outputs)` is null for the seeded rows
+  - Assert the ports step states the category's input/output requirements (Req 2.6)
+  - Run: `npx vitest run src/pages/node-designer/categoryDefaultPorts.property.test.ts src/pages/node-designer/CreateWizard.test.tsx src/pages/node-designer/RegistrationWizard.test.tsx` from `edge-cv-portal/frontend` on UNFIXED code
+  - **EXPECTED OUTCOME**: Test FAILS (this is correct - it proves the bug exists)
+  - Document counterexamples found to understand root cause
+  - Mark task complete when test is written, run, and failure is documented
+  - _Requirements: 1.4, 1.5, 2.4, 2.5, 2.6_
+
+- [x] 5. Write Bug 2 preservation property tests (BEFORE implementing fix)
+  - **Property 4: Preservation** - Edited rows, advisory guidance, and Port_Scan unchanged
+  - **IMPORTANT**: Follow observation-first methodology - observe UNFIXED wizard behavior for user-edited rows and Port_Scan, then encode it
+  - Create `edge-cv-portal/frontend/src/pages/node-designer/portDefaultsPreservation.property.test.ts` (fast-check)
+  - Property: for any port rows that are NOT untouched defaults (any rename, retype, addition, removal) and any sequence of category changes, the rows are returned exactly unchanged (Req 3.6)
+  - Property: `guidanceDivergence` and `portsStepErrors` answer identically to today for generated inputs; guidance stays advisory/non-blocking; the dismissable divergence advisory keeps firing (Req 3.8, 3.9)
+  - Property: `applySuggestions` replace-over-untouched-defaults / merge-over-edited semantics unchanged, including over today's in/out default pair (Req 3.10); non-input categories present their typical arrangements (Req 3.7)
+  - Run: `npx vitest run src/pages/node-designer/portDefaultsPreservation.property.test.ts` from `edge-cv-portal/frontend` on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests PASS (this confirms baseline behavior to preserve)
+  - Mark task complete when tests are written, run, and passing on unfixed code
+  - _Requirements: 3.6, 3.7, 3.8, 3.9, 3.10_
+
+- [x] 6. Fix Bug 2 — category-driven default ports in both wizards
+
+  - [x] 6.1 Implement the fix
+    - `edge-cv-portal/frontend/src/pages/node-designer/declaration.ts`: add pure helpers `defaultPortsForCategory(category)` (derived from `CATEGORY_ARRANGEMENTS`: input → no inputs + one VideoFrames "out"; preprocessing → byte-identical to today's in/out seeds; inference → VideoFrames "in" / InferenceMeta "out"; post_processing → InferenceMeta "in" / EventSignal "out"; output → one VideoFrames "in" / no outputs; unknown → preprocessing shape) and `isDefaultPortArrangement(inputs, outputs)` (true exactly when rows deep-equal some category's defaults)
+    - `edge-cv-portal/frontend/src/pages/node-designer/portScan.ts`: `isUntouchedDefaults()` delegates to `isDefaultPortArrangement()`; `applySuggestions()` and `removalBlockReason()` untouched
+    - `CreateWizard.tsx`: `initialForm()` seeds from `defaultPortsForCategory('preprocessing')`; category `Select.onChange` rewrites port rows to the new category's defaults only when `isDefaultPortArrangement(form.inputs, form.outputs)` is true, otherwise patches `category` only
+    - `RegistrationWizard.tsx`: same seeding for the detail-load form seed (~line 138) and same category-change rewrite
+    - `portGuidance.ts` + `PortGuidancePanel.tsx`: add pure `arrangementRequirements(category)` and render per-kind requirement lines (e.g. input → "Inputs: none · Outputs: 1 × VideoFrames"); panel stays purely advisory, no step gating
+    - Add/extend unit tests: `defaultPortsForCategory` per-category shapes; `PortGuidancePanel` requirement lines; wizard category change rewrites untouched defaults and preserves edited rows
+    - _Bug_Condition: isBugCondition2(input) from design — untouched default rows while the selected category's arrangement differs_
+    - _Expected_Behavior: Property 3 from design — seeded rows match the category's typical arrangement, names non-empty, guidanceDivergence null, requirements stated_
+    - _Preservation: Property 4 from design — edited rows invariant, guidance advisory, Port_Scan replace/merge semantics unchanged_
+    - _Requirements: 2.4, 2.5, 2.6, 3.6, 3.7, 3.8, 3.9, 3.10_
+
+  - [x] 6.2 Verify Bug 2 bug condition exploration test now passes
+    - **Property 3: Expected Behavior** - Default ports follow the selected category
+    - **IMPORTANT**: Re-run the SAME test from task 4 - do NOT write a new test
+    - Run: `npx vitest run src/pages/node-designer/categoryDefaultPorts.property.test.ts src/pages/node-designer/CreateWizard.test.tsx src/pages/node-designer/RegistrationWizard.test.tsx` from `edge-cv-portal/frontend`
+    - **EXPECTED OUTCOME**: Test PASSES (confirms bug is fixed)
+    - _Requirements: 2.4, 2.5, 2.6_
+
+  - [x] 6.3 Verify Bug 2 preservation tests still pass
+    - **Property 4: Preservation** - Edited rows, advisory guidance, and Port_Scan unchanged
+    - **IMPORTANT**: Re-run the SAME tests from task 5 - do NOT write new tests
+    - Run: `npx vitest run src/pages/node-designer/portDefaultsPreservation.property.test.ts` from `edge-cv-portal/frontend`
+    - **EXPECTED OUTCOME**: Tests PASS (confirms no regressions)
+    - _Requirements: 3.6, 3.7, 3.8, 3.9, 3.10_
+
+  - [x] 6.4 Run affected existing suites for Bug 2
+    - `npx vitest run src/pages/node-designer/portScan.test.ts src/pages/node-designer/declaration.test.ts src/pages/node-designer/PortGuidancePanel.test.tsx src/pages/node-designer/PortScanPanel.test.tsx src/pages/node-designer/portReplaceDefaults.property.test.ts src/pages/node-designer/portMergePreservation.property.test.ts src/pages/node-designer/categoryDivergence.property.test.ts` from `edge-cv-portal/frontend`
+    - Fix any regressions before proceeding
+    - _Requirements: 3.7, 3.8, 3.9, 3.10_
+
+### Stream C — Bug 3: Opt-in module import selection
+
+- [x] 7. Write Bug 3 bug condition exploration test
+  - **Property 5: Bug Condition** - Import selection defaults to none with an explicit gate
+  - **CRITICAL**: This test MUST FAIL on unfixed code - failure confirms the bug exists
+  - **DO NOT attempt to fix the test or the code when it fails**
+  - **NOTE**: This test encodes the expected behavior - it will validate the fix when it passes after implementation
+  - **GOAL**: Surface counterexamples (expected: `selectedModulePlugins.length === plugins.length` immediately after list load, import enabled with no explicit opt-in)
+  - Create `edge-cv-portal/frontend/src/pages/node-designer/importSelectionDefault.property.test.ts` (fast-check over non-empty plugin lists, including after switching modules) plus RTL assertions in/alongside `ImportView.test.tsx` with a mocked module plugin list
+  - From `isBugCondition3`: for any non-empty module plugin list loading in the import view, the selection is seeded empty (0 of N selected) and the import stays blocked (`formComplete` false, gate message shown) until the user selects at least one plugin individually or via "Select all" (from Property 5 in design)
+  - Run: `npx vitest run src/pages/node-designer/importSelectionDefault.property.test.ts src/pages/node-designer/ImportView.test.tsx` from `edge-cv-portal/frontend` on UNFIXED code
+  - **EXPECTED OUTCOME**: Test FAILS (this is correct - it proves the bug exists)
+  - Document counterexamples found to understand root cause
+  - Mark task complete when test is written, run, and failure is documented
+  - _Requirements: 1.6, 2.7, 2.8_
+
+- [x] 8. Write Bug 3 preservation property tests (BEFORE implementing fix)
+  - **Property 6: Preservation** - Import serialization and fallbacks unchanged
+  - **IMPORTANT**: Follow observation-first methodology - observe UNFIXED serialization/fallback behavior, then encode it
+  - Create `edge-cv-portal/frontend/src/pages/node-designer/importSelectionPreservation.property.test.ts` (fast-check)
+  - Property: for any plugin list and selection, `selectedPluginsParam` answers as today — a proper subset serializes to that subset as `selected_plugins` (Req 3.11); a full selection or no available list serializes to no `selected_plugins` parameter, i.e. whole-module import (Req 3.12); `moduleSelectionSummary` unchanged
+  - Property: an unavailable or empty plugin list never blocks the import (non-blocking whole-module fallback, Req 3.13)
+  - The post-fetch `pending_selection` dialog keeps its default-none, at-least-one-required (`pluginSelectionError`) behavior (Req 3.14)
+  - Run: `npx vitest run src/pages/node-designer/importSelectionPreservation.property.test.ts` from `edge-cv-portal/frontend` on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests PASS (this confirms baseline behavior to preserve)
+  - Mark task complete when tests are written, run, and passing on unfixed code
+  - _Requirements: 3.11, 3.12, 3.13, 3.14_
+
+- [x] 9. Fix Bug 3 — opt-in module plugin selection
+
+  - [x] 9.1 Implement the fix
+    - `edge-cv-portal/frontend/src/pages/node-designer/ImportView.tsx`: module plugin load effect (~line 258) seeds `setSelectedModulePlugins([])` instead of `allPluginNames(plugins)`; update the comment ("Default: none selected — the user opts in explicitly"); checkbox FormField description (~line 859) becomes opt-in wording, with the existing `errorText` ("Select at least one plugin to import") serving as the visible gate on the pristine empty state
+    - `edge-cv-portal/frontend/src/pages/node-designer/importFlow.ts` (optional, for testability): extract pure `moduleSelectionIncomplete(source, availableNames, selectedNames)` mirroring the inline gate expression
+    - No other changes: `selectedPluginsParam()`, `moduleSelectionSummary()`, "Select all"/"Clear" buttons, listing-unavailable fallback, and the `pending_selection` dialog stay untouched
+    - _Bug_Condition: isBugCondition3(input) from design — non-empty module plugin list load seeds a full selection_
+    - _Expected_Behavior: Property 5 from design — selection seeds empty, import blocked until explicit opt-in_
+    - _Preservation: Property 6 from design — serialization semantics and whole-module fallbacks unchanged_
+    - _Requirements: 2.7, 2.8, 3.11, 3.12, 3.13, 3.14_
+
+  - [x] 9.2 Verify Bug 3 bug condition exploration test now passes
+    - **Property 5: Expected Behavior** - Import selection defaults to none with an explicit gate
+    - **IMPORTANT**: Re-run the SAME test from task 7 - do NOT write a new test
+    - Run: `npx vitest run src/pages/node-designer/importSelectionDefault.property.test.ts src/pages/node-designer/ImportView.test.tsx` from `edge-cv-portal/frontend`
+    - **EXPECTED OUTCOME**: Test PASSES (confirms bug is fixed)
+    - _Requirements: 2.7, 2.8_
+
+  - [x] 9.3 Verify Bug 3 preservation tests still pass
+    - **Property 6: Preservation** - Import serialization and fallbacks unchanged
+    - **IMPORTANT**: Re-run the SAME tests from task 8 - do NOT write new tests
+    - Run: `npx vitest run src/pages/node-designer/importSelectionPreservation.property.test.ts` from `edge-cv-portal/frontend`
+    - **EXPECTED OUTCOME**: Tests PASS (confirms no regressions)
+    - _Requirements: 3.11, 3.12, 3.13, 3.14_
+
+  - [x] 9.4 Run affected existing suites for Bug 3
+    - Frontend: `npx vitest run src/pages/node-designer/importFlow.test.ts src/pages/node-designer/ImportView.test.tsx` from `edge-cv-portal/frontend`
+    - Backend: `python3 -m pytest tests/test_plugin_import_selection.py` from `edge-cv-portal/backend` (pending_selection / selected_plugins wire behavior)
+    - Fix any regressions before proceeding
+    - _Requirements: 3.11, 3.12, 3.13, 3.14_
+
+### Final checkpoint
+
+- [x] 10. Checkpoint - Ensure all tests pass
+  - Run the full portal backend suite: `python3 -m pytest` from `edge-cv-portal/backend`
+  - Run the full frontend suite: `npx vitest run` from `edge-cv-portal/frontend`
+  - Run the TypeScript build: `npx tsc -b` from `edge-cv-portal/frontend`
+  - Ensure all tests pass, ask the user if questions arise
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14_
+
+## Notes
+
+- Backend property tests: hypothesis, in `edge-cv-portal/backend/tests/test_property_*.py`, run with `python3 -m pytest` from `edge-cv-portal/backend`. Hypothesis profiles already cap examples (fast profile, 25 examples, default locally) — do NOT hardcode `max_examples` in new tests.
+- Frontend tests: vitest + React Testing Library + fast-check, under `edge-cv-portal/frontend/src`, run with `npx vitest run` from `edge-cv-portal/frontend`; typecheck with `npx tsc -b`.
+- Exploration tests (tasks 1, 4, 7) are expected to FAIL on unfixed code — that failure is the confirmation of each bug, not a problem to fix at that stage.
+- Requirement numbers reference `bugfix.md`: 1.x = current defective behavior, 2.x = expected behavior, 3.x = unchanged behavior (regression prevention). Properties 1–6 reference the Correctness Properties in `design.md`.

--- a/edge-cv-portal/backend/functions/data_accounts.py
+++ b/edge-cv-portal/backend/functions/data_accounts.py
@@ -92,13 +92,14 @@ DEFAULT_BEDROCK_CONFIG = {
     'model_id': 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
     'region': os.environ.get('AWS_REGION', 'us-east-1'),
     'max_tokens': 4096,
-    # Both sampling parameters remain part of the stored/displayed shape,
-    # but at invocation the Workflow_Generator prefers temperature: recent
-    # Anthropic models reject requests setting temperature AND top_p
-    # together, so top_p is only sent when temperature is null/absent
+    # Sampling parameters are unset by default: they are sent to Bedrock
+    # only when explicitly configured (or overridden per-request). Recent
+    # Anthropic models reject requests setting temperature at all, and
+    # never accept temperature AND top_p together, so the generators omit
+    # None values and send at most one of the two
     # (see workflow_generator.invoke_generation).
-    'temperature': 0.2,
-    'top_p': 0.9,
+    'temperature': None,
+    'top_p': None,
     'timeout_seconds': MAX_BEDROCK_TIMEOUT_SECONDS,
 }
 
@@ -543,7 +544,15 @@ def read_stored_bedrock_configuration() -> Dict:
                 stored = item.get('value') if isinstance(item.get('value'), dict) else item
                 stored = _decimal_to_native(stored)
                 for key in DEFAULT_BEDROCK_CONFIG:
-                    if stored.get(key) is not None:
+                    if key in ('temperature', 'top_p'):
+                        # Sampling parameters may be explicitly stored as
+                        # null (unset); carry the null through so it reads
+                        # back as unset instead of being masked by the
+                        # default. Mirrors
+                        # workflow_generator.get_bedrock_configuration().
+                        if key in stored:
+                            config[key] = stored[key]
+                    elif stored.get(key) is not None:
                         config[key] = stored[key]
         except ClientError as e:
             logger.warning(f"Could not read Bedrock configuration, using defaults: {str(e)}")
@@ -580,12 +589,16 @@ def validate_bedrock_configuration(config: Dict) -> List[str]:
     if not isinstance(max_tokens, int) or isinstance(max_tokens, bool) or max_tokens < 1:
         errors.append('max_tokens must be a positive integer')
 
+    # None is a valid stored state for the sampling parameters (unset:
+    # the parameter is omitted at invocation); non-None values must be
+    # numbers in [0, 1].
     temperature = config.get('temperature')
-    if not _is_number(temperature) or not (0 <= temperature <= 1):
+    if temperature is not None and (
+            not _is_number(temperature) or not (0 <= temperature <= 1)):
         errors.append('temperature must be a number between 0 and 1')
 
     top_p = config.get('top_p')
-    if not _is_number(top_p) or not (0 <= top_p <= 1):
+    if top_p is not None and (not _is_number(top_p) or not (0 <= top_p <= 1)):
         errors.append('top_p must be a number between 0 and 1')
 
     timeout_seconds = config.get('timeout_seconds')

--- a/edge-cv-portal/backend/functions/deployments.py
+++ b/edge-cv-portal/backend/functions/deployments.py
@@ -1660,10 +1660,16 @@ CAMERA_WARNING_LEGACY_PATH = 'COMPILED_PATH_UNREGISTERED'   # 9.5
 #: Camera_Source types (registry ``type`` attribute) compatible with each
 #: built-in Camera_Input_Node type. camera_source captures from a device
 #: camera (v4l2src, the JP4/5 camera adapter, or the JP6 CSI host
-#: service), so folder and network-stream sources cannot back it.
+#: service), so folder and network-stream sources cannot back it; a
+#: registered GenICam camera (AravisDiscovered) is a legitimate
+#: camera-backed source for it on the adapter-fed architectures
+#: (aravis-camera-input Requirement 5.3). aravis_camera_source must bind
+#: to an Aravis-backed source: a discovered bus camera or a configured
+#: Camera-type Image_Source (aravis-camera-input Requirement 5.2).
 _CAMERA_COMPATIBLE_SOURCE_TYPES = {
     'camera_source': frozenset({'Camera', 'ICam', 'NvidiaCSI',
-                                'V4L2Discovered'}),
+                                'V4L2Discovered', 'AravisDiscovered'}),
+    'aravis_camera_source': frozenset({'Camera', 'AravisDiscovered'}),
 }
 
 #: Camera_Source types that are never a camera. Custom camera-backed node

--- a/edge-cv-portal/backend/functions/workflow_generator.py
+++ b/edge-cv-portal/backend/functions/workflow_generator.py
@@ -121,13 +121,14 @@ DEFAULT_BEDROCK_CONFIG = {
     'model_id': 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
     'region': os.environ.get('AWS_REGION', 'us-east-1'),
     'max_tokens': 4096,
-    # Both sampling parameters are kept in the stored/displayed shape, but
-    # recent Anthropic models reject requests that set temperature AND
-    # top_p together, so invoke_generation() sends temperature only; top_p
-    # is sent only when temperature is explicitly null/absent (see
-    # get_bedrock_configuration / invoke_generation).
-    'temperature': 0.2,
-    'top_p': 0.9,
+    # Sampling parameters are unset by default: they are sent to Bedrock
+    # only when explicitly configured in the settings (or overridden
+    # per-request). Recent Anthropic models reject requests that set
+    # temperature at all, and never accept temperature AND top_p together,
+    # so invoke_generation() omits None values and sends at most one of
+    # the two (see get_bedrock_configuration / invoke_generation).
+    'temperature': None,
+    'top_p': None,
     'timeout_seconds': MAX_TIMEOUT_SECONDS,
 }
 

--- a/edge-cv-portal/backend/functions/workflow_packaging.py
+++ b/edge-cv-portal/backend/functions/workflow_packaging.py
@@ -404,6 +404,13 @@ def split_plugin_dependencies(plugin_dependencies: List[str]
 #: The built-in Camera_Input_Node type.
 CAMERA_SOURCE_TYPE_ID = 'camera_source'
 
+#: The Aravis (GenICam) Camera_Input_Node type (aravis-camera-input
+#: Requirements 4.1, 4.2). Aravis acquisition happens in the LocalServer
+#: process through the camera manager, so the binding never lands in an
+#: element argument: the binding point carries ``aravisBinding: true``
+#: with empty slots on every physical device architecture.
+ARAVIS_CAMERA_SOURCE_TYPE_ID = 'aravis_camera_source'
+
 #: Optional Custom_Node_Type descriptor flag declaring the type
 #: camera-backed. Both the snake_case spelling from the design and the
 #: camelCase convention of custom declaration wire shapes are honored.
@@ -437,10 +444,12 @@ def camera_backed_type_ids(node_type_items: List[Dict]) -> set:
 
 
 def gather_camera_input_nodes(graph, camera_backed_types: set) -> List:
-    """The graph's Camera_Input_Nodes: camera_source nodes plus nodes of
-    any Custom_Node_Type declared camera-backed, in graph node order."""
+    """The graph's Camera_Input_Nodes: camera_source and
+    aravis_camera_source nodes plus nodes of any Custom_Node_Type declared
+    camera-backed, in graph node order."""
     return [node for node in graph.nodes
             if node.type == CAMERA_SOURCE_TYPE_ID
+            or node.type == ARAVIS_CAMERA_SOURCE_TYPE_ID
             or node.type in camera_backed_types]
 
 
@@ -513,7 +522,11 @@ def build_binding_points(camera_nodes: List, compiled_doc: Dict, arch: str,
     default parameters, and arch-specific slots. On JP4/JP5 camera_source
     is adapter-fed (``adapterBinding: true``, empty slots); on JP6 the
     binding selects the CSI sensor the capture host service stages from
-    (``csiSensorBinding: true``, empty slots)."""
+    (``csiSensorBinding: true``, empty slots). aravis_camera_source is
+    executor-feed-bound on every physical device architecture
+    (``aravisBinding: true``, empty slots) with the rendered
+    camera_id/gain/exposure values in ``parameters`` (aravis-camera-input
+    Requirement 4.2)."""
     binding_points: List[Dict] = []
     for node in camera_nodes:
         descriptor = descriptors_by_id[node.type]
@@ -526,7 +539,9 @@ def build_binding_points(camera_nodes: List, compiled_doc: Dict, arch: str,
         hint = hints.get(node.id)
         if hint:
             entry['bindingHint'] = hint
-        if node.type == CAMERA_SOURCE_TYPE_ID and arch in ADAPTER_BINDING_ARCHS:
+        if node.type == ARAVIS_CAMERA_SOURCE_TYPE_ID:
+            entry['aravisBinding'] = True
+        elif node.type == CAMERA_SOURCE_TYPE_ID and arch in ADAPTER_BINDING_ARCHS:
             entry['adapterBinding'] = True
         elif node.type == CAMERA_SOURCE_TYPE_ID and arch == ARCH_ARM64_JP6:
             entry['csiSensorBinding'] = True

--- a/edge-cv-portal/backend/functions/workflow_packaging.py
+++ b/edge-cv-portal/backend/functions/workflow_packaging.py
@@ -348,12 +348,20 @@ def zip_artifact_name(arch: str) -> str:
 # Artifact assembly
 # --------------------------------------------------------------------------
 
+#: Node types whose per-node code and declared pip dependencies ship as
+#: python/{nodeId}/handler.py + requirements.txt in every architecture
+#: artifact zip and are listed together in the manifest's
+#: customPythonNodeIds (custom-python-frames Requirements 2.4, 2.5).
+CUSTOM_PYTHON_NODE_TYPES = ('custom_python', 'custom_python_preprocess')
+
+
 def gather_custom_python_nodes(graph) -> List[Dict]:
     """Custom_Python_Nodes whose code + declared dependencies ship in the
-    Workflow_Component artifacts (Requirement 7.3)"""
+    Workflow_Component artifacts (Requirement 7.3; both Custom Python node
+    types — custom-python-frames Requirements 2.4, 2.5)"""
     nodes = []
     for node in graph.nodes:
-        if node.type == 'custom_python':
+        if node.type in CUSTOM_PYTHON_NODE_TYPES:
             nodes.append({
                 'node_id': node.id,
                 'code': str(node.parameters.get('code') or ''),

--- a/edge-cv-portal/backend/layers/workflow_core/python/workflow_core/catalog/nodes.py
+++ b/edge-cv-portal/backend/layers/workflow_core/python/workflow_core/catalog/nodes.py
@@ -238,6 +238,52 @@ CAMERA_SOURCE = NodeTypeDescriptor(
     hardware_dependent=True,
 )
 
+ARAVIS_CAMERA_SOURCE = NodeTypeDescriptor(
+    type_id="aravis_camera_source",
+    category=CATEGORY_INPUT,
+    display_name="Aravis Camera Source",
+    inputs=[],
+    outputs=[PortDescriptor("out", PORT_TYPE_VIDEO_FRAMES)],
+    parameters=[
+        ParameterDescriptor("camera_id", "string", required=True, default=None,
+                            constraints={"min_length": 1},
+                            description="Aravis (GenICam) camera identifier "
+                                        "as enumerated on the edge device, "
+                                        "e.g. Aravis-Fake-GV01 or "
+                                        "Basler-12345678.",
+                            examples=["Aravis-Fake-GV01", "Basler-12345678"]),
+        ParameterDescriptor("gain", "int", required=False, default=4,
+                            constraints={"min": 0, "max": 100},
+                            description="Sensor gain (0-100) applied through "
+                                        "the camera manager. Higher values "
+                                        "brighten the image but add noise; "
+                                        "e.g. 4.",
+                            examples=[4, 10]),
+        ParameterDescriptor("exposure", "int", required=False, default=5000000,
+                            constraints={"min": 0},
+                            description="Sensor exposure time in nanoseconds "
+                                        "applied through the camera manager, "
+                                        "e.g. 5000000 (5 ms).",
+                            examples=[5000000, 16000000]),
+    ],
+    # Aravis acquisition happens in the LocalServer process through the
+    # camera manager (no aravissrc element ships in the DDA images):
+    # every physical architecture compiles an appsrc-headed chain the
+    # executor feeds a camera-manager-grabbed frame into, the classic
+    # Camera-type Frame_Feed model. The appsrc name is compile-time
+    # rendered per node ({nodeId} derived by the compiler) so
+    # multi-camera documents stay addressable. Simulation: fed from the
+    # Test_Dataset like camera_source (Requirement 12.6).
+    mappings=_same_on_device_archs(
+        element_chain=[
+            _element("appsrc", name="appsrc_{nodeId}"),
+            _element("videoconvert"),
+        ],
+        plugin_dependencies=["app", "videoconvertscale"],
+    ) + [_dataset_fed_sim_source()],
+    hardware_dependent=True,
+)
+
 FOLDER_SOURCE = NodeTypeDescriptor(
     type_id="folder_source",
     category=CATEGORY_INPUT,
@@ -977,6 +1023,7 @@ CAPTURE = NodeTypeDescriptor(
 
 NODE_CATALOG = (
     CAMERA_SOURCE,
+    ARAVIS_CAMERA_SOURCE,
     FOLDER_SOURCE,
     DIGITAL_INPUT,
     DEWARP,

--- a/edge-cv-portal/backend/layers/workflow_core/python/workflow_core/catalog/nodes.py
+++ b/edge-cv-portal/backend/layers/workflow_core/python/workflow_core/catalog/nodes.py
@@ -437,6 +437,44 @@ FORMAT_CONVERT = NodeTypeDescriptor(
     hardware_dependent=False,
 )
 
+CUSTOM_PYTHON_PREPROCESS = NodeTypeDescriptor(
+    type_id="custom_python_preprocess",
+    category=CATEGORY_PREPROCESSING,
+    display_name="Custom Python (Frames)",
+    inputs=[PortDescriptor("in", PORT_TYPE_VIDEO_FRAMES)],
+    outputs=[PortDescriptor("out", PORT_TYPE_VIDEO_FRAMES)],
+    parameters=[
+        ParameterDescriptor("code", "code", required=True, default=None,
+                            constraints={"min_length": 1},
+                            description="Python run for every video frame. "
+                                        "Define process_frame(frame, "
+                                        "metadata) and return the processed "
+                                        "frame; frame is a NumPy uint8 array "
+                                        "(rows x cols x channels) and "
+                                        "cv2/np are pre-imported. Return "
+                                        "None to pass the frame through. "
+                                        "Helpers: import dda_frames for "
+                                        "frame_info(), load_image(path or "
+                                        "s3:// URI), to_array(), to_bytes().",
+                            examples=["def process_frame(frame, metadata):\n"
+                                      "    return cv2.GaussianBlur(frame, (5, 5), 0)"]),
+        ParameterDescriptor("requirements", "string", required=False, default="",
+                            constraints={},
+                            description="Extra pip packages the code needs, "
+                                        "one per line in requirements.txt "
+                                        "form.",
+                            examples=["scikit-image==0.24.0"]),
+    ],
+    # Same emlpython bridge element and packaged plugin dependency as the
+    # custom_python post-processing node (Requirement 1.4); the compiler
+    # derives {python_handler_path} per node id, so no compiler changes.
+    mappings=_same_on_all_archs(
+        element_chain=[_element("emlpython", **{"handler-path": "{python_handler_path}"})],
+        plugin_dependencies=["dda-emlpython"],
+    ),
+    hardware_dependent=False,
+)
+
 # --------------------------------------------------------------------------
 # Model inference node type (Requirement 2.3)
 # --------------------------------------------------------------------------
@@ -607,12 +645,19 @@ CUSTOM_PYTHON = NodeTypeDescriptor(
     parameters=[
         ParameterDescriptor("code", "code", required=True, default=None,
                             constraints={"min_length": 1},
-                            description="Python source run for every item "
-                                        "passing through the node; define "
-                                        "process(data, metadata) and return "
-                                        "the (possibly modified) data.",
-                            examples=["def process(data, metadata):\n"
-                                      "    return data"]),
+                            description="Python run for every item passing "
+                                        "through the node. Define "
+                                        "process_frame(frame, metadata) to "
+                                        "work with video frames as NumPy "
+                                        "arrays (cv2/np pre-imported; import "
+                                        "dda_frames for helpers), or "
+                                        "handle(frame_bytes, metadata) -> "
+                                        "(frame_bytes, metadata) to work "
+                                        "with raw bytes.",
+                            examples=["def process_frame(frame, metadata):\n"
+                                      "    return frame",
+                                      "def handle(frame_bytes, metadata):\n"
+                                      "    return frame_bytes, metadata"]),
         ParameterDescriptor("requirements", "string", required=False, default="",
                             constraints={},
                             description="Extra pip packages the code needs, "
@@ -938,6 +983,7 @@ NODE_CATALOG = (
     ROTATE,
     CROP,
     FORMAT_CONVERT,
+    CUSTOM_PYTHON_PREPROCESS,
     MODEL_INFERENCE,
     BEDROCK_INFERENCE,
     CUSTOM_PYTHON,

--- a/edge-cv-portal/backend/layers/workflow_core/python/workflow_core/compiler/compiler.py
+++ b/edge-cv-portal/backend/layers/workflow_core/python/workflow_core/compiler/compiler.py
@@ -484,6 +484,11 @@ def _effective_parameters(node: Node, descriptor: NodeTypeDescriptor) -> Dict[st
 def _derived_values(node: Node, parameters: Dict[str, Any]) -> Dict[str, Any]:
     """Placeholder values the compiler derives per node."""
     derived: Dict[str, Any] = {
+        # The node's own id, for per-node element naming in mapping
+        # templates (e.g. aravis_camera_source's appsrc name
+        # ``appsrc_{nodeId}``) so multi-node documents render unique
+        # element names.
+        "nodeId": node.id,
         # Custom Python handler artifact path (packaging layout, task 7.1).
         "python_handler_path": "python/{0}/handler.py".format(node.id),
         # Per-node element name for simulation stub sources so the test

--- a/edge-cv-portal/backend/layers/workflow_core/tests/generators.py
+++ b/edge-cv-portal/backend/layers/workflow_core/tests/generators.py
@@ -98,10 +98,11 @@ __all__ = [
 
 #: Input node types that emit VideoFrames (a graph always gets one so a
 #: downstream chain is guaranteed to be wireable).
-_VIDEO_INPUT_TYPES = ("camera_source", "folder_source")
+_VIDEO_INPUT_TYPES = ("camera_source", "aravis_camera_source", "folder_source")
 
 #: All input-category node types.
-_INPUT_TYPES = ("camera_source", "folder_source", "digital_input")
+_INPUT_TYPES = ("camera_source", "aravis_camera_source", "folder_source",
+                "digital_input")
 
 #: Intermediate (non-input, non-output) node types. ``conditional`` is the
 #: multi-output executor node: both of its output ports register as

--- a/edge-cv-portal/backend/layers/workflow_core/tests/test_catalog_content.py
+++ b/edge-cv-portal/backend/layers/workflow_core/tests/test_catalog_content.py
@@ -7,6 +7,7 @@ Validates: Requirements 2.1, 2.2, 2.3, 2.4, 2.5
 """
 
 from workflow_core.catalog import (
+    ARCHITECTURES,
     CATEGORY_INFERENCE,
     CATEGORY_INPUT,
     CATEGORY_OUTPUT,
@@ -146,6 +147,88 @@ class TestPreprocessingNodeTypes:
         assert params["format"].param_type == "enum"
         assert {"RGB", "BGR", "GRAY8"} <= set(params["format"].constraints["values"])
         assert params["format"].default == "RGB"
+
+
+# --------------------------------------------------------------------------
+# Custom Python preprocessing node type
+# (custom-python-frames Requirements 1.1-1.5)
+# --------------------------------------------------------------------------
+
+class TestCustomPythonPreprocessNodeType:
+    def test_descriptor_present_in_preprocessing_category(self):
+        descriptor = get_node_type("custom_python_preprocess")
+        assert descriptor is not None
+        assert descriptor.category == CATEGORY_PREPROCESSING
+        assert descriptor.display_name == "Custom Python (Frames)"
+        assert descriptor.hardware_dependent is False
+
+    def test_fixed_video_frames_ports_without_type_overrides(self):
+        # Exactly one VideoFrames input and one VideoFrames output; the
+        # per-instance port type override parameters of custom_python
+        # must not exist here (Requirement 1.2).
+        descriptor = get_node_type("custom_python_preprocess")
+        assert _port_types(descriptor.inputs) == [PORT_TYPE_VIDEO_FRAMES]
+        assert _port_types(descriptor.outputs) == [PORT_TYPE_VIDEO_FRAMES]
+        params = _params_by_name(descriptor)
+        assert "input_port_type" not in params
+        assert "output_port_type" not in params
+
+    def test_parameterization(self):
+        params = _params_by_name(get_node_type("custom_python_preprocess"))
+        assert params["code"].required is True
+        assert params["code"].param_type == "code"
+        assert params["requirements"].required is False
+        assert params["requirements"].param_type == "string"
+
+    def test_mappings_identical_to_custom_python(self):
+        # Same emlpython element chain and plugin dependencies as the
+        # custom_python post-processing node on every architecture
+        # (Requirement 1.4).
+        preprocess = get_node_type("custom_python_preprocess")
+        post = get_node_type("custom_python")
+        assert {m.arch for m in preprocess.mappings} == set(ARCHITECTURES)
+        for arch in ARCHITECTURES:
+            pre_mapping = preprocess.mapping_for(arch)
+            post_mapping = post.mapping_for(arch)
+            assert post_mapping is not None, arch
+            assert pre_mapping.element_chain == post_mapping.element_chain, arch
+            assert pre_mapping.plugin_dependencies == \
+                post_mapping.plugin_dependencies, arch
+
+
+# --------------------------------------------------------------------------
+# Custom Python contract documentation
+# (custom-python-frames Requirements 1.5, 8.1, 8.2)
+# --------------------------------------------------------------------------
+
+class TestCustomPythonContractDocumentation:
+    def test_preprocess_code_description_documents_process_frame(self):
+        code = _params_by_name(
+            get_node_type("custom_python_preprocess"))["code"]
+        assert "process_frame" in code.description
+        assert "process(data, metadata)" not in code.description
+
+    def test_custom_python_code_description_documents_actual_entry_points(self):
+        # The actual runtime entry points (process_frame and handle),
+        # never the non-existent process(data, metadata) contract
+        # (Requirement 8.1).
+        code = _params_by_name(get_node_type("custom_python"))["code"]
+        assert "process_frame" in code.description
+        assert "handle" in code.description
+        assert "process(data, metadata)" not in code.description
+
+    def test_every_code_example_defines_a_runtime_entry_point(self):
+        # Each code example exec's to a module defining a callable
+        # process_frame or handle, so it is a valid handler under the
+        # runtime contract (Requirements 1.5, 8.2).
+        for type_id in ("custom_python", "custom_python_preprocess"):
+            code = _params_by_name(get_node_type(type_id))["code"]
+            assert isinstance(code.examples, list) and code.examples, type_id
+            for example in code.examples:
+                namespace = {}
+                exec(compile(example, "<example>", "exec"), namespace)
+                entry = namespace.get("process_frame") or namespace.get("handle")
+                assert callable(entry), (type_id, example)
 
 
 # --------------------------------------------------------------------------
@@ -421,6 +504,7 @@ class TestCatalogCoverage:
     EXPECTED_TYPE_IDS = {
         "camera_source", "folder_source", "digital_input",
         "dewarp", "rotate", "crop", "format_convert",
+        "custom_python_preprocess",
         "model_inference", "bedrock_inference",
         "custom_python", "inference_filter", "conditional",
         "digital_output", "mqtt_publish", "opcua_write", "capture",

--- a/edge-cv-portal/backend/layers/workflow_core/tests/test_catalog_content.py
+++ b/edge-cv-portal/backend/layers/workflow_core/tests/test_catalog_content.py
@@ -4,10 +4,19 @@ Asserts presence and parameterization of all required input,
 preprocessing, inference, post-processing, and output node types.
 
 Validates: Requirements 2.1, 2.2, 2.3, 2.4, 2.5
+
+Aravis camera input additions (aravis-camera-input task 1.3):
+descriptor identity, parameters, mappings, the camera_source pin, and
+the catalog mirror-equality check.
+
+Validates: aravis-camera-input Requirements 1.1, 1.2, 1.3, 1.4, 1.6, 7.4
 """
+
+import os
 
 from workflow_core.catalog import (
     ARCHITECTURES,
+    DEVICE_ARCHITECTURES,
     CATEGORY_INFERENCE,
     CATEGORY_INPUT,
     CATEGORY_OUTPUT,
@@ -100,6 +109,178 @@ class TestInputNodeTypes:
         assert params["trigger_edge"].default == "rising"
         assert params["poll_interval_ms"].param_type == "int"
         assert descriptor.hardware_dependent is True
+
+
+# --------------------------------------------------------------------------
+# Aravis camera input node type
+# (aravis-camera-input Requirements 1.1-1.4, 1.6, 7.4)
+# --------------------------------------------------------------------------
+
+class TestAravisCameraSourceNodeType:
+    def test_descriptor_identity(self):
+        # Requirement 1.1: type id, category, display name, no inputs,
+        # exactly one VideoFrames output port named "out".
+        descriptor = get_node_type("aravis_camera_source")
+        assert descriptor is not None
+        assert descriptor.type_id == "aravis_camera_source"
+        assert descriptor.category == CATEGORY_INPUT
+        assert descriptor.display_name == "Aravis Camera Source"
+        assert descriptor.inputs == []
+        assert [(port.name, port.port_type) for port in descriptor.outputs] == [
+            ("out", PORT_TYPE_VIDEO_FRAMES)]
+
+    def test_camera_id_parameterization(self):
+        # Requirement 1.2: required string camera_id, min_length 1,
+        # documented with at least one working example.
+        params = _params_by_name(get_node_type("aravis_camera_source"))
+        assert list(params) == ["camera_id", "gain", "exposure"]
+        camera_id = params["camera_id"]
+        assert camera_id.required is True
+        assert camera_id.param_type == "string"
+        assert camera_id.default is None
+        assert camera_id.constraints == {"min_length": 1}
+        assert camera_id.description.strip()
+        assert isinstance(camera_id.examples, list) and camera_id.examples
+
+    def test_gain_and_exposure_parameterization(self):
+        # Requirement 1.3: optional acquisition settings mirroring what
+        # the Camera_Manager applies, each documented with examples.
+        params = _params_by_name(get_node_type("aravis_camera_source"))
+        gain = params["gain"]
+        assert gain.required is False
+        assert gain.param_type == "int"
+        assert gain.default == 4
+        assert gain.constraints == {"min": 0, "max": 100}
+        assert gain.description.strip()
+        assert isinstance(gain.examples, list) and gain.examples
+        exposure = params["exposure"]
+        assert exposure.required is False
+        assert exposure.param_type == "int"
+        assert exposure.default == 5000000
+        assert exposure.constraints == {"min": 0}
+        assert exposure.description.strip()
+        assert isinstance(exposure.examples, list) and exposure.examples
+
+    def test_hardware_dependent(self):
+        # Requirement 1.4: the node is hardware dependent.
+        assert get_node_type("aravis_camera_source").hardware_dependent is True
+
+    def test_device_arch_mappings_are_the_appsrc_chain(self):
+        # Requirement 1.4: every physical device architecture renders
+        # appsrc name=appsrc_{nodeId} ! videoconvert with the app and
+        # videoconvertscale plugin dependencies. The appsrc name embeds
+        # the {nodeId} token so multi-camera documents stay addressable.
+        descriptor = get_node_type("aravis_camera_source")
+        assert {m.arch for m in descriptor.mappings} == set(ARCHITECTURES)
+        for arch in DEVICE_ARCHITECTURES:
+            mapping = descriptor.mapping_for(arch)
+            assert mapping is not None, arch
+            assert mapping.element_chain == [
+                {"factory": "appsrc",
+                 "args_template": {"name": "appsrc_{nodeId}"}},
+                {"factory": "videoconvert", "args_template": {}},
+            ], arch
+            assert mapping.plugin_dependencies == [
+                "app", "videoconvertscale"], arch
+            assert mapping.executor_binding is None, arch
+
+    def test_sim_mapping_is_the_dataset_fed_stub(self):
+        # Requirement 1.4: the sim mapping is the shared dataset-fed
+        # stub, byte-equal to camera_source's sim mapping.
+        aravis_sim = get_node_type("aravis_camera_source").mapping_for("sim")
+        camera_sim = get_node_type("camera_source").mapping_for("sim")
+        assert aravis_sim == camera_sim
+
+
+class TestCameraSourceUnchanged:
+    """Pin `camera_source`'s pre-Aravis descriptor shape.
+
+    Requirement 7.4: the existing camera_source node type keeps its
+    current parameters and mappings unchanged by the Aravis addition.
+    """
+
+    def test_identity_and_parameters_pinned(self):
+        descriptor = get_node_type("camera_source")
+        assert descriptor.type_id == "camera_source"
+        assert descriptor.category == CATEGORY_INPUT
+        assert descriptor.display_name == "Camera Source"
+        assert descriptor.inputs == []
+        assert [(port.name, port.port_type) for port in descriptor.outputs] == [
+            ("out", PORT_TYPE_VIDEO_FRAMES)]
+        assert descriptor.hardware_dependent is True
+        params = _params_by_name(descriptor)
+        assert list(params) == ["device", "gain", "exposure"]
+        device = params["device"]
+        assert device.required is False
+        assert device.param_type == "string"
+        assert device.default == "/dev/video0"
+        assert device.constraints == {"min_length": 1}
+        gain = params["gain"]
+        assert (gain.required, gain.param_type, gain.default) == (
+            False, "int", 4)
+        assert gain.constraints == {"min": 0, "max": 100}
+        exposure = params["exposure"]
+        assert (exposure.required, exposure.param_type, exposure.default) == (
+            False, "int", 5000000)
+        assert exposure.constraints == {"min": 0}
+
+    def test_mappings_pinned(self):
+        descriptor = get_node_type("camera_source")
+        assert {m.arch for m in descriptor.mappings} == set(ARCHITECTURES)
+        # x86 architectures: V4L2 capture, never appsrc.
+        for arch in ("x86_64", "x86_64_nvidia"):
+            mapping = descriptor.mapping_for(arch)
+            assert mapping.element_chain == [
+                {"factory": "v4l2src", "args_template": {"device": "{device}"}},
+                {"factory": "videoconvert", "args_template": {}},
+            ], arch
+            assert mapping.plugin_dependencies == [
+                "video4linux2", "videoconvertscale"], arch
+        # JP4/JP5: the classic adapter-fed appsrc named plain "appsrc"
+        # (never the per-node appsrc_{nodeId} the Aravis node uses).
+        for arch in ("arm64_jp4", "arm64_jp5"):
+            mapping = descriptor.mapping_for(arch)
+            assert mapping.element_chain == [
+                {"factory": "appsrc", "args_template": {"name": "appsrc"}},
+                {"factory": "videoconvert", "args_template": {}},
+            ], arch
+            assert mapping.plugin_dependencies == [
+                "app", "videoconvertscale"], arch
+        # JP6: the PNG-staged host-service capture path.
+        jp6 = descriptor.mapping_for("arm64_jp6")
+        assert [entry["factory"] for entry in jp6.element_chain] == [
+            "filesrc", "pngdec", "videoconvert"]
+        assert jp6.element_chain[0]["args_template"]["location"] == (
+            "/aws_dda/nvidia-csi-capture/latest.jpg.dda_decoded.png")
+        assert jp6.plugin_dependencies == [
+            "coreelements", "png", "videoconvertscale", "python:pillow"]
+
+
+class TestCatalogMirrorEquality:
+    def test_portal_and_vendor_catalog_nodes_are_byte_identical(self):
+        # Requirement 1.6: the portal layer catalog and the edge vendor
+        # mirror carry the node identically — the two nodes.py sources
+        # stay byte-identical.
+        import workflow_core.catalog.nodes as portal_nodes
+
+        portal_path = os.path.abspath(portal_nodes.__file__)
+        if portal_path.endswith(".pyc"):
+            portal_path = portal_path[:-1]
+        # tests/ -> workflow_core -> layers -> backend -> edge-cv-portal
+        # -> repository root
+        repo_root = os.path.abspath(os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "..", "..", "..", "..", ".."))
+        vendor_path = os.path.join(
+            repo_root, "src", "backend", "workflow_engine", "vendor",
+            "workflow_core", "catalog", "nodes.py")
+        assert os.path.isfile(vendor_path), vendor_path
+        with open(portal_path, "rb") as handle:
+            portal_bytes = handle.read()
+        with open(vendor_path, "rb") as handle:
+            vendor_bytes = handle.read()
+        assert portal_bytes == vendor_bytes, (
+            "portal layer and edge vendor catalog nodes.py have diverged")
 
 
 # --------------------------------------------------------------------------
@@ -502,7 +683,8 @@ class TestOutputNodeTypes:
 
 class TestCatalogCoverage:
     EXPECTED_TYPE_IDS = {
-        "camera_source", "folder_source", "digital_input",
+        "camera_source", "aravis_camera_source", "folder_source",
+        "digital_input",
         "dewarp", "rotate", "crop", "format_convert",
         "custom_python_preprocess",
         "model_inference", "bedrock_inference",

--- a/edge-cv-portal/backend/layers/workflow_core/tests/test_property_aravis_roundtrip_compilation.py
+++ b/edge-cv-portal/backend/layers/workflow_core/tests/test_property_aravis_roundtrip_compilation.py
@@ -1,0 +1,163 @@
+"""Property test for the Aravis node's generic catalog paths (task 1.4).
+
+**Feature: aravis-camera-input, Property 1: Aravis node definitions round-trip and compile through generic catalog paths**
+
+For any valid workflow definition containing ``aravis_camera_source``
+nodes, serializing then parsing the definition produces an equivalent
+graph, and validating then compiling it for a device architecture
+succeeds and renders the node's appsrc-headed element chain — with the
+appsrc ``name`` resolving the ``{nodeId}`` token uniquely per node.
+
+**Validates: Requirements 1.5**
+"""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from workflow_core.catalog import DEVICE_ARCHITECTURES, get_node_type
+from workflow_core.compiler import CompiledPipelineDocument, compile
+from workflow_core.serializer import (
+    Connection,
+    Node,
+    PortEndpoint,
+    Position,
+    WorkflowGraph,
+    parse,
+    serialize,
+)
+from workflow_core.validator import SEVERITY_ERROR, validate
+
+from .generators import graph_strategy, node_parameters_strategy
+
+ARAVIS_TYPE_ID = "aravis_camera_source"
+
+_ARAVIS_DESCRIPTOR = get_node_type(ARAVIS_TYPE_ID)
+_CAPTURE_DESCRIPTOR = get_node_type("capture")
+
+
+@st.composite
+def aravis_graph_strategy(draw):
+    """Valid Workflow_Definitions guaranteed to contain 1..3
+    ``aravis_camera_source`` nodes.
+
+    A drawn boolean starts from a random valid catalog graph (which may
+    itself contain Aravis nodes now that the shared generators include
+    the type among the video inputs), producing mixed-camera documents;
+    otherwise the graph is Aravis-only. Each appended Aravis node feeds
+    its own ``capture`` sink so the graph stays validator-valid (input +
+    output present, everything reachable, all connections type-
+    compatible).
+    """
+    if draw(st.booleans()):
+        base = draw(graph_strategy())
+        nodes = list(base.nodes)
+        connections = list(base.connections)
+    else:
+        nodes = []
+        connections = []
+
+    for index in range(draw(st.integers(min_value=1, max_value=3))):
+        source_id = "aravis-src-{0}".format(index)
+        sink_id = "aravis-cap-{0}".format(index)
+        nodes.append(Node(
+            id=source_id,
+            type=ARAVIS_TYPE_ID,
+            position=Position(x=float(index), y=0.0),
+            parameters=draw(node_parameters_strategy(_ARAVIS_DESCRIPTOR)),
+        ))
+        nodes.append(Node(
+            id=sink_id,
+            type="capture",
+            position=Position(x=float(index), y=100.0),
+            parameters=draw(node_parameters_strategy(_CAPTURE_DESCRIPTOR)),
+        ))
+        connections.append(Connection(
+            id="aravis-conn-{0}".format(index),
+            source=PortEndpoint(node=source_id, port="out"),
+            target=PortEndpoint(node=sink_id, port="in"),
+        ))
+
+    return WorkflowGraph(nodes=nodes, connections=connections)
+
+
+def _aravis_elements_by_node(document: CompiledPipelineDocument):
+    """nodeId -> ordered element list, for elements tagged with that id."""
+    elements_by_node = {}
+    for segment in document.segments:
+        for element in segment["elements"]:
+            node_id = element["nodeId"]
+            if node_id is not None:
+                elements_by_node.setdefault(node_id, []).append(element)
+    return elements_by_node
+
+
+@given(graph=aravis_graph_strategy())
+def test_aravis_definitions_round_trip_and_compile(graph):
+    """**Feature: aravis-camera-input, Property 1: Aravis node definitions round-trip and compile through generic catalog paths**
+
+    **Validates: Requirements 1.5**
+    """
+    aravis_nodes = [node for node in graph.nodes if node.type == ARAVIS_TYPE_ID]
+    assert aravis_nodes, "strategy must produce at least one Aravis node"
+
+    # --- serialize -> parse equivalence (generic serializer path) --------
+    document = serialize(graph)
+    result = parse(document)
+    assert result.ok, (
+        "parse rejected a serialized Aravis definition: {0}".format(result.error)
+    )
+    assert result.graph is not None
+    assert result.graph.is_equivalent_to(graph), (
+        "parsed graph is not equivalent to the original"
+    )
+    assert graph.is_equivalent_to(result.graph), (
+        "original graph is not equivalent to the parsed graph"
+    )
+    assert serialize(result.graph) == document, (
+        "re-serialized document is not byte-identical to the original"
+    )
+
+    # --- validation succeeds (generic validator path) --------------------
+    errors = [
+        finding for finding in validate(graph)
+        if finding.severity == SEVERITY_ERROR
+    ]
+    assert not errors, (
+        "validate reported errors for a valid Aravis definition: "
+        "{0}".format(errors)
+    )
+
+    # --- compilation succeeds per device architecture with the appsrc
+    # chain rendered and {nodeId} resolved uniquely per node --------------
+    for arch in DEVICE_ARCHITECTURES:
+        compiled = compile(graph, arch)
+        assert isinstance(compiled, CompiledPipelineDocument), (
+            "compile failed on '{0}': {1}".format(arch, compiled)
+        )
+
+        elements_by_node = _aravis_elements_by_node(compiled)
+        appsrc_names = []
+        for node in aravis_nodes:
+            elements = elements_by_node.get(node.id)
+            assert elements, (
+                "no elements rendered for Aravis node '{0}' on "
+                "'{1}'".format(node.id, arch)
+            )
+            factories = [element["factory"] for element in elements]
+            assert factories == ["appsrc", "videoconvert"], (
+                "Aravis node '{0}' chain on '{1}' is {2}, expected "
+                "appsrc ! videoconvert".format(node.id, arch, factories)
+            )
+            name = elements[0]["args"].get("name")
+            assert name == "appsrc_{0}".format(node.id), (
+                "appsrc name {0!r} did not resolve the {{nodeId}} token "
+                "for node '{1}' on '{2}'".format(name, node.id, arch)
+            )
+            appsrc_names.append(name)
+
+        assert len(set(appsrc_names)) == len(appsrc_names), (
+            "appsrc names are not unique per node on '{0}': "
+            "{1}".format(arch, appsrc_names)
+        )

--- a/edge-cv-portal/backend/layers/workflow_core/tests/test_property_custom_python_preprocess_compilation.py
+++ b/edge-cv-portal/backend/layers/workflow_core/tests/test_property_custom_python_preprocess_compilation.py
@@ -1,0 +1,156 @@
+"""Property test for the compiled emlpython element of Custom Python
+preprocessing nodes (custom-python-frames task 1.4).
+
+**Feature: custom-python-frames, Property 12: Compiled emlpython element
+per Custom Python preprocessing node**
+
+For any valid workflow graph embedding ``custom_python_preprocess`` nodes
+with arbitrary node ids, compiling for any architecture yields exactly one
+``emlpython`` element per such node, tagged with that node's id and
+carrying ``handler-path`` equal to ``python/{nodeId}/handler.py``.
+
+**Validates: Requirements 2.3**
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from workflow_core.catalog import ARCHITECTURES
+from workflow_core.compiler import CompiledPipelineDocument, compile
+from workflow_core.serializer import (
+    Connection,
+    Node,
+    PortEndpoint,
+    Position,
+    WorkflowGraph,
+)
+
+# Arbitrary node ids: non-empty, exercising unicode, whitespace, and
+# punctuation (the compiled handler path embeds the id verbatim).
+_NODE_ID = st.text(min_size=1, max_size=12)
+
+# Required `code` parameter values: any non-empty string satisfies the
+# descriptor's min_length constraint (content is never interpreted by
+# the compiler).
+_CODE = st.text(min_size=1, max_size=40)
+
+# format_convert output formats (its required parameter's enum values),
+# used for interleaved non-Custom-Python preprocessing nodes.
+_FORMATS = ("RGB", "RGBA", "BGR", "GRAY8", "NV12", "I420")
+
+
+@st.composite
+def _preprocess_workflow(draw):
+    """A valid workflow embedding 1..3 ``custom_python_preprocess`` nodes.
+
+    Structure: camera_source -> [custom_python_preprocess (optionally
+    followed by an interleaved format_convert)]+ -> capture. The linear
+    VideoFrames chain is always validator-valid (input and output nodes
+    present, compatible ports, acyclic, all reachable, required
+    parameters set).
+
+    Returns ``(graph, preprocess_node_ids)``.
+    """
+    preprocess_count = draw(st.integers(min_value=1, max_value=3))
+    # One drawn boolean per preprocess node: follow it with an
+    # interleaved format_convert node (varying the surrounding graph).
+    interleaved = [draw(st.booleans()) for _ in range(preprocess_count)]
+
+    total_nodes = 2 + preprocess_count + sum(interleaved)
+    node_ids = draw(
+        st.lists(_NODE_ID, min_size=total_nodes, max_size=total_nodes, unique=True)
+    )
+    id_iter = iter(node_ids)
+
+    def next_id():
+        return next(id_iter)
+
+    def make_node(type_id, parameters):
+        return Node(
+            id=next_id(),
+            type=type_id,
+            position=Position(x=0.0, y=0.0),
+            parameters=parameters,
+        )
+
+    nodes = [make_node("camera_source", {})]
+    preprocess_ids = []
+    for follow_with_convert in interleaved:
+        parameters = {"code": draw(_CODE)}
+        if draw(st.booleans()):
+            parameters["requirements"] = draw(st.text(max_size=20))
+        node = make_node("custom_python_preprocess", parameters)
+        preprocess_ids.append(node.id)
+        nodes.append(node)
+        if follow_with_convert:
+            nodes.append(
+                make_node("format_convert", {"format": draw(st.sampled_from(_FORMATS))})
+            )
+    nodes.append(make_node("capture", {"output_path": "/aws_dda/captures"}))
+
+    # Linear wiring: every node's single output feeds the next node's
+    # single input (camera_source's port is "out", every consumer's is
+    # "in").
+    connections = [
+        Connection(
+            id="c{0}".format(index),
+            source=PortEndpoint(node=nodes[index].id, port="out"),
+            target=PortEndpoint(node=nodes[index + 1].id, port="in"),
+        )
+        for index in range(len(nodes) - 1)
+    ]
+
+    return WorkflowGraph(nodes=nodes, connections=connections), preprocess_ids
+
+
+@given(
+    workflow=_preprocess_workflow(),
+    target_arch=st.sampled_from(ARCHITECTURES),
+)
+def test_compiled_emlpython_element_per_preprocess_node(workflow, target_arch):
+    """**Feature: custom-python-frames, Property 12: Compiled emlpython
+    element per Custom Python preprocessing node**
+
+    **Validates: Requirements 2.3**
+    """
+    graph, preprocess_ids = workflow
+
+    document = compile(graph, target_arch)
+    assert isinstance(document, CompiledPipelineDocument), (
+        "compile() failed for a valid graph on arch {!r}: {}".format(
+            target_arch, document
+        )
+    )
+
+    emlpython_elements = [
+        element
+        for segment in document.segments
+        for element in segment["elements"]
+        if element["factory"] == "emlpython"
+    ]
+
+    # Exactly one emlpython element per custom_python_preprocess node,
+    # tagged with that node's id — no extras, none missing.
+    expected = Counter(preprocess_ids)
+    actual = Counter(element["nodeId"] for element in emlpython_elements)
+    assert actual == expected, (
+        "emlpython elements do not match the preprocess node set on arch "
+        "{!r}: missing={}, extra_or_duplicate={}".format(
+            target_arch, sorted(expected - actual), sorted(actual - expected)
+        )
+    )
+
+    # Each element carries the packaging-layout handler path derived from
+    # its node id (Requirement 2.3).
+    for element in emlpython_elements:
+        expected_path = "python/{0}/handler.py".format(element["nodeId"])
+        assert element["args"]["handler-path"] == expected_path, (
+            "emlpython element for node {!r} carries handler-path {!r}, "
+            "expected {!r}".format(
+                element["nodeId"], element["args"].get("handler-path"), expected_path
+            )
+        )

--- a/edge-cv-portal/backend/layers/workflow_core/tests/test_property_preprocess_connection_validation.py
+++ b/edge-cv-portal/backend/layers/workflow_core/tests/test_property_preprocess_connection_validation.py
@@ -1,0 +1,133 @@
+"""Property test for validator acceptance of preprocessing node connections.
+
+**Feature: custom-python-frames, Property 1: Validator acceptance of
+preprocessing node connections**
+
+For any workflow graph wiring a source node's output port into a
+`custom_python_preprocess` node's input port, the Workflow_Validator
+accepts the connection exactly when
+`are_port_types_compatible(source_type, VideoFrames)` holds under the
+catalog's declared coercion rules (VideoFrames exactly, and
+InferenceMeta via the declared coercion), and otherwise reports a port
+type compatibility error identifying that connection.
+
+**Validates: Requirements 2.1, 2.2**
+"""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from workflow_core.catalog import (
+    NODE_CATALOG,
+    PORT_TYPES,
+    are_port_types_compatible,
+    get_node_type,
+)
+from workflow_core.catalog.models import PORT_TYPE_VIDEO_FRAMES
+from workflow_core.serializer import (
+    Connection,
+    Node,
+    PortEndpoint,
+    Position,
+    WorkflowGraph,
+)
+from workflow_core.validator import CODE_V2_INCOMPATIBLE_TYPES, validate
+
+from .generators import node_parameters_strategy
+
+#: Every catalog node type that declares at least one output port is a
+#: candidate source for wiring into the preprocessing node's input.
+_SOURCE_DESCRIPTORS = [d for d in NODE_CATALOG if d.outputs]
+
+
+@st.composite
+def preprocess_wiring_strategy(draw):
+    """A two-node graph: a random source node type's drawn output port
+    wired into a `custom_python_preprocess` node's `in` port.
+
+    Returns ``(graph, connection_id, effective_source_port_type)`` where
+    the effective type accounts for per-instance `output_port_type`
+    overrides (custom_python), mirroring the validator's port resolution.
+    """
+    descriptor = draw(st.sampled_from(_SOURCE_DESCRIPTORS))
+
+    # Per-instance port typing: when the source type declares an
+    # output_port_type parameter, draw the override explicitly so every
+    # port type is exercised as a source.
+    forced = None
+    parameter_names = {p.name for p in descriptor.parameters}
+    if "output_port_type" in parameter_names:
+        forced = {"output_port_type": draw(st.sampled_from(PORT_TYPES))}
+
+    source = Node(
+        id="src",
+        type=descriptor.type_id,
+        position=Position(x=0.0, y=0.0),
+        parameters=draw(node_parameters_strategy(descriptor, forced)),
+    )
+
+    output_port = draw(st.sampled_from(descriptor.outputs))
+    if forced is not None:
+        effective_type = forced["output_port_type"]
+    else:
+        effective_type = output_port.port_type
+
+    preprocess_descriptor = get_node_type("custom_python_preprocess")
+    preprocess = Node(
+        id="pre",
+        type="custom_python_preprocess",
+        position=Position(x=100.0, y=0.0),
+        parameters=draw(node_parameters_strategy(preprocess_descriptor)),
+    )
+
+    connection = Connection(
+        id="c1",
+        source=PortEndpoint(node=source.id, port=output_port.name),
+        target=PortEndpoint(node=preprocess.id, port="in"),
+    )
+
+    graph = WorkflowGraph(nodes=[source, preprocess], connections=[connection])
+    return graph, connection.id, effective_type
+
+
+@given(wiring=preprocess_wiring_strategy())
+def test_validator_accepts_preprocess_input_exactly_for_video_frames(wiring):
+    """**Feature: custom-python-frames, Property 1: Validator acceptance
+    of preprocessing node connections**
+
+    validate() reports no port type compatibility finding for the
+    connection exactly when are_port_types_compatible(source_port_type,
+    VideoFrames) holds under the catalog's declared coercion rules
+    (VideoFrames exactly, and InferenceMeta via the declared coercion),
+    and reports a port type compatibility finding identifying the
+    connection for every other source port type.
+
+    **Validates: Requirements 2.1, 2.2**
+    """
+    graph, connection_id, source_port_type = wiring
+
+    findings = validate(graph)
+    compatibility_findings = [
+        finding for finding in findings
+        if finding.code == CODE_V2_INCOMPATIBLE_TYPES
+        and finding.connection_id == connection_id
+    ]
+
+    if are_port_types_compatible(source_port_type, PORT_TYPE_VIDEO_FRAMES):
+        assert compatibility_findings == [], (
+            "{0} -> custom_python_preprocess input is compatible with "
+            "VideoFrames under the declared coercion rules and must be "
+            "accepted, but validate() reported: {1}".format(
+                source_port_type,
+                [f.to_dict() for f in compatibility_findings],
+            )
+        )
+    else:
+        assert compatibility_findings, (
+            "{0} output wired into the custom_python_preprocess input "
+            "(connection '{1}') must yield a port type compatibility "
+            "finding identifying the connection, but validate() reported "
+            "none".format(source_port_type, connection_id)
+        )

--- a/edge-cv-portal/backend/tests/test_camera_binding_submission.py
+++ b/edge-cv-portal/backend/tests/test_camera_binding_submission.py
@@ -340,3 +340,59 @@ class TestBindingRecordStorage:
         record = fleet.env.stack.tables.deployments.get_item(
             Key={"deployment_id": payload["deployment_id"]})["Item"]
         assert "camera_bindings" not in record
+
+
+# --------------------------------------------------------------------------
+# Aravis binding delivery (aravis-camera-input task 8.4 — Requirement 5.5)
+# --------------------------------------------------------------------------
+
+class TestAravisBindingDelivery:
+    def test_aravis_binding_writes_shadow_and_leaves_artifact_untouched(
+            self, fleet):
+        """A submission binding an aravis_camera_source node to a
+        registered AravisDiscovered Camera_Source writes the expected
+        desired document into the target's dda-camera-bindings shadow —
+        keyed {workflowId}/{version}, carrying the node's binding — and
+        leaves the packaged artifact untouched: the Greengrass deployment
+        references only the component, and the staged artifact bytes are
+        byte-identical after submission (5.5)."""
+        aravis_node = {"node_id": "arv1", "node_type": "aravis_camera_source"}
+        fleet.seed_workflow([aravis_node])
+        fleet.seed_registry("line-a", {"arv-1": {
+            "type": "AravisDiscovered",
+            "origin": "edge-discovered",
+            "params": {"cameraId": "Aravis-Fake-GV01", "serial": "GV01",
+                       "protocol": "Fake", "address": "0.0.0.0"},
+        }})
+        fleet.gg.register_device("line-a")
+
+        # The packaged Workflow_Component artifact as staged in portal S3
+        # by the Component_Packager — bindings ride the shadow, never the
+        # artifact.
+        artifact_key = f"workflows/{fleet.workflow_id}/1/arm64_jp5/component.zip"
+        artifact_bytes = b"compiled-workflow-artifact-bytes"
+        fleet.env.s3.put_object(Bucket=fleet.env.bucket, Key=artifact_key,
+                                Body=artifact_bytes)
+
+        bindings = {"line-a": {"arv1": {"cameraSourceId": "arv-1"}}}
+        status, payload = fleet.deploy(["line-a"], camera_bindings=bindings)
+
+        assert status == 201, payload
+        assert payload["camera_bindings_delivered"] is True
+        # The expected desired document (unchanged shadow mechanism):
+        # desired.bindings["{workflowId}/{version}"] = node bindings.
+        assert fleet.iot_data.bindings["line-a"] == {
+            f"{fleet.workflow_id}/1": {"arv1": {"cameraSourceId": "arv-1"}}}
+        # The Greengrass deployment carries only the component map — no
+        # binding data rides the component set.
+        [call] = fleet.gg.create_deployment_calls
+        assert call["components"] == {
+            f"dda.workflow.{fleet.workflow_id}": {"componentVersion": "1.0.0"}}
+        # The staged artifact bytes are untouched.
+        stored = fleet.env.s3.get_object(
+            Bucket=fleet.env.bucket, Key=artifact_key)["Body"].read()
+        assert stored == artifact_bytes
+        # The delivered bindings are recorded on the deployment record.
+        record = fleet.env.stack.tables.deployments.get_item(
+            Key={"deployment_id": payload["deployment_id"]})["Item"]
+        assert record["camera_bindings"] == bindings

--- a/edge-cv-portal/backend/tests/test_camera_binding_validation.py
+++ b/edge-cv-portal/backend/tests/test_camera_binding_validation.py
@@ -253,6 +253,96 @@ class TestTypeAndOverride:
 
 
 # ==========================================================================
+# Aravis type compatibility and override constraints
+# (aravis-camera-input task 8.1 — Requirements 5.2, 5.3, 5.4)
+# ==========================================================================
+
+def aravis_node(node_id="n1"):
+    return camera_node(node_id, "aravis_camera_source")
+
+
+class TestAravisTypeAndOverride:
+    def test_aravis_binding_to_aravis_discovered_accepted(self, deployments):
+        """An aravis_camera_source node binds to a discovered bus camera
+        (5.2)."""
+        errors, warnings = deployments.validate_camera_bindings(
+            version_item([aravis_node()]), ["line-a"],
+            {"line-a": snapshot({"arv-1": registry_entry("AravisDiscovered")})},
+            {"line-a": {"n1": {"cameraSourceId": "arv-1"}}}, [])
+        assert errors == []
+        assert warnings == []
+
+    def test_aravis_binding_to_configured_camera_accepted(self, deployments):
+        """A configured Camera-type Image_Source (Aravis-backed) is a
+        valid binding for the Aravis node (5.2)."""
+        errors, _ = deployments.validate_camera_bindings(
+            version_item([aravis_node()]), ["line-a"],
+            {"line-a": snapshot({"cfg-1": registry_entry("Camera")})},
+            {"line-a": {"n1": {"cameraSourceId": "cfg-1"}}}, [])
+        assert errors == []
+
+    @pytest.mark.parametrize("source_type", [
+        "V4L2Discovered", "ICam", "NvidiaCSI", "Folder", "RTSP"])
+    def test_aravis_binding_to_incompatible_type_rejected(
+            self, deployments, source_type):
+        """Anything that is not Aravis-backed is rejected with
+        CAMERA_TYPE_INCOMPATIBLE (5.2)."""
+        errors, _ = deployments.validate_camera_bindings(
+            version_item([aravis_node()]), ["line-a"],
+            {"line-a": snapshot({"src-1": registry_entry(source_type)})},
+            {"line-a": {"n1": {"cameraSourceId": "src-1"}}}, [])
+        [error] = errors
+        assert error["code"] == deployments.CAMERA_ERROR_TYPE_INCOMPATIBLE
+        assert error["sourceType"] == source_type
+        assert error["nodeType"] == "aravis_camera_source"
+
+    def test_camera_source_binding_to_aravis_discovered_accepted(
+            self, deployments):
+        """A registered GenICam camera is a legitimate camera-backed
+        source for the generic camera_source node (5.3)."""
+        errors, _ = deployments.validate_camera_bindings(
+            version_item([camera_node()]), ["line-a"],
+            {"line-a": snapshot({"arv-1": registry_entry("AravisDiscovered")})},
+            {"line-a": {"n1": {"cameraSourceId": "arv-1"}}}, [])
+        assert errors == []
+
+    def test_valid_aravis_override_accepted(self, deployments):
+        """Override values within the aravis_camera_source descriptor's
+        declared constraints are accepted (5.4)."""
+        errors, warnings = deployments.validate_camera_bindings(
+            version_item([aravis_node()]), ["line-a"],
+            {"line-a": snapshot({})},
+            {"line-a": {"n1": {"override": {"camera_id": "Aravis-Fake-GV01",
+                                            "gain": 8,
+                                            "exposure": 100000}}}}, [])
+        assert errors == []
+        assert warnings == []
+
+    def test_aravis_override_with_empty_camera_id_rejected(self, deployments):
+        """camera_id declares min_length 1 in the catalog (5.4)."""
+        errors, _ = deployments.validate_camera_bindings(
+            version_item([aravis_node()]), ["line-a"],
+            {"line-a": snapshot({})},
+            {"line-a": {"n1": {"override": {"camera_id": ""}}}}, [])
+        [error] = errors
+        assert error["code"] == deployments.CAMERA_ERROR_OVERRIDE_INVALID
+        assert error["parameter"] == "camera_id"
+        assert error["violation"] == "PARAM_MIN_LENGTH"
+
+    def test_aravis_override_with_out_of_range_gain_rejected(self, deployments):
+        """gain declares max 100 in the catalog (5.4)."""
+        errors, _ = deployments.validate_camera_bindings(
+            version_item([aravis_node()]), ["line-a"],
+            {"line-a": snapshot({})},
+            {"line-a": {"n1": {"override": {"camera_id": "Basler-12345678",
+                                            "gain": 500}}}}, [])
+        [error] = errors
+        assert error["code"] == deployments.CAMERA_ERROR_OVERRIDE_INVALID
+        assert error["parameter"] == "gain"
+        assert error["violation"] == "PARAM_MAX"
+
+
+# ==========================================================================
 # Degraded-source and never-synced warnings (9.3, 8.8)
 # ==========================================================================
 

--- a/edge-cv-portal/backend/tests/test_camera_sync_ingest.py
+++ b/edge-cv-portal/backend/tests/test_camera_sync_ingest.py
@@ -368,3 +368,100 @@ class TestMetaStamping:
         entry = camera_item(items, "cfg-a")
         assert entry["usecase_id"] == usecase_id
         assert entry["last_reported_at"] == 1730000042000
+
+
+def aravis_discovered(version, camera_id="Aravis-Fake-GV01"):
+    """An AravisDiscovered Camera_Source exactly as the Edge_Sync_Agent
+    reports it (aravis-camera-input: build_inventory discovered-only
+    entry shape)."""
+    return {
+        "version": version,
+        "name": "Aravis Fake GV",
+        "type": "AravisDiscovered",
+        "origin": "edge-discovered",
+        "params": {
+            "cameraId": camera_id,
+            "serial": "SN-0001",
+            "protocol": "GigEVision",
+            "address": "192.168.1.20",
+        },
+        "capabilities": {"aravis": {
+            "model": "Fake GV",
+            "address": "192.168.1.20",
+            "physicalId": "eth0",
+            "protocol": "GigEVision",
+            "serial": "SN-0001",
+            "vendor": "Aravis",
+        }},
+    }
+
+
+class TestAravisDiscoveredIngestion:
+    """Registry ingestion of AravisDiscovered reports (aravis-camera-input
+    Requirement 7.3): the existing reduce_report/handler path stores the
+    new type verbatim without changes to existing Camera_Source types."""
+
+    def test_aravis_discovered_entry_stored_verbatim(self, ingest_env, env):
+        """An AravisDiscovered entry flows through the ingest handler as
+        one more opaque type string: every declared field lands in the
+        registry exactly as reported (Req 7.3)."""
+        usecase_id = env.create_usecase()
+        thing_name = register_device(ingest_env, usecase_id)
+        csid = "arv-3fe9c0d21ab4"
+        incoming = aravis_discovered(1)
+        record = make_record(thing_name, report(
+            {csid: incoming}, reported_at=1730000000000))
+
+        result = ingest_env.module.handler({"Records": [record]}, None)
+
+        assert result == {"batchItemFailures": []}
+        entry = camera_item(device_items(ingest_env, thing_name), csid)
+        assert entry is not None
+        assert entry["camera_source_id"] == csid
+        assert entry["name"] == incoming["name"]
+        assert entry["type"] == "AravisDiscovered"
+        assert entry["origin"] == "edge-discovered"
+        assert entry["params"] == incoming["params"]
+        assert entry["capabilities"] == incoming["capabilities"]
+        assert entry["version"] == 1
+        assert entry["sync_status"] == "synced"
+        assert entry["usecase_id"] == usecase_id
+        assert entry["last_reported_at"] == 1730000000000
+
+    def test_existing_types_unaffected_by_aravis_entries(
+            self, ingest_env, env):
+        """A report carrying AravisDiscovered entries alongside existing
+        types stores the existing-type entries exactly as a report without
+        the Aravis entries does (Req 7.3)."""
+        usecase_id = env.create_usecase()
+        with_aravis = register_device(ingest_env, usecase_id)
+        without_aravis = register_device(ingest_env, usecase_id)
+        classic = {
+            "cfg-a": camera(2, "line-1"),
+            "disc-9a1b2c3d4e5f": camera(
+                1, "usb-cam", "/dev/video2",
+                origin="edge-discovered", type="V4L2Discovered"),
+        }
+        mixed = dict(classic)
+        mixed["arv-3fe9c0d21ab4"] = aravis_discovered(1)
+
+        ingest_env.module.handler({"Records": [
+            make_record(with_aravis, report(mixed,
+                                            reported_at=1730000000000)),
+            make_record(without_aravis, report(classic,
+                                               reported_at=1730000000000)),
+        ]}, None)
+
+        items_with = device_items(ingest_env, with_aravis)
+        items_without = device_items(ingest_env, without_aravis)
+
+        def strip_device(item):
+            return {k: v for k, v in item.items() if k != "device_id"}
+
+        # The Aravis entry is stored; every existing-type entry is
+        # byte-identical to the Aravis-free ingestion of the same report.
+        assert camera_item(items_with, "arv-3fe9c0d21ab4") is not None
+        assert camera_item(items_without, "arv-3fe9c0d21ab4") is None
+        for csid in classic:
+            assert strip_device(camera_item(items_with, csid)) == \
+                strip_device(camera_item(items_without, csid))

--- a/edge-cv-portal/backend/tests/test_property_aravis_binding_points.py
+++ b/edge-cv-portal/backend/tests/test_property_aravis_binding_points.py
@@ -1,0 +1,230 @@
+"""
+Property-based test for Aravis binding point emission (task 7.2).
+
+**Feature: aravis-camera-input, Property 9: Packaging emits Aravis binding points**
+
+*For any* workflow definition containing `aravis_camera_source` nodes,
+packaging SHALL emit exactly one `bindingPoints` entry per Aravis node
+per architecture carrying `aravisBinding: true`, empty slots, and the
+node's rendered `camera_id`/`gain`/`exposure` parameter values, and
+SHALL record each node in the version item's `camera_input_nodes` with
+`has_binding_points: true`.
+
+**Validates: Requirements 4.1, 4.2**
+
+The layer under test is the packager's pure binding-point pipeline —
+``gather_camera_input_nodes`` -> ``binding_hints_from_definition`` ->
+``build_binding_points`` -> ``camera_input_nodes_record`` — exercised
+over compiler output exactly as the handler drives it (same call
+sequence, same built-in catalog), with no AWS. The module is imported
+through the shared moto-backed session fixture only so its module-level
+boto3 clients bind to the mock (same re-import pattern as
+test_property_packaging_gates.py). ``has_binding_points`` is asserted
+through the value the handler stores: ``bool(camera_nodes)``.
+
+Generators: definitions with 1..3 source->capture chains, each headed
+by an aravis_camera_source or (mixed) a camera_source, with generated
+camera_id/device values, optional gain/exposure overrides, and optional
+cameraBindingHint node data.
+"""
+import json
+import sys
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from workflow_core.serializer import parse
+from workflow_core.compiler import compile as compile_workflow, CompileContext
+from workflow_core.catalog import DEVICE_ARCHITECTURES
+from workflow_core.catalog.custom import resolve_catalog
+
+
+@pytest.fixture(scope="module")
+def packaging(aws_stack):
+    """Import workflow_packaging inside the moto mock so its module-level
+    boto3 clients (DynamoDB / S3 / KMS) are intercepted."""
+    sys.modules.pop("workflow_packaging", None)
+    import workflow_packaging
+
+    return workflow_packaging
+
+
+# ---------------------------------------------------------------------------
+# Reference model: the rendered parameter values Requirement 4.2 demands,
+# restated from the catalog contract (declared defaults overlaid with the
+# node's explicit values) rather than imported from the implementation.
+# ---------------------------------------------------------------------------
+
+ARAVIS_TYPE = "aravis_camera_source"
+CAMERA_TYPE = "camera_source"
+
+#: aravis_camera_source declared parameter defaults (design section 1).
+DEFAULT_GAIN = 4
+DEFAULT_EXPOSURE = 5000000
+
+
+def expected_rendered_parameters(node_parameters):
+    """camera_id (required, no default) plus gain/exposure defaults
+    overlaid with the node's explicit values."""
+    rendered = {"camera_id": node_parameters["camera_id"],
+                "gain": DEFAULT_GAIN, "exposure": DEFAULT_EXPOSURE}
+    rendered.update(node_parameters)
+    return rendered
+
+
+# ---------------------------------------------------------------------------
+# Generators
+# ---------------------------------------------------------------------------
+
+_camera_ids = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.",
+    min_size=1, max_size=32)
+
+_device_paths = st.integers(min_value=0, max_value=63).map(
+    lambda n: "/dev/video{}".format(n))
+
+_hint_text = st.text(min_size=1, max_size=24)
+
+_hints = st.fixed_dictionaries(
+    {"cameraSourceId": _hint_text},
+    optional={"cameraName": _hint_text, "sourceDeviceId": _hint_text},
+)
+
+
+@st.composite
+def _aravis_definitions(draw):
+    """A valid definition of 1..3 source->capture chains, at least one
+    headed by an aravis_camera_source, the rest optionally mixed with
+    camera_source chains. Returns (definition, aravis_specs, camera_ids)
+    where aravis_specs maps node id -> (parameters, hint-or-None) and
+    camera_ids is the full ordered list of Camera_Input_Node ids."""
+    chain_count = draw(st.integers(min_value=1, max_value=3))
+    aravis_indices = draw(st.sets(
+        st.integers(min_value=0, max_value=chain_count - 1), min_size=1))
+
+    nodes, connections = [], []
+    aravis_specs, camera_node_ids = {}, []
+    for i in range(chain_count):
+        if i in aravis_indices:
+            source_id = "arv{}".format(i)
+            parameters = {"camera_id": draw(_camera_ids)}
+            if draw(st.booleans()):
+                parameters["gain"] = draw(st.integers(min_value=0, max_value=100))
+            if draw(st.booleans()):
+                parameters["exposure"] = draw(
+                    st.integers(min_value=0, max_value=10_000_000))
+            source = {"id": source_id, "type": ARAVIS_TYPE,
+                      "position": {"x": 100.0 * i, "y": 0.0},
+                      "parameters": parameters}
+            hint = draw(st.one_of(st.none(), _hints))
+            if hint is not None:
+                source["data"] = {"cameraBindingHint": hint}
+            aravis_specs[source_id] = (parameters, hint)
+        else:
+            source_id = "cam{}".format(i)
+            source = {"id": source_id, "type": CAMERA_TYPE,
+                      "position": {"x": 100.0 * i, "y": 0.0},
+                      "parameters": {"device": draw(_device_paths)}}
+        camera_node_ids.append(source_id)
+        nodes.append(source)
+        nodes.append({"id": "cap{}".format(i), "type": "capture",
+                      "position": {"x": 100.0 * i, "y": 200.0},
+                      "parameters": {"output_path": "/out/{}".format(i)}})
+        connections.append({
+            "id": "c{}".format(i),
+            "from": {"node": source_id, "port": "out"},
+            "to": {"node": "cap{}".format(i), "port": "in"},
+        })
+
+    definition = {"schemaVersion": 1, "nodes": nodes,
+                  "connections": connections}
+    return definition, aravis_specs, camera_node_ids
+
+
+# ---------------------------------------------------------------------------
+# Property 9
+# ---------------------------------------------------------------------------
+
+@settings(deadline=None)
+@given(case=_aravis_definitions())
+def test_packaging_emits_aravis_binding_points(packaging, case):
+    """**Feature: aravis-camera-input, Property 9: Packaging emits Aravis binding points**
+
+    Exactly one bindingPoints entry per Aravis node per device
+    architecture, carrying ``aravisBinding: true``, empty slots, and the
+    rendered camera_id/gain/exposure values; each node recorded in
+    camera_input_nodes with has_binding_points: true.
+
+    **Validates: Requirements 4.1, 4.2**
+    """
+    definition, aravis_specs, camera_node_ids = case
+
+    parse_result = parse(json.dumps(definition))
+    assert parse_result.ok, parse_result.error
+    graph = parse_result.graph
+
+    # 4.1: every aravis_camera_source is gathered as a Camera_Input_Node
+    # (alongside any camera_source), in graph node order.
+    camera_nodes = packaging.gather_camera_input_nodes(graph, set())
+    assert [node.id for node in camera_nodes] == camera_node_ids
+
+    hints = packaging.binding_hints_from_definition(definition)
+    catalog = resolve_catalog([])
+    descriptors_by_id = {d.type_id: d for d in catalog}
+    context = CompileContext(workflow_id="wf-p9", workflow_version="1")
+
+    arch_binding_points, arch_compiled_dicts = {}, {}
+    for arch in DEVICE_ARCHITECTURES:
+        compiled = compile_workflow(graph, arch, context, simulation=False,
+                                    catalog=catalog)
+        assert not isinstance(compiled, list), (
+            "compilation failed on {}: {}".format(arch, compiled))
+        compiled_dict = compiled.to_dict()
+        points = packaging.build_binding_points(
+            camera_nodes, compiled_dict, arch, hints, descriptors_by_id)
+        arch_compiled_dicts[arch] = compiled_dict
+        arch_binding_points[arch] = points
+
+        # One entry per Camera_Input_Node, hence exactly one per Aravis
+        # node per architecture (4.1).
+        assert [p["nodeId"] for p in points] == camera_node_ids
+
+        for point in points:
+            if point["nodeId"] in aravis_specs:
+                parameters, hint = aravis_specs[point["nodeId"]]
+                # 4.2: the aravisBinding marker with empty slots on every
+                # physical device architecture.
+                assert point["nodeType"] == ARAVIS_TYPE
+                assert point["aravisBinding"] is True
+                assert point["slots"] == []
+                # 4.2: rendered (defaults-overlaid) parameter values.
+                assert point["parameters"] == expected_rendered_parameters(
+                    parameters)
+                # The hint rides along exactly when the definition
+                # carries one; the other camera markers never appear.
+                assert point.get("bindingHint") == hint or (
+                    hint is None and "bindingHint" not in point)
+                assert "adapterBinding" not in point
+                assert "csiSensorBinding" not in point
+            else:
+                # Mixed camera_source entries never gain the Aravis marker.
+                assert "aravisBinding" not in point
+
+    # 4.1: the version item records each Aravis node in camera_input_nodes
+    # through the existing recording path...
+    records = packaging.camera_input_nodes_record(
+        camera_nodes, hints, arch_binding_points, arch_compiled_dicts)
+    assert [r["node_id"] for r in records] == camera_node_ids
+    for record in records:
+        if record["node_id"] in aravis_specs:
+            _, hint = aravis_specs[record["node_id"]]
+            assert record["node_type"] == ARAVIS_TYPE
+            assert record.get("binding_hint") == hint or (
+                hint is None and "binding_hint" not in record)
+            # No Aravis parameter ever lands in an element argument.
+            assert record["compiled_device_paths"] == {}
+
+    # ...with has_binding_points: true (the handler stores
+    # bool(camera_nodes) — an Aravis workflow always has camera nodes).
+    assert bool(camera_nodes) is True

--- a/edge-cv-portal/backend/tests/test_property_aravis_free_packaging_identity.py
+++ b/edge-cv-portal/backend/tests/test_property_aravis_free_packaging_identity.py
@@ -1,0 +1,204 @@
+"""
+Property-based test for Aravis-free packaging identity (task 7.3).
+
+**Feature: aravis-camera-input, Property 10: Aravis-free packaging identity**
+
+*For any* workflow definition containing no `aravis_camera_source`
+node, the packaged compiled document SHALL be byte-identical to the
+pre-feature packaging output for the same definition.
+
+**Validates: Requirements 4.3**
+
+Pre-feature oracle: the only packaging behavior the feature changed is
+gated on the new `aravis_camera_source` type id (the gather predicate
+and the ``aravisBinding`` branch of ``build_binding_points``), so the
+pre-feature output over an Aravis-free definition is reconstructed by
+running the same pure pipeline with the pre-feature gather rule —
+Camera_Input_Nodes are ``camera_source`` (or camera-backed custom)
+nodes only — and asserting the current output equals it byte-for-byte.
+The structure is additionally pinned the way the camera-registry-sync
+snapshot tests (test_workflow_packaging_binding_points.py) pinned
+theirs: a cameraless document IS the compiler's own serialization
+(``compiled.to_json()``), a camera document is that serialization plus
+only the pre-existing bindingPoints section, and no ``aravisBinding``
+key appears anywhere in any produced document.
+
+The module is imported through the shared moto-backed session fixture
+only so its module-level boto3 clients bind to the mock (same re-import
+pattern as test_property_packaging_gates.py).
+
+Generators: 1..3 source->capture chains headed by folder_source or
+camera_source (any mix, including zero camera nodes), with generated
+device paths, optional gain/exposure overrides, and optional
+cameraBindingHint node data.
+"""
+import json
+import sys
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from workflow_core.serializer import parse
+from workflow_core.compiler import compile as compile_workflow, CompileContext
+from workflow_core.catalog import DEVICE_ARCHITECTURES
+from workflow_core.catalog.custom import resolve_catalog
+
+
+@pytest.fixture(scope="module")
+def packaging(aws_stack):
+    """Import workflow_packaging inside the moto mock so its module-level
+    boto3 clients (DynamoDB / S3 / KMS) are intercepted."""
+    sys.modules.pop("workflow_packaging", None)
+    import workflow_packaging
+
+    return workflow_packaging
+
+
+# ---------------------------------------------------------------------------
+# Generators: Aravis-free definitions
+# ---------------------------------------------------------------------------
+
+_device_paths = st.integers(min_value=0, max_value=63).map(
+    lambda n: "/dev/video{}".format(n))
+
+_hint_text = st.text(min_size=1, max_size=24)
+
+_hints = st.fixed_dictionaries(
+    {"cameraSourceId": _hint_text},
+    optional={"cameraName": _hint_text, "sourceDeviceId": _hint_text},
+)
+
+
+@st.composite
+def _aravis_free_definitions(draw):
+    """A valid definition of 1..3 source->capture chains headed by
+    folder_source or camera_source — never aravis_camera_source."""
+    chain_count = draw(st.integers(min_value=1, max_value=3))
+    nodes, connections = [], []
+    for i in range(chain_count):
+        if draw(st.booleans()):
+            parameters = {"device": draw(_device_paths)}
+            if draw(st.booleans()):
+                parameters["gain"] = draw(st.integers(min_value=0, max_value=100))
+            if draw(st.booleans()):
+                parameters["exposure"] = draw(
+                    st.integers(min_value=0, max_value=10_000_000))
+            source = {"id": "cam{}".format(i), "type": "camera_source",
+                      "position": {"x": 100.0 * i, "y": 0.0},
+                      "parameters": parameters}
+            if draw(st.booleans()):
+                source["data"] = {"cameraBindingHint": draw(_hints)}
+        else:
+            source = {"id": "src{}".format(i), "type": "folder_source",
+                      "position": {"x": 100.0 * i, "y": 0.0},
+                      "parameters": {"location": "/data/images/{}".format(i)}}
+        nodes.append(source)
+        nodes.append({"id": "cap{}".format(i), "type": "capture",
+                      "position": {"x": 100.0 * i, "y": 200.0},
+                      "parameters": {"output_path": "/out/{}".format(i)}})
+        connections.append({
+            "id": "c{}".format(i),
+            "from": {"node": source["id"], "port": "out"},
+            "to": {"node": "cap{}".format(i), "port": "in"},
+        })
+    return {"schemaVersion": 1, "nodes": nodes, "connections": connections}
+
+
+# ---------------------------------------------------------------------------
+# Pre-feature oracle
+# ---------------------------------------------------------------------------
+
+#: Binding-point entry keys the pre-feature packager could produce
+#: (camera-registry-sync): never aravisBinding.
+PRE_FEATURE_POINT_KEYS = {"nodeId", "nodeType", "parameters", "slots",
+                          "bindingHint", "adapterBinding", "csiSensorBinding"}
+
+
+def pre_feature_camera_nodes(graph):
+    """The pre-feature gather rule: camera_source nodes only (no custom
+    camera-backed types are in play — resolved_items is empty here)."""
+    return [node for node in graph.nodes if node.type == "camera_source"]
+
+
+def assert_no_aravis_key(value):
+    """No aravisBinding key anywhere in the document tree."""
+    if isinstance(value, dict):
+        assert "aravisBinding" not in value
+        for child in value.values():
+            assert_no_aravis_key(child)
+    elif isinstance(value, list):
+        for child in value:
+            assert_no_aravis_key(child)
+
+
+# ---------------------------------------------------------------------------
+# Property 10
+# ---------------------------------------------------------------------------
+
+@settings(deadline=None)
+@given(definition=_aravis_free_definitions())
+def test_aravis_free_packaging_is_byte_identical_to_pre_feature_output(
+        packaging, definition):
+    """**Feature: aravis-camera-input, Property 10: Aravis-free packaging identity**
+
+    For any Aravis-free definition, ``compiled_document_json`` over the
+    current pipeline is byte-equal to the pre-feature serialization of
+    the same definition on every device architecture.
+
+    **Validates: Requirements 4.3**
+    """
+    parse_result = parse(json.dumps(definition))
+    assert parse_result.ok, parse_result.error
+    graph = parse_result.graph
+
+    # The feature's gather gate adds nothing on an Aravis-free graph:
+    # the gathered Camera_Input_Nodes ARE the pre-feature set.
+    camera_nodes = packaging.gather_camera_input_nodes(graph, set())
+    expected_nodes = pre_feature_camera_nodes(graph)
+    assert [n.id for n in camera_nodes] == [n.id for n in expected_nodes]
+
+    hints = packaging.binding_hints_from_definition(definition)
+    catalog = resolve_catalog([])
+    descriptors_by_id = {d.type_id: d for d in catalog}
+    context = CompileContext(workflow_id="wf-p10", workflow_version="1")
+
+    for arch in DEVICE_ARCHITECTURES:
+        compiled = compile_workflow(graph, arch, context, simulation=False,
+                                    catalog=catalog)
+        assert not isinstance(compiled, list), (
+            "compilation failed on {}: {}".format(arch, compiled))
+        compiled_dict = compiled.to_dict()
+
+        binding_points = packaging.build_binding_points(
+            camera_nodes, compiled_dict, arch, hints, descriptors_by_id)
+        packaged_text = packaging.compiled_document_json(
+            compiled, binding_points)
+
+        # Pre-feature reconstruction: same pure pipeline driven by the
+        # pre-feature gather rule (the type-id gate is the only change).
+        pre_feature_points = packaging.build_binding_points(
+            expected_nodes, compiled_dict, arch, hints, descriptors_by_id)
+        pre_feature_text = packaging.compiled_document_json(
+            compiled, pre_feature_points)
+
+        # 4.3: byte-identical output.
+        assert packaged_text == pre_feature_text
+
+        # Structure pinning, as the camera-registry-sync snapshots did:
+        document = json.loads(packaged_text)
+        assert_no_aravis_key(document)
+        if not camera_nodes:
+            # Cameraless: byte-identical to the compiler's own
+            # serialization — exactly the pre-feature packager output.
+            assert packaged_text == compiled.to_json()
+            assert "bindingPoints" not in document
+        else:
+            # Camera workflow: the compiler serialization plus only the
+            # pre-existing bindingPoints section, canonically serialized.
+            expected_doc = compiled.to_dict()
+            expected_doc["bindingPoints"] = binding_points
+            assert packaged_text == json.dumps(
+                expected_doc, sort_keys=True, indent=2, ensure_ascii=True)
+            for point in document["bindingPoints"]:
+                assert set(point) <= PRE_FEATURE_POINT_KEYS

--- a/edge-cv-portal/backend/tests/test_property_aravis_override_constraints.py
+++ b/edge-cv-portal/backend/tests/test_property_aravis_override_constraints.py
@@ -1,0 +1,176 @@
+"""
+Property-based test for manual-override constraint validation of
+aravis_camera_source nodes — validate_camera_bindings
+(functions/deployments.py).
+
+**Feature: aravis-camera-input, Property 12: Aravis override constraint validation**
+
+*For any* manual override submitted for an `aravis_camera_source` node,
+validation SHALL accept the override exactly when every value satisfies
+the descriptor's declared constraints (non-empty string `camera_id`,
+`gain` within 0-100, `exposure` non-negative, no undeclared parameter
+names).
+
+**Validates: Requirements 5.4**
+
+Task 8.3 (spec: aravis-camera-input). The example-based override unit
+tests live in test_camera_binding_validation.py (task 8.1); the generic
+override property over camera_source (camera-registry-sync Property 16)
+lives in test_camera_binding_type_override_properties.py.
+"""
+import sys
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+
+@pytest.fixture(scope="module")
+def deployments(aws_stack):
+    """Import deployments inside the moto mock so its module-level boto3
+    clients are intercepted."""
+    for module_name in ("deployments", "workflow_guards"):
+        sys.modules.pop(module_name, None)
+    import deployments
+
+    return deployments
+
+
+# ---------------------------------------------------------------------------
+# Generators: per declared parameter, a valid pool and a violating pool,
+# so the expected verdict is decidable by the requirement's own words
+# (never by the implementation's validator).
+# ---------------------------------------------------------------------------
+
+#: camera_id: string, min_length 1 — valid iff a non-empty string.
+_CAMERA_ID_VALID = st.one_of(
+    st.sampled_from(["Aravis-Fake-GV01", "Basler-12345678", "caméra ☂"]),
+    st.text(min_size=1, max_size=30),
+)
+#: Violations: emptiness (the emptiness case named by the task) and
+#: non-string values.
+_CAMERA_ID_INVALID = st.one_of(
+    st.just(""),
+    st.integers(min_value=-10, max_value=10),
+    st.booleans(),
+)
+
+#: gain: int, 0-100 — valid iff an int (bools are not ints to the
+#: validator) within bounds.
+_GAIN_VALID = st.integers(min_value=0, max_value=100)
+_GAIN_INVALID = st.one_of(
+    st.integers(min_value=-1000, max_value=-1),
+    st.integers(min_value=101, max_value=1_000_000),
+    st.sampled_from(["4", "high"]),
+    st.booleans(),
+    st.floats(allow_nan=False, allow_infinity=False),
+)
+
+#: exposure: int, min 0 (no max) — valid iff a non-negative int.
+_EXPOSURE_VALID = st.integers(min_value=0, max_value=10**12)
+_EXPOSURE_INVALID = st.one_of(
+    st.integers(min_value=-10**9, max_value=-1),
+    st.sampled_from(["5000000"]),
+    st.booleans(),
+    st.floats(allow_nan=False, allow_infinity=False),
+)
+
+_POOLS = {
+    "camera_id": (_CAMERA_ID_VALID, _CAMERA_ID_INVALID),
+    "gain": (_GAIN_VALID, _GAIN_INVALID),
+    "exposure": (_EXPOSURE_VALID, _EXPOSURE_INVALID),
+}
+
+#: Undeclared parameter names: violations whatever the value.
+_UNDECLARED_NAMES = ["device", "bogus", "camera-id"]
+
+
+@st.composite
+def _override_cases(draw):
+    """One aravis_camera_source node per target with a manual-override
+    binding drawing, per declared parameter, from the valid or the
+    violating pool (recording which), plus optionally an undeclared key.
+    Returns the expected per-value verdicts alongside the inputs."""
+    targets = draw(st.lists(st.sampled_from(["line-a", "line-b"]),
+                            unique=True, min_size=1, max_size=2))
+
+    bindings = {}
+    # (device, name) -> expected_valid
+    verdicts = {}
+    for device in targets:
+        override = {}
+        names = draw(st.lists(st.sampled_from(sorted(_POOLS)),
+                              unique=True, max_size=3))
+        for name in names:
+            valid_pool, invalid_pool = _POOLS[name]
+            valid = draw(st.booleans())
+            override[name] = draw(valid_pool if valid else invalid_pool)
+            verdicts[(device, name)] = valid
+        if draw(st.booleans()):
+            name = draw(st.sampled_from(_UNDECLARED_NAMES))
+            override[name] = draw(st.one_of(
+                st.text(max_size=10), st.integers(-5, 5)))
+            verdicts[(device, name)] = False
+        bindings[device] = {"n1": {"override": override}}
+
+    version = {
+        "has_binding_points": True,
+        "camera_input_nodes": [
+            {"node_id": "n1", "node_type": "aravis_camera_source"}
+        ],
+    }
+    registry_snapshot = {device: {"never_synced": False, "cameras": {}}
+                         for device in targets}
+    return version, targets, registry_snapshot, bindings, verdicts
+
+
+# ---------------------------------------------------------------------------
+# Property 12
+# ---------------------------------------------------------------------------
+
+# Example count comes from the conftest hypothesis profile: 25 for fast
+# local runs (portal-fast), 100 (the spec minimum) with HYPOTHESIS_PROFILE=ci.
+@settings(deadline=None)
+@given(_override_cases())
+def test_aravis_override_accepted_exactly_when_constraints_hold(
+        deployments, case):
+    """**Feature: aravis-camera-input, Property 12: Aravis override
+    constraint validation**
+
+    **Validates: Requirements 5.4**
+
+    An aravis_camera_source override produces one
+    CAMERA_OVERRIDE_INVALID error per value violating the descriptor's
+    declared constraints (empty or non-string camera_id, gain outside
+    0-100 or not an int, negative or non-int exposure) and per
+    undeclared parameter name — and is accepted (no error at all)
+    exactly when every supplied value satisfies its declared constraint.
+    """
+    version, targets, registry_snapshot, bindings, verdicts = case
+
+    errors, warnings = deployments.validate_camera_bindings(
+        version, targets, registry_snapshot, bindings, [])
+
+    override_errors = [
+        e for e in errors
+        if e["code"] == deployments.CAMERA_ERROR_OVERRIDE_INVALID]
+
+    expected_rejections = {(device, name)
+                           for (device, name), valid in verdicts.items()
+                           if not valid}
+
+    # One error per violating value / undeclared name, none for
+    # satisfying values: acceptance exactly when every value holds.
+    assert {(e["device"], e["parameter"]) for e in override_errors} \
+        == expected_rejections
+    assert len(override_errors) == len(expected_rejections)
+
+    for error in override_errors:
+        assert error["nodeId"] == "n1"
+        # The message names the offending parameter.
+        assert error["parameter"] in error["message"]
+
+    # Override constraint checking is the only error signal here, and a
+    # bound (overridden) node on a synced target raises no warnings.
+    assert len(errors) == len(override_errors)
+    assert warnings == []

--- a/edge-cv-portal/backend/tests/test_property_aravis_type_compatibility.py
+++ b/edge-cv-portal/backend/tests/test_property_aravis_type_compatibility.py
@@ -1,0 +1,172 @@
+"""
+Property-based test for the Aravis type-compatibility rule of
+deploy-time Camera_Binding validation — validate_camera_bindings
+(functions/deployments.py).
+
+**Feature: aravis-camera-input, Property 11: Aravis type-compatibility validation**
+
+*For any* workflow version with Camera_Input_Nodes, target registry
+snapshot, and binding set, `validate_camera_bindings` SHALL produce a
+type-incompatibility error for a binding exactly when the bound
+Camera_Source's type is outside the node type's declared compatible set
+— `{Camera, AravisDiscovered}` for `aravis_camera_source`, the existing
+set plus `AravisDiscovered` for `camera_source`.
+
+**Validates: Requirements 5.2, 5.3**
+
+Task 8.2 (spec: aravis-camera-input). The example-based unit tests over
+the same rule live in test_camera_binding_validation.py (task 8.1); the
+pre-feature type/override property (camera-registry-sync Property 16)
+lives in test_camera_binding_type_override_properties.py.
+"""
+import sys
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+
+@pytest.fixture(scope="module")
+def deployments(aws_stack):
+    """Import deployments inside the moto mock so its module-level boto3
+    clients are intercepted."""
+    for module_name in ("deployments", "workflow_guards"):
+        sys.modules.pop(module_name, None)
+    import deployments
+
+    return deployments
+
+
+# ---------------------------------------------------------------------------
+# Compatibility-map oracle (restated from the requirements, independent
+# of the implementation's _CAMERA_COMPATIBLE_SOURCE_TYPES)
+# ---------------------------------------------------------------------------
+
+#: camera_source keeps its pre-feature camera-backed set plus
+#: AravisDiscovered (Requirement 5.3); aravis_camera_source must bind to
+#: an Aravis-backed source (Requirement 5.2).
+_COMPATIBLE = {
+    "camera_source": frozenset({"Camera", "ICam", "NvidiaCSI",
+                                "V4L2Discovered", "AravisDiscovered"}),
+    "aravis_camera_source": frozenset({"Camera", "AravisDiscovered"}),
+}
+
+_NODE_TYPES = sorted(_COMPATIBLE)
+
+#: Arbitrary registry source types: every type in either compatible set,
+#: plus types outside both (Folder is Requirement 9.4's categorical
+#: mismatch; RTSP/HTTPPull are network-stream types) and an unknown one.
+_SOURCE_TYPES = ["Camera", "ICam", "NvidiaCSI", "V4L2Discovered",
+                 "AravisDiscovered", "Folder", "RTSP", "HTTPPull",
+                 "SomethingElse"]
+
+_NODE_IDS = ["n1", "n2", "n3", "n4"]
+_DEVICES = ["line-a", "line-b", "line-c"]
+
+
+@st.composite
+def _type_cases(draw):
+    """A version item mixing aravis_camera_source and camera_source
+    nodes, per-device registries whose entries carry arbitrary source
+    types, and a binding set referencing them. Every referenced source
+    exists and is healthy (synced, present, fresh), so type
+    compatibility is the only possible error signal."""
+    node_ids = draw(st.lists(st.sampled_from(_NODE_IDS),
+                             unique=True, min_size=1, max_size=4))
+    node_types = {node_id: draw(st.sampled_from(_NODE_TYPES))
+                  for node_id in node_ids}
+    # At least one Aravis node so every case exercises the new rule.
+    node_types[node_ids[0]] = "aravis_camera_source"
+    targets = draw(st.lists(st.sampled_from(_DEVICES),
+                            unique=True, min_size=1, max_size=3))
+
+    registry_snapshot = {}
+    bindings = {}
+    # (device, node_id) -> (camera_source_id, source_type)
+    source_refs = {}
+
+    for device in targets:
+        cameras = {}
+        device_bindings = {}
+        for node_id in node_ids:
+            source_type = draw(st.sampled_from(_SOURCE_TYPES))
+            camera_source_id = f"src-{device}-{node_id}"
+            cameras[camera_source_id] = {
+                "type": source_type,
+                "params": {"cameraId": "Aravis-Fake-GV01"},
+                "sync_status": "synced",
+                "absent": False,
+                "stale": False,
+            }
+            device_bindings[node_id] = {"cameraSourceId": camera_source_id}
+            source_refs[(device, node_id)] = (camera_source_id, source_type)
+        registry_snapshot[device] = {"never_synced": False,
+                                     "cameras": cameras}
+        bindings[device] = device_bindings
+
+    version = {
+        "has_binding_points": True,
+        "camera_input_nodes": [
+            {"node_id": node_id, "node_type": node_types[node_id]}
+            for node_id in node_ids
+        ],
+    }
+    return version, targets, registry_snapshot, bindings, node_types, \
+        source_refs
+
+
+# ---------------------------------------------------------------------------
+# Property 11
+# ---------------------------------------------------------------------------
+
+# Example count comes from the conftest hypothesis profile: 25 for fast
+# local runs (portal-fast), 100 (the spec minimum) with HYPOTHESIS_PROFILE=ci.
+@settings(deadline=None)
+@given(_type_cases())
+def test_aravis_type_incompatibility_is_flagged_exactly(deployments, case):
+    """**Feature: aravis-camera-input, Property 11: Aravis
+    type-compatibility validation**
+
+    **Validates: Requirements 5.2, 5.3**
+
+    A CAMERA_TYPE_INCOMPATIBLE error is produced exactly for the
+    bindings whose Camera_Source type is outside the node type's
+    compatible set per the compatibility-map oracle: an
+    aravis_camera_source node accepts only {Camera, AravisDiscovered}
+    (5.2), a camera_source node accepts its pre-feature set plus
+    AravisDiscovered (5.3) — and no other error is produced for these
+    healthy, fully bound cases.
+    """
+    (version, targets, registry_snapshot, bindings, node_types,
+     source_refs) = case
+
+    errors, warnings = deployments.validate_camera_bindings(
+        version, targets, registry_snapshot, bindings, [])
+
+    expected_mismatches = {
+        (device, node_id, camera_source_id, source_type)
+        for (device, node_id), (camera_source_id, source_type)
+        in source_refs.items()
+        if source_type not in _COMPATIBLE[node_types[node_id]]
+    }
+
+    type_errors = [
+        e for e in errors
+        if e["code"] == deployments.CAMERA_ERROR_TYPE_INCOMPATIBLE]
+
+    # Exactly one type error per incompatible binding; every compatible
+    # binding passes the type check.
+    assert {(e["device"], e["nodeId"], e["cameraSourceId"], e["sourceType"])
+            for e in type_errors} == expected_mismatches
+    assert len(type_errors) == len(expected_mismatches)
+
+    # Each error identifies both sides of the mismatch.
+    for error in type_errors:
+        assert error["nodeType"] == node_types[error["nodeId"]]
+        assert error["sourceType"] in error["message"]
+        assert error["nodeType"] in error["message"]
+
+    # Healthy, present, fully bound sources: type compatibility is the
+    # only signal — no other errors, no warnings.
+    assert len(errors) == len(type_errors)
+    assert warnings == []

--- a/edge-cv-portal/backend/tests/test_property_bedrock_sampling_preservation.py
+++ b/edge-cv-portal/backend/tests/test_property_bedrock_sampling_preservation.py
@@ -1,0 +1,594 @@
+"""Bug 1 preservation property tests (workflow-designer-bugfixes, task 2).
+
+**Feature: workflow-designer-bugfixes, Property 2: Preservation - Explicit
+temperature behavior unchanged**
+
+_For any_ input where the bug condition does NOT hold - a temperature
+explicitly stored as a number in [0, 1], or a per-request override supplied -
+the pipeline SHALL produce exactly the same result as the original: the
+applicable temperature sent as `inferenceConfig.temperature` with `topP`
+suppressed; invalid overrides (out of range, non-numeric, boolean) rejected
+with 400 `INVALID_TEMPERATURE` before any Bedrock call; `temperature` and
+`topP` never sent together; a request without a temperature key (what a blank
+GenerateChatPanel field produces) using the configured value; and all
+non-temperature settings validation rules unchanged.
+
+**Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5**
+
+PRESERVATION TESTS (observation-first): these encode the observed behavior of
+the UNFIXED code for non-buggy inputs and MUST PASS both before and after the
+Bug 1 fix - they pin down the baseline the fix must not disturb. Assertions
+deliberately avoid anything that differs between the unfixed and fixed code
+(e.g. the effective temperature when nothing was stored).
+
+Runs against the shared moto stack from conftest.py with the Bedrock Converse
+API mocked exactly as in test_property_bedrock_sampling_unset.py /
+test_workflow_generation.py.
+"""
+import json
+import os
+import sys
+import uuid
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from conftest import REGION
+
+SETTINGS_TABLE_NAME = "test-settings-sampling-preservation"
+CHAT_SESSIONS_TABLE_NAME = "test-workflow-chat-sessions-sampling-preservation"
+NODE_GEN_SESSIONS_TABLE_NAME = "test-node-gen-sessions-sampling-preservation"
+
+BEDROCK_CONFIG_RESOURCE_ID = "bedrock-configuration"
+
+# Minimal catalog-conformant Workflow_Definition (as in
+# test_workflow_generation.py) so the generated definition validates cleanly.
+VALID_DEFINITION = {
+    "schemaVersion": 1,
+    "nodes": [
+        {"id": "n1", "type": "camera_source",
+         "position": {"x": 100, "y": 100}, "parameters": {}},
+        {"id": "n2", "type": "capture",
+         "position": {"x": 350, "y": 100},
+         "parameters": {"output_path": "/data/captures"}},
+    ],
+    "connections": [
+        {"id": "c1",
+         "from": {"node": "n1", "port": "out"},
+         "to": {"node": "n2", "port": "in"}},
+    ],
+}
+
+NODE_DECLARATION = {
+    "typeId": "custom_blur",
+    "displayName": "Custom Blur",
+    "description": "Blurs each frame.",
+    "category": "preprocessing",
+    "inputs": [{"name": "in", "portType": "VideoFrames"}],
+    "outputs": [{"name": "out", "portType": "VideoFrames"}],
+    "parameters": [],
+    "architectures": ["x86_64"],
+}
+
+
+def tool_response(tool_name, tool_input):
+    """A Converse API response whose assistant message calls the tool."""
+    return {
+        "output": {"message": {"role": "assistant", "content": [
+            {"toolUse": {"toolUseId": "tool-1", "name": tool_name,
+                         "input": tool_input}},
+        ]}},
+        "stopReason": "tool_use",
+    }
+
+
+@pytest.fixture(scope="module")
+def sampling_env(aws_stack):
+    """Settings + chat-session tables and freshly imported
+    workflow_generator / node_generator / data_accounts modules bound to
+    them inside moto, with the Converse clients mocked."""
+    import boto3
+
+    os.environ["SETTINGS_TABLE"] = SETTINGS_TABLE_NAME
+    os.environ["WORKFLOW_CHAT_SESSIONS_TABLE"] = CHAT_SESSIONS_TABLE_NAME
+    os.environ["NODE_GEN_SESSIONS_TABLE"] = NODE_GEN_SESSIONS_TABLE_NAME
+    os.environ["PLUGIN_SOURCES_PREFIX"] = "plugin-sources"
+
+    client = boto3.client("dynamodb", region_name=REGION)
+    for table_name in (SETTINGS_TABLE_NAME, CHAT_SESSIONS_TABLE_NAME,
+                       NODE_GEN_SESSIONS_TABLE_NAME):
+        key = ("setting_key" if table_name == SETTINGS_TABLE_NAME
+               else "session_id")
+        client.create_table(
+            TableName=table_name,
+            KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": key,
+                                   "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+    # Re-import so the modules bind the table names above and
+    # moto-intercepted boto3 clients (conftest pattern). node_generator
+    # takes get_bedrock_configuration from workflow_generator, and
+    # data_accounts serves the settings API.
+    for module_name in ("data_accounts", "node_generator",
+                        "workflow_generator", "workflow_validation"):
+        sys.modules.pop(module_name, None)
+    import workflow_generator
+    import node_generator
+    import data_accounts
+
+    # Mocked Converse clients, one per pipeline, injected permanently
+    # through get_bedrock_client (reset per example in the tests).
+    wf_client = MagicMock(name="bedrock-runtime-workflow")
+    node_client = MagicMock(name="bedrock-runtime-node")
+    workflow_generator.get_bedrock_client = lambda region, timeout: wf_client
+    node_generator.get_bedrock_client = lambda region, timeout: node_client
+
+    # Run the node-generation worker synchronously in-process so a
+    # dispatched turn is settled by the time the start route returns.
+    def dispatch(session_id, prompt, user):
+        node_generator.handler({
+            "node_gen_worker": True,
+            "session_id": session_id,
+            "prompt": prompt,
+            "user": user,
+        }, None)
+    node_generator.dispatch_generation_worker = dispatch
+
+    from workflow_core.scaffold import render_scaffold
+    reference_files = render_scaffold(NODE_DECLARATION)
+
+    # One Use_Case with a DataScientist (workflow generation) and a
+    # UseCaseAdmin (node generation), reused across examples.
+    usecase_id = f"uc-{uuid.uuid4()}"
+    aws_stack.tables.usecases.put_item(Item={
+        "usecase_id": usecase_id, "name": "UC", "account_id": "123456789012",
+    })
+
+    def make_user(role, usecase_role=None):
+        user_id = f"user-{uuid.uuid4()}"
+        user = {"user_id": user_id, "email": f"{user_id}@example.com",
+                "username": user_id, "role": role}
+        if usecase_role:
+            aws_stack.tables.user_roles.put_item(Item={
+                "user_id": user_id, "usecase_id": usecase_id,
+                "role": usecase_role,
+            })
+        return user
+
+    resource = boto3.resource("dynamodb", region_name=REGION)
+    yield SimpleNamespace(
+        workflow_generator=workflow_generator,
+        node_generator=node_generator,
+        data_accounts=data_accounts,
+        settings_table=resource.Table(SETTINGS_TABLE_NAME),
+        wf_client=wf_client,
+        node_client=node_client,
+        reference_files=reference_files,
+        usecase_id=usecase_id,
+        wf_user=make_user("DataScientist", "DataScientist"),
+        node_user=make_user("UseCaseAdmin", "UseCaseAdmin"),
+        admin=make_user("PortalAdmin"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Store-state setup and invocation helpers
+# ---------------------------------------------------------------------------
+
+def _to_ddb(value):
+    return Decimal(str(value)) if isinstance(value, float) else value
+
+
+def store_sampling_config(env, temperature, top_p=None):
+    """Store a Bedrock_Configuration item with an explicitly configured
+    temperature (a number - the non-bug-condition store states) and an
+    optionally stored top_p."""
+    env.settings_table.delete_item(
+        Key={"setting_key": "bedrock_configuration"})
+    value = {"temperature": _to_ddb(temperature)}
+    if top_p is not None:
+        value["top_p"] = _to_ddb(top_p)
+    env.settings_table.put_item(Item={
+        "setting_key": "bedrock_configuration",
+        "value": value,
+    })
+
+
+def clear_stored_config(env):
+    env.settings_table.delete_item(
+        Key={"setting_key": "bedrock_configuration"})
+
+
+def auth_context(user):
+    return {
+        "authorizer": {
+            "claims": {
+                "sub": user["user_id"],
+                "email": user["email"],
+                "cognito:username": user["username"],
+                "custom:role": user["role"],
+            }
+        }
+    }
+
+
+_NO_OVERRIDE = object()
+
+
+def generate_workflow(env, temperature_override=_NO_OVERRIDE):
+    """POST /workflows/generate, optionally carrying a temperature override.
+
+    When no override is given the request body has no temperature key at
+    all - exactly the payload a blank GenerateChatPanel temperature field
+    produces (Requirement 3.5).
+    """
+    env.wf_client.converse.reset_mock(return_value=True, side_effect=True)
+    env.wf_client.converse.return_value = tool_response(
+        "create_workflow", VALID_DEFINITION)
+    body = {"usecase_id": env.usecase_id, "prompt": "Camera to capture"}
+    if temperature_override is not _NO_OVERRIDE:
+        body["temperature"] = temperature_override
+    event = {
+        "httpMethod": "POST",
+        "resource": "/workflows/generate",
+        "path": "/workflows/generate",
+        "body": json.dumps(body),
+        "requestContext": auth_context(env.wf_user),
+    }
+    response = env.workflow_generator.handler(event, None)
+    return response["statusCode"], json.loads(response["body"])
+
+
+def generate_node(env):
+    """POST /plugins/generate (start) polled to its settled outcome."""
+    env.node_client.converse.reset_mock(return_value=True, side_effect=True)
+    env.node_client.converse.return_value = tool_response(
+        "create_plugin_scaffold", {"files": dict(env.reference_files)})
+
+    def invoke(resource, method, body=None, session_id=None):
+        event = {
+            "httpMethod": method,
+            "resource": resource,
+            "path": resource.replace("{session}", session_id or ""),
+            "pathParameters": ({"session": session_id} if session_id
+                               else None),
+            "body": json.dumps(body) if body is not None else None,
+            "requestContext": auth_context(env.node_user),
+        }
+        response = env.node_generator.handler(event, None)
+        return response["statusCode"], json.loads(response["body"])
+
+    status, body = invoke("/plugins/generate", "POST", {
+        "usecase_id": env.usecase_id,
+        "prompt": "Blur frames",
+        "declaration": NODE_DECLARATION,
+    })
+    if status != 202:
+        return status, body
+    poll_status, turn = invoke("/plugins/generate/{session}", "GET",
+                               session_id=body["session_id"])
+    assert poll_status == 200
+    if turn["turn_status"] == "completed":
+        return 200, turn
+    error = turn["turn_error"]
+    return error.get("http_status", 502), {"error": error}
+
+
+def invoke_settings(env, method, body=None):
+    """GET/PUT /data-accounts/bedrock-configuration as PortalAdmin."""
+    event = {
+        "httpMethod": method,
+        "resource": "/data-accounts/{id}",
+        "path": f"/data-accounts/{BEDROCK_CONFIG_RESOURCE_ID}",
+        "pathParameters": {"id": BEDROCK_CONFIG_RESOURCE_ID},
+        "body": json.dumps(body) if body is not None else None,
+        "requestContext": auth_context(env.admin),
+    }
+    response = env.data_accounts.handler(event, None)
+    return response["statusCode"], json.loads(response["body"])
+
+
+def captured_inference_config(client):
+    assert client.converse.call_count == 1
+    return client.converse.call_args.kwargs["inferenceConfig"]
+
+
+def assert_temperature_sent(inference_config, expected):
+    """The applicable temperature is sent, topP suppressed, and the
+    never-both invariant holds (Requirements 3.1, 3.2, 3.4)."""
+    assert inference_config.get("temperature") == pytest.approx(
+        float(expected)), (
+        f"expected temperature {expected!r} in {inference_config!r}")
+    assert "topP" not in inference_config, (
+        f"topP must be suppressed when a temperature applies, got "
+        f"{inference_config!r}")
+    assert_never_both(inference_config)
+
+
+def assert_never_both(inference_config):
+    """Invariant across all generated cases: temperature and topP are
+    never both present (Requirement 3.4)."""
+    assert not ("temperature" in inference_config
+                and "topP" in inference_config), (
+        f"temperature and topP must never be sent together, got "
+        f"{inference_config!r}")
+
+
+# ---------------------------------------------------------------------------
+# Generators
+# ---------------------------------------------------------------------------
+
+# Floats destined for DynamoDB storage are rounded to 6 decimal places:
+# raw hypothesis floats include subnormals (e.g. 2.2e-311) below DynamoDB's
+# representable number range (magnitude >= 1e-130), which fail PutItem with
+# a number underflow before the code under test even runs. Six decimals
+# comfortably covers the realistic temperature/top_p input space.
+storable_floats = st.floats(
+    min_value=0, max_value=1, allow_nan=False, allow_infinity=False,
+).map(lambda x: round(x, 6))
+
+# Explicitly stored temperatures: numeric ints (0, 1) and floats in [0, 1]
+# (floats are Decimal-encoded on storage, as DynamoDB requires).
+stored_temperatures = st.one_of(
+    st.integers(min_value=0, max_value=1),
+    storable_floats,
+)
+
+optional_stored_top_ps = st.one_of(st.none(), storable_floats)
+
+# Valid per-request overrides: numbers in [0, 1] (booleans are NOT valid).
+valid_overrides = st.one_of(
+    st.integers(min_value=0, max_value=1),
+    st.floats(min_value=0, max_value=1,
+              allow_nan=False, allow_infinity=False),
+)
+
+# Invalid per-request overrides: out-of-range numbers, booleans,
+# non-numeric JSON values. None is excluded - it means "no override".
+invalid_overrides = st.one_of(
+    st.floats(min_value=1, max_value=1e6, exclude_min=True,
+              allow_nan=False, allow_infinity=False),
+    st.floats(min_value=-1e6, max_value=0, exclude_max=True,
+              allow_nan=False, allow_infinity=False),
+    st.integers(min_value=2, max_value=1000),
+    st.integers(min_value=-1000, max_value=-1),
+    st.booleans(),
+    st.text(max_size=10),
+    st.lists(st.integers(), max_size=3),
+    st.dictionaries(st.text(max_size=5), st.integers(), max_size=2),
+)
+
+# Invalid stored sampling values for the settings PUT: out-of-range numbers,
+# booleans, non-numbers. Explicit null is excluded - its acceptance is the
+# Bug 1 fix itself (exploration test), not preserved behavior.
+invalid_sampling_values = st.one_of(
+    st.floats(min_value=1, max_value=100, exclude_min=True,
+              allow_nan=False, allow_infinity=False),
+    st.floats(min_value=-100, max_value=0, exclude_max=True,
+              allow_nan=False, allow_infinity=False),
+    st.integers(min_value=2, max_value=100),
+    st.integers(min_value=-100, max_value=-1),
+    st.booleans(),
+    st.text(max_size=10),
+    st.lists(st.integers(), max_size=2),
+)
+
+
+# ---------------------------------------------------------------------------
+# Property 2a: an explicitly stored temperature keeps being sent
+#              (workflow generation), topP suppressed (Req 3.1, 3.4, 3.5)
+# ---------------------------------------------------------------------------
+
+@settings(deadline=None)
+@given(temperature=stored_temperatures, top_p=optional_stored_top_ps)
+def test_workflow_generation_sends_stored_temperature(
+        sampling_env, temperature, top_p):
+    """For any explicitly stored temperature in [0, 1] (with or without a
+    stored top_p) and a generation request without a temperature key (the
+    blank-GenerateChatPanel payload), the stored temperature is sent as
+    inferenceConfig.temperature and topP is suppressed
+    (Requirements 3.1, 3.4, 3.5)."""
+    store_sampling_config(sampling_env, temperature, top_p)
+
+    status, _ = generate_workflow(sampling_env)
+    assert status == 200
+
+    inference_config = captured_inference_config(sampling_env.wf_client)
+    assert_temperature_sent(inference_config, temperature)
+
+
+# ---------------------------------------------------------------------------
+# Property 2b: node scaffold generation keeps sending the stored
+#              temperature (Req 3.1, 3.4)
+# ---------------------------------------------------------------------------
+
+@settings(deadline=None)
+@given(temperature=stored_temperatures, top_p=optional_stored_top_ps)
+def test_node_generation_sends_stored_temperature(
+        sampling_env, temperature, top_p):
+    """For any explicitly stored temperature in [0, 1], node scaffold
+    generation (node_generator reuses get_bedrock_configuration()) keeps
+    sending it as inferenceConfig.temperature with topP suppressed
+    (Requirements 3.1, 3.4)."""
+    store_sampling_config(sampling_env, temperature, top_p)
+
+    status, _ = generate_node(sampling_env)
+    assert status == 200
+
+    inference_config = captured_inference_config(sampling_env.node_client)
+    assert_temperature_sent(inference_config, temperature)
+
+
+# ---------------------------------------------------------------------------
+# Property 2c: a valid override replaces the configured temperature for
+#              that invocation only (Req 3.2, 3.4)
+# ---------------------------------------------------------------------------
+
+@settings(deadline=None)
+@given(stored=stored_temperatures, top_p=optional_stored_top_ps,
+       override=valid_overrides)
+def test_valid_override_replaces_stored_temperature_for_one_invocation(
+        sampling_env, stored, top_p, override):
+    """For any explicitly stored temperature and any valid override
+    (a number in [0, 1]), the override is sent for that invocation
+    (topP suppressed), and a subsequent invocation without an override
+    reverts to the stored temperature (Requirements 3.2, 3.4)."""
+    store_sampling_config(sampling_env, stored, top_p)
+
+    # Overridden invocation: the override wins.
+    status, _ = generate_workflow(sampling_env,
+                                  temperature_override=override)
+    assert status == 200
+    inference_config = captured_inference_config(sampling_env.wf_client)
+    assert_temperature_sent(inference_config, override)
+
+    # Next invocation without an override: back to the stored value -
+    # the override applied to that invocation only.
+    status, _ = generate_workflow(sampling_env)
+    assert status == 200
+    inference_config = captured_inference_config(sampling_env.wf_client)
+    assert_temperature_sent(inference_config, stored)
+
+
+# ---------------------------------------------------------------------------
+# Property 2d: invalid overrides keep rejecting with 400 INVALID_TEMPERATURE
+#              before any Bedrock call (Req 3.3)
+# ---------------------------------------------------------------------------
+
+@settings(deadline=None)
+@given(stored=stored_temperatures, override=invalid_overrides)
+def test_invalid_override_rejected_before_bedrock_call(
+        sampling_env, stored, override):
+    """For any invalid per-request temperature (out of range, non-numeric,
+    or boolean), the request is rejected with 400 INVALID_TEMPERATURE and
+    Bedrock is never invoked (Requirement 3.3)."""
+    store_sampling_config(sampling_env, stored)
+
+    status, body = generate_workflow(sampling_env,
+                                     temperature_override=override)
+    assert status == 400, (
+        f"override {override!r} must be rejected, got {status}: {body!r}")
+    assert body["error"]["code"] == "INVALID_TEMPERATURE"
+    assert sampling_env.wf_client.converse.call_count == 0, (
+        "Bedrock must not be invoked when the override is invalid")
+
+
+# ---------------------------------------------------------------------------
+# Property 2e: settings validation keeps rejecting invalid sampling values
+#              and accepting numeric ones (Req 3.1)
+# ---------------------------------------------------------------------------
+
+@settings(deadline=None)
+@given(key=st.sampled_from(["temperature", "top_p"]),
+       value=invalid_sampling_values)
+def test_settings_rejects_invalid_sampling_values(sampling_env, key, value):
+    """PUT bedrock-configuration with an out-of-range, boolean, or
+    non-numeric temperature/top_p keeps rejecting with 400 and the
+    established validation message (unchanged validation rules)."""
+    clear_stored_config(sampling_env)
+
+    status, body = invoke_settings(sampling_env, "PUT", {key: value})
+    assert status == 400, (
+        f"{key}={value!r} must be rejected, got {status}: {body!r}")
+    assert f"{key} must be a number between 0 and 1" \
+        in body["validation_errors"]
+
+
+@settings(deadline=None)
+@given(temperature=stored_temperatures, top_p=storable_floats)
+def test_settings_accepts_numeric_sampling_values_and_round_trips(
+        sampling_env, temperature, top_p):
+    """PUT bedrock-configuration with numeric temperature/top_p in [0, 1]
+    keeps being accepted with 200 and round-trips through GET
+    (Requirement 3.1)."""
+    clear_stored_config(sampling_env)
+
+    status, body = invoke_settings(sampling_env, "PUT", {
+        "temperature": temperature, "top_p": top_p,
+    })
+    assert status == 200, f"got {status}: {body!r}"
+    assert body["bedrock_configuration"]["temperature"] == pytest.approx(
+        temperature)
+    assert body["bedrock_configuration"]["top_p"] == pytest.approx(top_p)
+
+    status, body = invoke_settings(sampling_env, "GET")
+    assert status == 200
+    assert body["bedrock_configuration"]["temperature"] == pytest.approx(
+        temperature)
+    assert body["bedrock_configuration"]["top_p"] == pytest.approx(top_p)
+
+
+# ---------------------------------------------------------------------------
+# Property 2f: non-temperature settings validation rules unchanged
+# ---------------------------------------------------------------------------
+
+@st.composite
+def non_sampling_field_cases(draw):
+    """(field, value, valid, error_snippet) over the non-sampling
+    Bedrock_Configuration fields' validation rules as they stand today."""
+    field = draw(st.sampled_from(
+        ["model_id", "region", "max_tokens", "timeout_seconds"]))
+    valid = draw(st.booleans())
+
+    if field in ("model_id", "region"):
+        if valid:
+            value = draw(st.text(min_size=1, max_size=40).filter(
+                lambda s: s.strip()))
+        else:
+            value = draw(st.one_of(
+                st.just(""), st.just("   "),
+                st.integers(), st.booleans(), st.none(),
+                st.lists(st.text(max_size=3), max_size=2),
+            ))
+        snippet = f"{field} must be a non-empty string"
+    elif field == "max_tokens":
+        if valid:
+            value = draw(st.integers(min_value=1, max_value=100000))
+        else:
+            value = draw(st.one_of(
+                st.integers(min_value=-1000, max_value=0),
+                st.booleans(),
+                st.floats(allow_nan=False, allow_infinity=False),
+                st.text(max_size=10), st.none(),
+            ))
+        snippet = "max_tokens must be a positive integer"
+    else:  # timeout_seconds: integer in [1, 60]
+        if valid:
+            value = draw(st.integers(min_value=1, max_value=60))
+        else:
+            value = draw(st.one_of(
+                st.integers(min_value=-1000, max_value=0),
+                st.integers(min_value=61, max_value=1000),
+                st.booleans(),
+                st.floats(allow_nan=False, allow_infinity=False),
+                st.text(max_size=10), st.none(),
+            ))
+        snippet = "timeout_seconds must be an integer between 1 and 60"
+    return field, value, valid, snippet
+
+
+@settings(deadline=None)
+@given(case=non_sampling_field_cases())
+def test_settings_non_sampling_rules_unchanged(sampling_env, case):
+    """model_id / region / max_tokens / timeout_seconds keep accepting and
+    rejecting exactly as today (unchanged validation rules, timeout clamp
+    domain 1..60)."""
+    field, value, valid, snippet = case
+    clear_stored_config(sampling_env)
+
+    status, body = invoke_settings(sampling_env, "PUT", {field: value})
+    if valid:
+        assert status == 200, (
+            f"valid {field}={value!r} must be accepted, got {status}: "
+            f"{body!r}")
+    else:
+        assert status == 400, (
+            f"invalid {field}={value!r} must be rejected, got {status}: "
+            f"{body!r}")
+        assert snippet in body["validation_errors"]

--- a/edge-cv-portal/backend/tests/test_property_bedrock_sampling_unset.py
+++ b/edge-cv-portal/backend/tests/test_property_bedrock_sampling_unset.py
@@ -1,0 +1,422 @@
+"""Bug 1 bug condition exploration property test (workflow-designer-bugfixes,
+task 1).
+
+**Feature: workflow-designer-bugfixes, Property 1: Bug Condition - Temperature
+omitted when unset**
+
+_For any_ Bedrock configuration store state in which no temperature value was
+explicitly stored (nothing stored at all, a stored item without the
+`temperature` key, or a stored explicit null) and any generation request
+without a temperature override, the `get_bedrock_configuration()` +
+`invoke_generation()` pipeline (workflow and node generators alike) SHALL
+produce an `inferenceConfig` containing no `temperature` key - and no `topP`
+key unless a top_p was explicitly stored; and _for any_ settings save with a
+blank/null temperature (or top_p), validation SHALL accept the save and store
+the parameter as unset, round-tripping as unset through GET
+(`read_stored_bedrock_configuration`).
+
+**Validates: Requirements 1.1, 1.2, 1.3, 2.1, 2.2, 2.3**
+
+EXPLORATION TEST: this encodes the EXPECTED (fixed) behavior and is EXPECTED
+TO FAIL on the unfixed code - the failure (with its counterexamples) confirms
+the bug exists (isBugCondition1 in design.md). After the Bug 1 fix it must
+pass unchanged.
+
+Runs against the shared moto stack from conftest.py with the Bedrock Converse
+API mocked exactly as in test_workflow_generation.py /
+test_node_generator_integration.py.
+"""
+import json
+import os
+import sys
+import uuid
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from conftest import REGION, TEST_ENV
+
+SETTINGS_TABLE_NAME = "test-settings-sampling-unset"
+CHAT_SESSIONS_TABLE_NAME = "test-workflow-chat-sessions-sampling-unset"
+NODE_GEN_SESSIONS_TABLE_NAME = "test-node-gen-sessions-sampling-unset"
+
+BEDROCK_CONFIG_RESOURCE_ID = "bedrock-configuration"
+
+# Minimal catalog-conformant Workflow_Definition (as in
+# test_workflow_generation.py) so the generated definition validates cleanly.
+VALID_DEFINITION = {
+    "schemaVersion": 1,
+    "nodes": [
+        {"id": "n1", "type": "camera_source",
+         "position": {"x": 100, "y": 100}, "parameters": {}},
+        {"id": "n2", "type": "capture",
+         "position": {"x": 350, "y": 100},
+         "parameters": {"output_path": "/data/captures"}},
+    ],
+    "connections": [
+        {"id": "c1",
+         "from": {"node": "n1", "port": "out"},
+         "to": {"node": "n2", "port": "in"}},
+    ],
+}
+
+NODE_DECLARATION = {
+    "typeId": "custom_blur",
+    "displayName": "Custom Blur",
+    "description": "Blurs each frame.",
+    "category": "preprocessing",
+    "inputs": [{"name": "in", "portType": "VideoFrames"}],
+    "outputs": [{"name": "out", "portType": "VideoFrames"}],
+    "parameters": [],
+    "architectures": ["x86_64"],
+}
+
+
+def tool_response(tool_name, tool_input):
+    """A Converse API response whose assistant message calls the tool."""
+    return {
+        "output": {"message": {"role": "assistant", "content": [
+            {"toolUse": {"toolUseId": "tool-1", "name": tool_name,
+                         "input": tool_input}},
+        ]}},
+        "stopReason": "tool_use",
+    }
+
+
+@pytest.fixture(scope="module")
+def sampling_env(aws_stack):
+    """Settings + chat-session tables and freshly imported
+    workflow_generator / node_generator / data_accounts modules bound to
+    them inside moto, with the Converse clients mocked."""
+    import boto3
+
+    os.environ["SETTINGS_TABLE"] = SETTINGS_TABLE_NAME
+    os.environ["WORKFLOW_CHAT_SESSIONS_TABLE"] = CHAT_SESSIONS_TABLE_NAME
+    os.environ["NODE_GEN_SESSIONS_TABLE"] = NODE_GEN_SESSIONS_TABLE_NAME
+    os.environ["PLUGIN_SOURCES_PREFIX"] = "plugin-sources"
+
+    client = boto3.client("dynamodb", region_name=REGION)
+    for table_name in (SETTINGS_TABLE_NAME, CHAT_SESSIONS_TABLE_NAME,
+                       NODE_GEN_SESSIONS_TABLE_NAME):
+        key = ("setting_key" if table_name == SETTINGS_TABLE_NAME
+               else "session_id")
+        client.create_table(
+            TableName=table_name,
+            KeySchema=[{"AttributeName": key, "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": key,
+                                   "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+    # Re-import so the modules bind the table names above and
+    # moto-intercepted boto3 clients (conftest pattern). node_generator
+    # takes get_bedrock_configuration from workflow_generator, and
+    # data_accounts serves the settings API.
+    for module_name in ("data_accounts", "node_generator",
+                        "workflow_generator", "workflow_validation"):
+        sys.modules.pop(module_name, None)
+    import workflow_generator
+    import node_generator
+    import data_accounts
+
+    # Mocked Converse clients, one per pipeline, injected permanently
+    # through get_bedrock_client (reset per example in the tests).
+    wf_client = MagicMock(name="bedrock-runtime-workflow")
+    node_client = MagicMock(name="bedrock-runtime-node")
+    workflow_generator.get_bedrock_client = lambda region, timeout: wf_client
+    node_generator.get_bedrock_client = lambda region, timeout: node_client
+
+    # Run the node-generation worker synchronously in-process so a
+    # dispatched turn is settled by the time the start route returns.
+    def dispatch(session_id, prompt, user):
+        node_generator.handler({
+            "node_gen_worker": True,
+            "session_id": session_id,
+            "prompt": prompt,
+            "user": user,
+        }, None)
+    node_generator.dispatch_generation_worker = dispatch
+
+    from workflow_core.scaffold import render_scaffold
+    reference_files = render_scaffold(NODE_DECLARATION)
+
+    # One Use_Case with a DataScientist (workflow generation) and a
+    # UseCaseAdmin (node generation), reused across examples.
+    usecase_id = f"uc-{uuid.uuid4()}"
+    aws_stack.tables.usecases.put_item(Item={
+        "usecase_id": usecase_id, "name": "UC", "account_id": "123456789012",
+    })
+
+    def make_user(role, usecase_role=None):
+        user_id = f"user-{uuid.uuid4()}"
+        user = {"user_id": user_id, "email": f"{user_id}@example.com",
+                "username": user_id, "role": role}
+        if usecase_role:
+            aws_stack.tables.user_roles.put_item(Item={
+                "user_id": user_id, "usecase_id": usecase_id,
+                "role": usecase_role,
+            })
+        return user
+
+    resource = boto3.resource("dynamodb", region_name=REGION)
+    yield SimpleNamespace(
+        workflow_generator=workflow_generator,
+        node_generator=node_generator,
+        data_accounts=data_accounts,
+        settings_table=resource.Table(SETTINGS_TABLE_NAME),
+        wf_client=wf_client,
+        node_client=node_client,
+        reference_files=reference_files,
+        usecase_id=usecase_id,
+        wf_user=make_user("DataScientist", "DataScientist"),
+        node_user=make_user("UseCaseAdmin", "UseCaseAdmin"),
+        admin=make_user("PortalAdmin"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Store-state setup and invocation helpers
+# ---------------------------------------------------------------------------
+
+def _to_ddb(value):
+    return Decimal(str(value)) if isinstance(value, float) else value
+
+
+def apply_store_state(env, state, top_p):
+    """Materialize an unset-temperature Bedrock_Configuration store state.
+
+    state:
+      'no_item'            - nothing stored at all
+      'no_temperature_key' - stored item whose value has no temperature key
+      'explicit_null'      - stored item with temperature explicitly null
+    top_p: an explicitly stored top_p value, or None for not stored
+    (necessarily None when state == 'no_item').
+    """
+    env.settings_table.delete_item(Key={"setting_key": "bedrock_configuration"})
+    if state == "no_item":
+        return
+    value = {}
+    if state == "explicit_null":
+        value["temperature"] = None
+    if top_p is not None:
+        value["top_p"] = _to_ddb(top_p)
+    env.settings_table.put_item(Item={
+        "setting_key": "bedrock_configuration",
+        "value": value,
+    })
+
+
+def auth_context(user):
+    return {
+        "authorizer": {
+            "claims": {
+                "sub": user["user_id"],
+                "email": user["email"],
+                "cognito:username": user["username"],
+                "custom:role": user["role"],
+            }
+        }
+    }
+
+
+def generate_workflow(env):
+    """POST /workflows/generate without a temperature override."""
+    env.wf_client.converse.reset_mock(return_value=True, side_effect=True)
+    env.wf_client.converse.return_value = tool_response(
+        "create_workflow", VALID_DEFINITION)
+    event = {
+        "httpMethod": "POST",
+        "resource": "/workflows/generate",
+        "path": "/workflows/generate",
+        "body": json.dumps({"usecase_id": env.usecase_id,
+                            "prompt": "Camera to capture"}),
+        "requestContext": auth_context(env.wf_user),
+    }
+    response = env.workflow_generator.handler(event, None)
+    return response["statusCode"], json.loads(response["body"])
+
+
+def generate_node(env):
+    """POST /plugins/generate (start) polled to its settled outcome."""
+    env.node_client.converse.reset_mock(return_value=True, side_effect=True)
+    env.node_client.converse.return_value = tool_response(
+        "create_plugin_scaffold", {"files": dict(env.reference_files)})
+
+    def invoke(resource, method, body=None, session_id=None):
+        event = {
+            "httpMethod": method,
+            "resource": resource,
+            "path": resource.replace("{session}", session_id or ""),
+            "pathParameters": ({"session": session_id} if session_id
+                               else None),
+            "body": json.dumps(body) if body is not None else None,
+            "requestContext": auth_context(env.node_user),
+        }
+        response = env.node_generator.handler(event, None)
+        return response["statusCode"], json.loads(response["body"])
+
+    status, body = invoke("/plugins/generate", "POST", {
+        "usecase_id": env.usecase_id,
+        "prompt": "Blur frames",
+        "declaration": NODE_DECLARATION,
+    })
+    if status != 202:
+        return status, body
+    poll_status, turn = invoke("/plugins/generate/{session}", "GET",
+                               session_id=body["session_id"])
+    assert poll_status == 200
+    if turn["turn_status"] == "completed":
+        return 200, turn
+    error = turn["turn_error"]
+    return error.get("http_status", 502), {"error": error}
+
+
+def invoke_settings(env, method, body=None):
+    """GET/PUT /data-accounts/bedrock-configuration as PortalAdmin."""
+    event = {
+        "httpMethod": method,
+        "resource": "/data-accounts/{id}",
+        "path": f"/data-accounts/{BEDROCK_CONFIG_RESOURCE_ID}",
+        "pathParameters": {"id": BEDROCK_CONFIG_RESOURCE_ID},
+        "body": json.dumps(body) if body is not None else None,
+        "requestContext": auth_context(env.admin),
+    }
+    response = env.data_accounts.handler(event, None)
+    return response["statusCode"], json.loads(response["body"])
+
+
+def assert_no_temperature(inference_config, top_p):
+    """Property 1 core assertion over a captured inferenceConfig."""
+    assert "temperature" not in inference_config, (
+        f"temperature must be omitted when unset, got "
+        f"{inference_config!r}")
+    if top_p is None:
+        assert "topP" not in inference_config, (
+            f"topP must be omitted unless a top_p was explicitly stored, "
+            f"got {inference_config!r}")
+    else:
+        assert inference_config.get("topP") == pytest.approx(top_p)
+
+
+# ---------------------------------------------------------------------------
+# Generators: unset-temperature store states from isBugCondition1
+# ---------------------------------------------------------------------------
+
+@st.composite
+def unset_temperature_stores(draw):
+    """(state, top_p): a store state where no temperature was explicitly
+    stored, optionally with an explicitly stored top_p (only possible when
+    an item exists at all)."""
+    state = draw(st.sampled_from(
+        ["no_item", "no_temperature_key", "explicit_null"]))
+    top_p = None
+    if state != "no_item":
+        # Rounded to 6 decimal places: DynamoDB numbers only support
+        # exponents down to ~1e-130, so unconstrained floats (e.g.
+        # 6.5e-177) are unrealizable store states - boto3's Decimal
+        # serializer raises Underflow before the property is evaluated.
+        top_p = draw(st.one_of(
+            st.none(),
+            st.floats(min_value=0, max_value=1,
+                      allow_nan=False, allow_infinity=False)
+            .map(lambda x: round(x, 6)),
+        ))
+    return state, top_p
+
+
+# ---------------------------------------------------------------------------
+# Property 1a: workflow generation omits temperature when unset
+# ---------------------------------------------------------------------------
+
+@settings(deadline=None)
+@given(store=unset_temperature_stores())
+def test_workflow_generation_omits_temperature_when_unset(sampling_env, store):
+    """For any unset-temperature store state and a generation request with
+    no temperature override, the workflow-generation inferenceConfig
+    contains no temperature key, and no topP key unless a top_p was
+    explicitly stored (Requirements 1.1, 2.1)."""
+    state, top_p = store
+    apply_store_state(sampling_env, state, top_p)
+
+    status, _ = generate_workflow(sampling_env)
+    assert status == 200
+
+    assert sampling_env.wf_client.converse.call_count == 1
+    inference_config = sampling_env.wf_client.converse.call_args.kwargs[
+        "inferenceConfig"]
+    assert_no_temperature(inference_config, top_p)
+
+
+# ---------------------------------------------------------------------------
+# Property 1b: node scaffold generation omits temperature when unset
+# ---------------------------------------------------------------------------
+
+@settings(deadline=None)
+@given(store=unset_temperature_stores())
+def test_node_generation_omits_temperature_when_unset(sampling_env, store):
+    """For any unset-temperature store state and a node scaffold generation
+    (node_generator reuses get_bedrock_configuration()), the inferenceConfig
+    contains no temperature key, and no topP key unless a top_p was
+    explicitly stored (Requirements 1.2, 2.2)."""
+    state, top_p = store
+    apply_store_state(sampling_env, state, top_p)
+
+    status, _ = generate_node(sampling_env)
+    assert status == 200
+
+    assert sampling_env.node_client.converse.call_count == 1
+    inference_config = sampling_env.node_client.converse.call_args.kwargs[
+        "inferenceConfig"]
+    assert_no_temperature(inference_config, top_p)
+
+
+# ---------------------------------------------------------------------------
+# Property 1c: settings save accepts null sampling parameters and
+#              round-trips them as unset
+# ---------------------------------------------------------------------------
+
+@settings(deadline=None)
+@given(
+    nulled=st.lists(st.sampled_from(["temperature", "top_p"]),
+                    min_size=1, max_size=2, unique=True),
+    prior_numeric_config=st.booleans(),
+)
+def test_settings_save_accepts_null_and_round_trips_unset(
+        sampling_env, nulled, prior_numeric_config):
+    """PUT bedrock-configuration with temperature (and/or top_p) explicitly
+    null is accepted with 200 and the value round-trips as unset through GET
+    / read_stored_bedrock_configuration (Requirements 1.3, 2.3)."""
+    sampling_env.settings_table.delete_item(
+        Key={"setting_key": "bedrock_configuration"})
+
+    if prior_numeric_config:
+        # An admin previously configured numeric sampling values and now
+        # clears the field(s).
+        status, _ = invoke_settings(sampling_env, "PUT", {
+            "temperature": 0.5, "top_p": 0.8,
+        })
+        assert status == 200
+
+    body = {key: None for key in nulled}
+    status, payload = invoke_settings(sampling_env, "PUT", body)
+    assert status == 200, (
+        f"save with {body!r} must be accepted, got {status}: {payload!r}")
+
+    for key in nulled:
+        assert payload["bedrock_configuration"][key] is None
+
+    # Round-trip: GET reports the parameter as unset, not the default.
+    status, payload = invoke_settings(sampling_env, "GET")
+    assert status == 200
+    for key in nulled:
+        assert payload["bedrock_configuration"][key] is None, (
+            f"{key} must round-trip as unset, got "
+            f"{payload['bedrock_configuration'][key]!r}")
+
+    config = sampling_env.data_accounts.read_stored_bedrock_configuration()
+    for key in nulled:
+        assert config[key] is None

--- a/edge-cv-portal/backend/tests/test_property_custom_python_gathering.py
+++ b/edge-cv-portal/backend/tests/test_property_custom_python_gathering.py
@@ -1,0 +1,143 @@
+"""Property test for Custom Python node gathering and manifest membership
+(custom-python-frames task 2.2).
+
+**Feature: custom-python-frames, Property 3: Custom Python node gathering and manifest membership**
+
+For any workflow graph containing an arbitrary mix of ``custom_python``
+nodes, ``custom_python_preprocess`` nodes, and other node types with
+arbitrary node ids, code strings, and requirements strings:
+
+- ``gather_custom_python_nodes`` returns exactly the Custom Python nodes
+  of both types (no other node gathered, none missed), with each node's
+  ``code`` and ``requirements`` parameter values preserved;
+- ``build_manifest``'s ``customPythonNodeIds`` equals exactly those
+  nodes' ids.
+
+**Validates: Requirements 2.4, 2.5**
+
+Both functions are pure over the parsed graph / plain values, so they
+are exercised directly with no AWS calls. The module is imported through
+the shared moto-backed session fixture only so its module-level boto3
+clients are intercepted and the real ``shared_utils`` layer backs the
+import, mirroring the other packaging property tests.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from workflow_core.serializer.models import Node, Position, WorkflowGraph
+
+
+@pytest.fixture(scope="module")
+def packaging(aws_stack):
+    """Import workflow_packaging inside the moto mock so its module-level
+    boto3 clients (DynamoDB / S3 / KMS) are intercepted."""
+    sys.modules.pop("workflow_packaging", None)
+    import workflow_packaging
+
+    return workflow_packaging
+
+
+# ---------------------------------------------------------------------------
+# Reference expectations, restated from Requirements 2.4 / 2.5 (not imported
+# from the implementation, so the test cannot silently agree with a wrong
+# type set).
+# ---------------------------------------------------------------------------
+
+CUSTOM_PYTHON_TYPES = ("custom_python", "custom_python_preprocess")
+
+# Other node types a graph may mix in: realistic catalog type ids plus
+# arbitrary strings, excluding the two Custom Python types.
+OTHER_TYPE_EXAMPLES = (
+    "folder_source", "camera_source", "dewarp", "format_convert",
+    "model_inference", "capture", "overlay",
+)
+
+_id_alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
+node_ids = st.text(alphabet=_id_alphabet, min_size=1, max_size=24)
+
+other_types = st.one_of(
+    st.sampled_from(OTHER_TYPE_EXAMPLES),
+    st.text(min_size=1, max_size=30).filter(
+        lambda t: t not in CUSTOM_PYTHON_TYPES),
+)
+
+# Arbitrary code / requirements parameter values as the definition may
+# carry them (including empty and absent — gather normalizes to str).
+code_values = st.text(max_size=200)
+requirements_values = st.text(max_size=100)
+
+
+@st.composite
+def graphs(draw):
+    """A WorkflowGraph mixing both Custom Python node types and other
+    types, with unique random ids and random code/requirements values.
+    Returns (graph, expected) where expected is the ordered list of
+    {node_id, code, requirements} entries for the Custom Python nodes."""
+    ids = draw(st.lists(node_ids, min_size=0, max_size=12, unique=True))
+    nodes, expected = [], []
+    for node_id in ids:
+        kind = draw(st.sampled_from(("custom_python",
+                                     "custom_python_preprocess",
+                                     "other")))
+        if kind == "other":
+            nodes.append(Node(id=node_id, type=draw(other_types),
+                              position=Position(0.0, 0.0),
+                              parameters={"code": draw(code_values)}))
+            continue
+        parameters = {}
+        code = draw(code_values)
+        requirements = draw(requirements_values)
+        parameters["code"] = code
+        # requirements is optional; sometimes omit it entirely.
+        include_requirements = draw(st.booleans())
+        if include_requirements:
+            parameters["requirements"] = requirements
+        nodes.append(Node(id=node_id, type=kind,
+                          position=Position(0.0, 0.0),
+                          parameters=parameters))
+        expected.append({
+            "node_id": node_id,
+            "code": str(code or ""),
+            "requirements": str(requirements or "") if include_requirements else "",
+        })
+    return WorkflowGraph(nodes=nodes, connections=[]), expected
+
+
+ARCHS = ("x86_64", "x86_64_nvidia", "arm64_jp4", "arm64_jp5", "arm64_jp6")
+
+
+@settings(deadline=None)
+@given(scenario=graphs(), arch=st.sampled_from(ARCHS))
+def test_gathering_and_manifest_membership(packaging, scenario, arch):
+    """**Feature: custom-python-frames, Property 3: Custom Python node gathering and manifest membership**
+
+    For any graph mixing both Custom Python node types and other node
+    types with arbitrary ids/code/requirements, gather_custom_python_nodes
+    returns exactly the Custom Python nodes with code and requirements
+    preserved, and build_manifest's customPythonNodeIds equals exactly
+    those nodes' ids.
+
+    **Validates: Requirements 2.4, 2.5**
+    """
+    graph, expected = scenario
+
+    gathered = packaging.gather_custom_python_nodes(graph)
+
+    # Exactly the Custom Python nodes of both types, in graph order,
+    # with code and requirements preserved (2.4).
+    assert gathered == expected
+    assert [n["node_id"] for n in gathered] == \
+        [node.id for node in graph.nodes if node.type in CUSTOM_PYTHON_TYPES]
+
+    # The manifest lists exactly those nodes' ids, both types together (2.5).
+    manifest = packaging.build_manifest(
+        "wf-1", 1, arch,
+        gst_plugins=["dda-emlpython"], python_packages=[],
+        custom_python_nodes=gathered, user={"user_id": "user-1"})
+    assert manifest["customPythonNodeIds"] == [n["node_id"] for n in expected]

--- a/edge-cv-portal/backend/tests/test_workflow_generation.py
+++ b/edge-cv-portal/backend/tests/test_workflow_generation.py
@@ -283,18 +283,18 @@ class TestPromptAndCatalogAssembly:
         assert "topP" not in kwargs["inferenceConfig"]
         assert bedrock.client_requests[-1] == ("eu-west-1", 30)
 
-    def test_default_configuration_sends_temperature_without_top_p(
+    def test_default_configuration_sends_no_sampling_parameters(
             self, gen_env, bedrock, ctx):
-        """With nothing stored, the default configuration (which carries
-        both temperature and top_p in its stored shape) invokes with
-        temperature only - temperature and top_p must never be sent
-        together."""
+        """With nothing stored, the default configuration is unset for
+        both sampling parameters, so the invocation carries neither
+        temperature nor topP - they are sent only when explicitly
+        configured or overridden."""
         status, _ = generate(gen_env, ctx, "Any pipeline")
         assert status == 200
 
         inference_config = bedrock.client.converse.call_args.kwargs[
             "inferenceConfig"]
-        assert inference_config["temperature"] == 0.2
+        assert "temperature" not in inference_config
         assert "topP" not in inference_config
 
     def test_top_p_is_sent_when_temperature_is_explicitly_null(

--- a/edge-cv-portal/backend/tests/test_workflow_packaging_binding_points.py
+++ b/edge-cv-portal/backend/tests/test_workflow_packaging_binding_points.py
@@ -413,3 +413,188 @@ class TestPackagingSnapshots:
         item = e.version_item()
         assert item["has_binding_points"] is False
         assert item["camera_input_nodes"] == []
+
+
+# --------------------------------------------------------------------------
+# Task 7.1 (spec: aravis-camera-input) - Aravis binding points
+#
+# An aravis_camera_source node is a Camera_Input_Node: packaging emits a
+# bindingPoints entry carrying ``aravisBinding: true`` with empty slots on
+# every physical device architecture, parameters holding the rendered
+# camera_id/gain/exposure (defaults-overlaid) values, and the bindingHint
+# when the definition carries one. The version item records the node in
+# camera_input_nodes with has_binding_points: true. Aravis-free workflows
+# package byte-identically to their pre-feature output.
+# _Requirements: 4.1, 4.2, 4.3_
+# --------------------------------------------------------------------------
+
+ARAVIS_HINT = {"cameraSourceId": "arv-1a2b3c4d5e6f",
+               "cameraName": "Basler GigE Line 2",
+               "sourceDeviceId": "thing-2"}
+
+
+def aravis_definition(hint=None):
+    """aravis_camera_source -> capture. The node's plugin dependencies
+    (app, videoconvertscale) are LocalServer-bundled on every
+    architecture, so packaging needs no curated plugin library seeding."""
+    aravis_node = {"id": "arv", "type": "aravis_camera_source",
+                   "position": {"x": 0, "y": 0},
+                   "parameters": {"camera_id": "Aravis-Fake-GV01"}}
+    if hint is not None:
+        aravis_node["data"] = {"cameraBindingHint": hint}
+    return {
+        "schemaVersion": 1,
+        "nodes": [
+            aravis_node,
+            {"id": "cap", "type": "capture", "position": {"x": 200, "y": 0},
+             "parameters": {"output_path": "/out"}},
+        ],
+        "connections": [
+            {"id": "c1", "from": {"node": "arv", "port": "out"},
+             "to": {"node": "cap", "port": "in"}},
+        ],
+    }
+
+
+def mixed_camera_definition():
+    """camera_source -> capture plus aravis_camera_source -> capture:
+    both Camera_Input_Node types in one definition."""
+    return {
+        "schemaVersion": 1,
+        "nodes": [
+            {"id": "cam", "type": "camera_source", "position": {"x": 0, "y": 0},
+             "parameters": {"device": "/dev/video1"}},
+            {"id": "arv", "type": "aravis_camera_source",
+             "position": {"x": 0, "y": 200},
+             "parameters": {"camera_id": "Aravis-Fake-GV01", "gain": 10}},
+            {"id": "cap1", "type": "capture", "position": {"x": 200, "y": 0},
+             "parameters": {"output_path": "/out1"}},
+            {"id": "cap2", "type": "capture", "position": {"x": 200, "y": 200},
+             "parameters": {"output_path": "/out2"}},
+        ],
+        "connections": [
+            {"id": "c1", "from": {"node": "cam", "port": "out"},
+             "to": {"node": "cap1", "port": "in"}},
+            {"id": "c2", "from": {"node": "arv", "port": "out"},
+             "to": {"node": "cap2", "port": "in"}},
+        ],
+    }
+
+
+class TestAravisBindingPoints:
+    """aravisBinding emission for aravis_camera_source (Requirements
+    4.1, 4.2)."""
+
+    #: Every physical device architecture (the sim document is never
+    #: packaged).
+    ARCHS = ["x86_64", "x86_64_nvidia", "arm64_jp4", "arm64_jp5",
+             "arm64_jp6"]
+
+    @pytest.fixture
+    def aravis_env(self, env, packaging, monkeypatch):
+        e = BindingPointsEnv(env, packaging, monkeypatch,
+                             aravis_definition(hint=ARAVIS_HINT))
+        status, payload = e.package(self.ARCHS)
+        assert status == 201, payload
+        return e
+
+    def test_aravis_binding_marker_on_every_device_arch(self, aravis_env):
+        """The Aravis node's entry carries aravisBinding: true with empty
+        slots and the rendered (defaults-overlaid) camera_id/gain/exposure
+        parameters on every device architecture, hint included."""
+        for arch in self.ARCHS:
+            points = aravis_env.compiled_pipeline(arch)["bindingPoints"]
+            assert len(points) == 1, arch
+            point = points[0]
+            assert point["nodeId"] == "arv"
+            assert point["nodeType"] == "aravis_camera_source"
+            assert point["aravisBinding"] is True
+            assert point["slots"] == []
+            # Explicit camera_id + declared gain/exposure defaults.
+            assert point["parameters"] == {"camera_id": "Aravis-Fake-GV01",
+                                           "gain": 4, "exposure": 5000000}
+            assert point["bindingHint"] == ARAVIS_HINT
+            # Never the other camera markers.
+            assert "adapterBinding" not in point
+            assert "csiSensorBinding" not in point
+
+    def test_version_item_records_the_aravis_node(self, aravis_env):
+        """camera_input_nodes lists the Aravis node through the existing
+        recording path with has_binding_points: true (Requirement 4.1)."""
+        item = aravis_env.version_item()
+        assert item["has_binding_points"] is True
+        nodes = item["camera_input_nodes"]
+        assert len(nodes) == 1
+        assert nodes[0]["node_id"] == "arv"
+        assert nodes[0]["node_type"] == "aravis_camera_source"
+        assert nodes[0]["binding_hint"] == ARAVIS_HINT
+        # No parameter ever lands in an element argument -> no device paths.
+        assert nodes[0]["compiled_device_paths"] == {}
+
+    def test_mixed_definition_emits_both_nodes_entries(self, env, packaging,
+                                                       monkeypatch):
+        """camera_source and aravis_camera_source in one definition each
+        get their own binding point with their own marker/slots; neither
+        disturbs the other (Requirements 4.1, 4.2)."""
+        e = BindingPointsEnv(env, packaging, monkeypatch,
+                             mixed_camera_definition())
+        status, payload = e.package(["x86_64", "arm64_jp5"])
+        assert status == 201, payload
+
+        for arch in ("x86_64", "arm64_jp5"):
+            points = {p["nodeId"]: p
+                      for p in e.compiled_pipeline(arch)["bindingPoints"]}
+            assert set(points) == {"cam", "arv"}
+
+            aravis = points["arv"]
+            assert aravis["aravisBinding"] is True
+            assert aravis["slots"] == []
+            assert aravis["parameters"] == {"camera_id": "Aravis-Fake-GV01",
+                                            "gain": 10, "exposure": 5000000}
+
+            cam = points["cam"]
+            assert "aravisBinding" not in cam
+            if arch == "x86_64":
+                # camera_source keeps its v4l2src device slot, resolving
+                # to the rendered device argument in this document.
+                (slot,) = cam["slots"]
+                assert slot["param"] == "device"
+                assert slot["arg"] == "device"
+                compiled = e.compiled_pipeline(arch)
+                element = (compiled["segments"][slot["segment"]]
+                           ["elements"][slot["element"]])
+                assert element["nodeId"] == "cam"
+                assert element["factory"] == "v4l2src"
+                assert element["args"]["device"] == "/dev/video1"
+            else:
+                assert cam["adapterBinding"] is True
+                assert cam["slots"] == []
+
+        item = e.version_item()
+        assert item["has_binding_points"] is True
+        assert {(n["node_id"], n["node_type"])
+                for n in item["camera_input_nodes"]} == {
+                    ("cam", "camera_source"),
+                    ("arv", "aravis_camera_source")}
+
+    def test_aravis_free_definition_output_is_unchanged(self, env, packaging,
+                                                        monkeypatch):
+        """An Aravis-free camera workflow's compiled document is exactly
+        the pre-feature output plus the pre-existing bindingPoints section
+        - no aravisBinding marker anywhere (Requirement 4.3)."""
+        e = BindingPointsEnv(env, packaging, monkeypatch, camera_definition())
+        status, payload = e.package(["x86_64", "arm64_jp5"])
+        assert status == 201, payload
+
+        for arch in ("x86_64", "arm64_jp5"):
+            packaged_text = e.compiled_pipeline_text(arch)
+            packaged_doc = json.loads(packaged_text)
+            binding_points = packaged_doc.pop("bindingPoints")
+            assert all("aravisBinding" not in p for p in binding_points)
+
+            expected_doc = pre_feature_compiled(env, e.workflow_id,
+                                                arch).to_dict()
+            assert packaged_doc == expected_doc
+            expected_doc["bindingPoints"] = binding_points
+            assert packaged_text == json.dumps(
+                expected_doc, sort_keys=True, indent=2, ensure_ascii=True)

--- a/edge-cv-portal/backend/tests/test_workflow_packaging_deployment_integration.py
+++ b/edge-cv-portal/backend/tests/test_workflow_packaging_deployment_integration.py
@@ -260,6 +260,41 @@ def make_custom_python_definition():
     }
 
 
+CUSTOM_PYTHON_PREPROCESS_CODE = (
+    "def process_frame(frame, metadata):\n"
+    "    return cv2.GaussianBlur(frame, (5, 5), 0)\n"
+)
+CUSTOM_PYTHON_PREPROCESS_REQUIREMENTS = "scikit-image==0.24.0"
+
+
+def make_custom_python_preprocess_definition():
+    """folder_source -> custom_python_preprocess -> capture. The new
+    preprocessing node's code and declared dependencies must ship in the
+    artifacts exactly like custom_python's (custom-python-frames
+    Requirements 2.3, 2.4, 2.5)."""
+    return {
+        "schemaVersion": 1,
+        "nodes": [
+            {"id": "src", "type": "folder_source", "position": {"x": 0, "y": 0},
+             "parameters": {"location": "/data/images"}},
+            {"id": "prenode", "type": "custom_python_preprocess",
+             "position": {"x": 200, "y": 0},
+             "parameters": {
+                 "code": CUSTOM_PYTHON_PREPROCESS_CODE,
+                 "requirements": CUSTOM_PYTHON_PREPROCESS_REQUIREMENTS,
+             }},
+            {"id": "cap", "type": "capture", "position": {"x": 400, "y": 0},
+             "parameters": {"output_path": "/out"}},
+        ],
+        "connections": [
+            {"id": "c1", "from": {"node": "src", "port": "out"},
+             "to": {"node": "prenode", "port": "in"}},
+            {"id": "c2", "from": {"node": "prenode", "port": "out"},
+             "to": {"node": "cap", "port": "in"}},
+        ],
+    }
+
+
 # --------------------------------------------------------------------------
 # Harness
 # --------------------------------------------------------------------------
@@ -553,6 +588,46 @@ class TestCustomPythonArtifacts:
             assert manifest["customPythonNodeIds"] == ["pynode"]
             # The emlpython bridge plugin ships alongside the code.
             assert "plugins/x86_64/dda-emlpython.so" in names
+
+    def test_custom_python_preprocess_ships_in_every_arch_zip(
+            self, env, packaging, deployments, monkeypatch):
+        """A custom_python_preprocess node packages its handler.py and
+        requirements.txt into every architecture zip with the node id
+        listed in the manifest's customPythonNodeIds (custom-python-frames
+        Requirements 2.3, 2.4, 2.5)."""
+        archs = ["x86_64", "arm64_jp5", "arm64_jp6"]
+        fleet = FleetEnv(env, packaging, deployments, monkeypatch,
+                         definition=make_custom_python_preprocess_definition())
+        fleet.seed_plugins(archs, plugins=("dda-emlpython",))
+
+        status, payload = fleet.package(archs)
+
+        assert status == 201, payload
+        for arch in archs:
+            with fleet.zip_contents(arch) as zf:
+                names = set(zf.namelist())
+                assert "python/prenode/handler.py" in names
+                assert "python/prenode/requirements.txt" in names
+                assert zf.read("python/prenode/handler.py").decode() == \
+                    CUSTOM_PYTHON_PREPROCESS_CODE
+                assert zf.read("python/prenode/requirements.txt").decode() == \
+                    CUSTOM_PYTHON_PREPROCESS_REQUIREMENTS
+
+                # The compiled pipeline carries the node's emlpython
+                # element with the packaged handler path (2.3).
+                compiled = json.loads(zf.read("compiled_pipeline.json"))
+                elements = [element
+                            for segment in compiled["segments"]
+                            for element in segment["elements"]
+                            if element.get("nodeId") == "prenode"]
+                assert [e["factory"] for e in elements] == ["emlpython"]
+                assert elements[0]["args"]["handler-path"] == \
+                    "python/prenode/handler.py"
+
+                manifest = json.loads(zf.read("manifest.json"))
+                assert manifest["customPythonNodeIds"] == ["prenode"]
+                # The emlpython bridge plugin ships alongside the code.
+                assert f"plugins/{arch}/dda-emlpython.so" in names
 
 
 # ==========================================================================

--- a/edge-cv-portal/frontend/src/components/BedrockConfigurationSettings.test.tsx
+++ b/edge-cv-portal/frontend/src/components/BedrockConfigurationSettings.test.tsx
@@ -203,4 +203,63 @@ describe('BedrockConfigurationSettings', () => {
     });
     expect(await screen.findByText('Bedrock configuration saved')).toBeInTheDocument();
   });
+
+  it('loads a stored null temperature and top_p as blank fields (Bugfix Requirement 2.3)', async () => {
+    setAuthRole('PortalAdmin');
+    getBedrockConfiguration.mockResolvedValue({
+      bedrock_configuration: { ...STORED_CONFIG, temperature: null, top_p: null },
+      defaults: {},
+      max_timeout_seconds: 60,
+    });
+    render(<BedrockConfigurationSettings />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Timeout seconds')).toHaveValue(60);
+    });
+    // Unset sampling parameters render as blank inputs, not "null".
+    expect(screen.getByLabelText('Temperature')).toHaveValue(null);
+    expect(screen.getByLabelText('Top P')).toHaveValue(null);
+  });
+
+  it('accepts blank temperature and top_p and saves them as explicit null (Bugfix Requirement 2.3)', async () => {
+    setAuthRole('PortalAdmin');
+    render(<BedrockConfigurationSettings />);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Temperature')).toHaveValue(0.2);
+    });
+
+    fireEvent.change(screen.getByLabelText('Temperature'), { target: { value: '' } });
+    fireEvent.change(screen.getByLabelText('Top P'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Configuration' }));
+
+    await waitFor(() => {
+      expect(updateBedrockConfiguration).toHaveBeenCalledWith({
+        model_id: STORED_CONFIG.model_id,
+        region: STORED_CONFIG.region,
+        max_tokens: 4096,
+        temperature: null,
+        top_p: null,
+        timeout_seconds: 60,
+      });
+    });
+    expect(screen.queryByText('Temperature must be between 0 and 1')).toBeNull();
+    expect(screen.queryByText('Top P must be between 0 and 1')).toBeNull();
+    expect(await screen.findByText('Bedrock configuration saved')).toBeInTheDocument();
+  });
+
+  it('keeps rejecting a non-blank out-of-range temperature and top_p without calling the API', async () => {
+    setAuthRole('PortalAdmin');
+    render(<BedrockConfigurationSettings />);
+    await waitFor(() => {
+      expect(screen.getByLabelText('Temperature')).toHaveValue(0.2);
+    });
+
+    fireEvent.change(screen.getByLabelText('Temperature'), { target: { value: '1.5' } });
+    fireEvent.change(screen.getByLabelText('Top P'), { target: { value: '-0.1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Configuration' }));
+
+    expect(await screen.findByText('Temperature must be between 0 and 1')).toBeInTheDocument();
+    expect(await screen.findByText('Top P must be between 0 and 1')).toBeInTheDocument();
+    expect(updateBedrockConfiguration).not.toHaveBeenCalled();
+  });
 });

--- a/edge-cv-portal/frontend/src/components/BedrockConfigurationSettings.tsx
+++ b/edge-cv-portal/frontend/src/components/BedrockConfigurationSettings.tsx
@@ -53,14 +53,20 @@ function validate(form: BedrockFormState): FieldErrors {
     errors.max_tokens = 'Max tokens must be a positive integer';
   }
 
-  const temperature = Number(form.temperature);
-  if (form.temperature.trim() === '' || Number.isNaN(temperature) || temperature < 0 || temperature > 1) {
-    errors.temperature = 'Temperature must be between 0 and 1';
+  // Blank temperature / top_p means "unset": the sampling parameter is
+  // omitted from Bedrock invocations so the model uses its own default.
+  if (form.temperature.trim() !== '') {
+    const temperature = Number(form.temperature);
+    if (Number.isNaN(temperature) || temperature < 0 || temperature > 1) {
+      errors.temperature = 'Temperature must be between 0 and 1';
+    }
   }
 
-  const topP = Number(form.top_p);
-  if (form.top_p.trim() === '' || Number.isNaN(topP) || topP < 0 || topP > 1) {
-    errors.top_p = 'Top P must be between 0 and 1';
+  if (form.top_p.trim() !== '') {
+    const topP = Number(form.top_p);
+    if (Number.isNaN(topP) || topP < 0 || topP > 1) {
+      errors.top_p = 'Top P must be between 0 and 1';
+    }
   }
 
   const timeout = Number(form.timeout_seconds);
@@ -131,8 +137,10 @@ export default function BedrockConfigurationSettings() {
           model_id: config.model_id,
           region: config.region,
           max_tokens: String(config.max_tokens),
-          temperature: String(config.temperature),
-          top_p: String(config.top_p),
+          // A null/undefined sampling parameter is "unset" and renders as
+          // a blank field (never the literal string "null").
+          temperature: config.temperature == null ? '' : String(config.temperature),
+          top_p: config.top_p == null ? '' : String(config.top_p),
           timeout_seconds: String(config.timeout_seconds),
         });
       })
@@ -172,8 +180,11 @@ export default function BedrockConfigurationSettings() {
         model_id: form.model_id.trim(),
         region: form.region.trim(),
         max_tokens: Number(form.max_tokens),
-        temperature: Number(form.temperature),
-        top_p: Number(form.top_p),
+        // A blank field is sent as an explicit null: the backend merges
+        // provided keys over the current configuration, so omitting the
+        // key would keep the old value instead of unsetting it.
+        temperature: form.temperature.trim() === '' ? null : Number(form.temperature),
+        top_p: form.top_p.trim() === '' ? null : Number(form.top_p),
         timeout_seconds: Number(form.timeout_seconds),
       });
       setSuccess('Bedrock configuration saved');
@@ -276,7 +287,11 @@ export default function BedrockConfigurationSettings() {
             />
           </FormField>
 
-          <FormField label="Temperature" constraintText="0 to 1" errorText={fieldErrors.temperature}>
+          <FormField
+            label="Temperature"
+            constraintText="0 to 1 — leave blank to let the model use its default (parameter is omitted)"
+            errorText={fieldErrors.temperature}
+          >
             <Input
               type="number"
               step={0.1}
@@ -286,7 +301,11 @@ export default function BedrockConfigurationSettings() {
             />
           </FormField>
 
-          <FormField label="Top P" constraintText="0 to 1" errorText={fieldErrors.top_p}>
+          <FormField
+            label="Top P"
+            constraintText="0 to 1 — leave blank to let the model use its default (parameter is omitted)"
+            errorText={fieldErrors.top_p}
+          >
             <Input type="number" step={0.1} value={form.top_p} onChange={setField('top_p')} ariaLabel="Top P" />
           </FormField>
 

--- a/edge-cv-portal/frontend/src/pages/deployments/CameraBindingMatrix.test.tsx
+++ b/edge-cv-portal/frontend/src/pages/deployments/CameraBindingMatrix.test.tsx
@@ -48,6 +48,36 @@ const STALE: CameraSourceEntry = {
   absent: false,
 };
 
+const ARAVIS_DISCOVERED: CameraSourceEntry = {
+  camera_source_id: 'arv-1',
+  name: 'Basler acA1920',
+  type: 'AravisDiscovered',
+  params: { cameraId: 'Basler-12345678' },
+  sync_status: 'synced',
+  stale: false,
+  absent: false,
+};
+
+const ARAVIS_CONFIGURED: CameraSourceEntry = {
+  camera_source_id: 'cfg-3',
+  name: 'Inspection GigE cam',
+  type: 'Camera',
+  params: { cameraId: 'Aravis-Fake-GV01' },
+  sync_status: 'synced',
+  stale: false,
+  absent: false,
+};
+
+const V4L2_DISCOVERED: CameraSourceEntry = {
+  camera_source_id: 'disc-1',
+  name: 'USB webcam',
+  type: 'V4L2Discovered',
+  params: { devicePath: '/dev/video9' },
+  sync_status: 'synced',
+  stale: false,
+  absent: false,
+};
+
 const NODE_HINTED: BindingContextNode = {
   node_id: 'cam_in_1',
   node_type: 'camera_source',
@@ -294,6 +324,56 @@ describe('CameraBindingMatrix', () => {
       screen.getByText("Node 'cam_in_2' on device 'thing-1': no binding supplied")
     ).toBeInTheDocument();
     expect(screen.getByText("Device 'thing-2': never synced")).toBeInTheDocument();
+  });
+
+  it('offers only Aravis-compatible sources for an aravis_camera_source row with hint pre-selection (aravis-camera-input Requirement 5.1)', () => {
+    // Mixed registry: two Aravis-compatible entries (a discovered bus
+    // camera and a configured Camera-type source with a cameraId), a
+    // V4L2Discovered entry, and a Camera-type entry without a cameraId —
+    // the last two must not be offered to the Aravis node.
+    const aravisNode: BindingContextNode = {
+      node_id: 'arv_in_1',
+      node_type: 'aravis_camera_source',
+      binding_hint: {
+        cameraSourceId: 'arv-1',
+        cameraName: 'Basler acA1920',
+        sourceDeviceId: 'dev-ref',
+      },
+    };
+    const context = bindingContext({
+      camera_input_nodes: [aravisNode, NODE_PLAIN],
+      targets: {
+        'thing-1': {
+          state: 'synced',
+          cameras: [HEALTHY, ARAVIS_DISCOVERED, ARAVIS_CONFIGURED, V4L2_DISCOVERED],
+          preselected: { arv_in_1: 'arv-1' },
+        },
+      },
+    });
+    const { container } = renderMatrix({ context });
+
+    // The Aravis row's dropdown contains exactly the compatible entries.
+    const aravisCell = bodyCell(container, 1, 2).getElement();
+    const aravisSelect = createWrapper(aravisCell).findSelect()!;
+    aravisSelect.openDropdown();
+    const aravisOptions = aravisSelect
+      .findDropdown()
+      .findOptions()
+      .map((o) => o.getElement().textContent);
+    expect(aravisOptions).toHaveLength(2);
+    expect(aravisOptions[0]).toContain('Basler acA1920');
+    expect(aravisOptions[1]).toContain('Inspection GigE cam');
+    aravisSelect.closeDropdown();
+
+    // Hint pre-selection is unchanged: the hinted compatible entry is
+    // pre-selected and marked as suggested.
+    expect(aravisCell.textContent).toContain('Suggested from workflow hint');
+    expect(aravisCell.textContent).toContain('Basler acA1920');
+
+    // The camera_source row still offers every registered entry.
+    const cameraSelect = createWrapper(bodyCell(container, 2, 2).getElement()).findSelect()!;
+    cameraSelect.openDropdown();
+    expect(cameraSelect.findDropdown().findOptions()).toHaveLength(4);
   });
 
   it('shows the empty state for a context without Camera_Input_Nodes (Requirement 8.9 contract)', () => {

--- a/edge-cv-portal/frontend/src/pages/deployments/CameraBindingMatrix.tsx
+++ b/edge-cv-portal/frontend/src/pages/deployments/CameraBindingMatrix.tsx
@@ -40,6 +40,7 @@ import {
   getBindingCell,
   BindingSelections,
 } from './cameraBindings';
+import { isAravisCompatibleCamera } from '../workflows/cameraReference';
 
 export interface CameraBindingMatrixProps {
   context: CameraBindingContext;
@@ -68,7 +69,16 @@ function BindingCellControl({
 }) {
   const target = context.targets[device];
   const neverSynced = target?.state === 'never-synced';
-  const cameras = target?.cameras ?? [];
+  const allCameras = target?.cameras ?? [];
+  // An aravis_camera_source row offers only Aravis-compatible sources —
+  // the same predicate the Workflow_Builder picker uses — so users are
+  // not offered bindings the validator would reject (aravis-camera-input
+  // Requirement 5.1). Hint pre-selection is unaffected: the cell state
+  // is seeded upstream by initialBindingSelections.
+  const cameras =
+    node.node_type === 'aravis_camera_source'
+      ? allCameras.filter(isAravisCompatibleCamera)
+      : allCameras;
 
   // Never-synced targets are restricted to manual override (8.8).
   if (neverSynced) {

--- a/edge-cv-portal/frontend/src/pages/node-designer/CreateWizard.test.tsx
+++ b/edge-cv-portal/frontend/src/pages/node-designer/CreateWizard.test.tsx
@@ -12,6 +12,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import createWrapper from '@cloudscape-design/components/test-utils/dom';
 import CreateWizard from './CreateWizard';
 
 const {
@@ -242,5 +243,81 @@ describe('CreateWizard', () => {
     // Zip download of the complete scaffold project (1.5).
     fireEvent.click(screen.getByRole('button', { name: 'Download zip' }));
     expect(downloadZipMock).toHaveBeenCalledWith(SCAFFOLD_FILES, 'Blur-Regions');
+  });
+});
+
+/**
+ * Category-driven default ports (workflow-designer-bugfixes Bug 2,
+ * Requirements 1.4, 2.4, 2.5, 2.6).
+ *
+ * BUG CONDITION EXPLORATION (task 4): these tests encode the EXPECTED
+ * behavior and are expected to FAIL on the unfixed code — the wizard
+ * seeds one "in" input and one "out" output regardless of the selected
+ * palette category (isBugCondition2 in the workflow-designer-bugfixes
+ * design). They validate the fix when they pass.
+ */
+describe('CreateWizard category-driven default ports (workflow-designer-bugfixes Bug 2)', () => {
+  /** Select the palette category on the details step ([0] use case, [1] category). */
+  function selectCategory(container: HTMLElement, category: string) {
+    const categorySelect = createWrapper(container).findAllSelects()[1];
+    categorySelect.openDropdown();
+    categorySelect.selectOptionByValue(category);
+  }
+
+  it('presents no input rows and one VideoFrames output after selecting the input category on untouched defaults (1.4, 2.4, 2.5)', async () => {
+    const { container } = render(<CreateWizard />);
+    await waitFor(() => expect(listUseCases).toHaveBeenCalled());
+
+    fillName(container, 'Camera Source');
+    selectCategory(container, 'input');
+    clickNext();
+    await screen.findByText('Input ports');
+
+    // Input (source) nodes: no input port rows (2.4).
+    expect(screen.getByText('No inputs declared.')).toBeInTheDocument();
+    expect(container.querySelectorAll('input[placeholder="in"]')).toHaveLength(0);
+
+    // Exactly one VideoFrames output with a non-empty name (2.4).
+    const outputNames = container.querySelectorAll('input[placeholder="out"]');
+    expect(outputNames).toHaveLength(1);
+    expect((outputNames[0] as HTMLInputElement).value.trim()).not.toBe('');
+    const typeSelects = createWrapper(container).findAllSelects();
+    expect(typeSelects).toHaveLength(1);
+    expect(typeSelects[0].findTrigger().getElement().textContent).toContain(
+      'VideoFrames'
+    );
+  });
+
+  it('presents one input row and no output rows after selecting the output category on untouched defaults (1.5, 2.5)', async () => {
+    const { container } = render(<CreateWizard />);
+    await waitFor(() => expect(listUseCases).toHaveBeenCalled());
+
+    fillName(container, 'Alert Publisher');
+    selectCategory(container, 'output');
+    clickNext();
+    await screen.findByText('Input ports');
+
+    // Output (sink) nodes: at least one input, no outputs (2.5).
+    expect(screen.getByText('No outputs declared.')).toBeInTheDocument();
+    expect(container.querySelectorAll('input[placeholder="out"]')).toHaveLength(0);
+    const inputNames = container.querySelectorAll('input[placeholder="in"]');
+    expect(inputNames).toHaveLength(1);
+    expect((inputNames[0] as HTMLInputElement).value.trim()).not.toBe('');
+  });
+
+  it("states the selected category's input/output requirements on the ports step (2.6)", async () => {
+    const { container } = render(<CreateWizard />);
+    await waitFor(() => expect(listUseCases).toHaveBeenCalled());
+
+    fillName(container, 'Camera Source');
+    selectCategory(container, 'input');
+    clickNext();
+    await screen.findByText('Input ports');
+
+    // The design's fix interface: PortGuidancePanel states the per-kind
+    // requirements under data-testid="port-guidance-requirements".
+    const requirements = screen.getByTestId('port-guidance-requirements');
+    expect(requirements.textContent).toMatch(/inputs/i);
+    expect(requirements.textContent).toMatch(/outputs/i);
   });
 });

--- a/edge-cv-portal/frontend/src/pages/node-designer/CreateWizard.tsx
+++ b/edge-cv-portal/frontend/src/pages/node-designer/CreateWizard.tsx
@@ -51,9 +51,11 @@ import {
   WizardForm,
   architecturesStepErrors,
   buildDeclaration,
+  defaultPortsForCategory,
   detailsStepErrors,
   emptyParameter,
   emptyPort,
+  isDefaultPortArrangement,
   parametersStepErrors,
   portsStepErrors,
 } from './declaration';
@@ -65,8 +67,7 @@ const initialForm = (): WizardForm => ({
   name: '',
   description: '',
   category: 'preprocessing',
-  inputs: [{ ...emptyPort(), name: 'in' }],
-  outputs: [{ ...emptyPort(), name: 'out' }],
+  ...defaultPortsForCategory('preprocessing'),
   parameters: [],
   architectures: ['x86_64'],
 });
@@ -368,9 +369,19 @@ export default function CreateWizard() {
                   <Select
                     selectedOption={{ label: form.category, value: form.category }}
                     options={CATEGORIES.map((c) => ({ label: c, value: c }))}
-                    onChange={({ detail }) =>
-                      patch({ category: detail.selectedOption.value || 'preprocessing' })
-                    }
+                    onChange={({ detail }) => {
+                      const category =
+                        detail.selectedOption.value || 'preprocessing';
+                      // Untouched default port rows follow the selected
+                      // category's typical arrangement; user-edited rows
+                      // are preserved exactly (workflow-designer-bugfixes
+                      // Bug 2, Req 2.4, 2.5, 3.6).
+                      if (isDefaultPortArrangement(form.inputs, form.outputs)) {
+                        patch({ category, ...defaultPortsForCategory(category) });
+                      } else {
+                        patch({ category });
+                      }
+                    }}
                   />
                 </FormField>
               </SpaceBetween>

--- a/edge-cv-portal/frontend/src/pages/node-designer/ImportView.test.tsx
+++ b/edge-cv-portal/frontend/src/pages/node-designer/ImportView.test.tsx
@@ -314,21 +314,23 @@ const IMPORTED_RESPONSE = {
 };
 
 describe('ImportView module plugin selection', () => {
-  it('loads the plugin list defaulting to all and sends a partial selection', async () => {
+  it('loads the plugin list defaulting to none and sends a partial selection', async () => {
     listModulePlugins.mockResolvedValue(MODULE_PLUGINS_RESPONSE);
     importPlugin.mockResolvedValue(IMPORTED_RESPONSE);
     const { container } = render(<ImportView />);
     await fillForm(container, 'gst-plugins-good');
 
-    // The chosen module's plugins load with everything selected.
+    // The chosen module's plugins load with nothing selected: the
+    // user opts in explicitly (2.7).
     await screen.findByText('Plugins to import');
     expect(listModulePlugins).toHaveBeenCalledWith('gst-plugins-good');
-    expect(screen.getByText('3 of 3 selected')).toBeInTheDocument();
+    expect(screen.getByText('0 of 3 selected')).toBeInTheDocument();
 
-    // Deselect jpeg (via its checkbox: the name itself now links to
-    // the plugin's docs page), review: the confirm step summarizes
+    // Check rtp and udp (via their checkboxes: the name itself links
+    // to the plugin's docs page), review: the confirm step summarizes
     // the subset.
-    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+    fireEvent.click(screen.getAllByRole('checkbox')[1]);
+    fireEvent.click(screen.getAllByRole('checkbox')[2]);
     expect(screen.getByText('2 of 3 selected')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Review import' }));
     await screen.findByText('Upstream classification');
@@ -348,6 +350,11 @@ describe('ImportView module plugin selection', () => {
     importPlugin.mockResolvedValue(IMPORTED_RESPONSE);
     const { container } = render(<ImportView />);
     await fillForm(container, 'gst-plugins-good');
+    await screen.findByText('0 of 3 selected');
+
+    // Selecting every plugin explicitly keeps today's wire behavior:
+    // a full selection means whole-module import (3.12).
+    fireEvent.click(screen.getByRole('button', { name: 'Select all' }));
     await screen.findByText('3 of 3 selected');
 
     fireEvent.click(screen.getByRole('button', { name: 'Review import' }));
@@ -359,18 +366,22 @@ describe('ImportView module plugin selection', () => {
     expect(importPlugin.mock.calls[0][0].selected_plugins).toBeUndefined();
   });
 
-  it('blocks the review only while the selection is empty', async () => {
+  it('blocks the review while the selection is empty, including the pristine default', async () => {
     listModulePlugins.mockResolvedValue(MODULE_PLUGINS_RESPONSE);
     const { container } = render(<ImportView />);
     await fillForm(container, 'gst-plugins-good');
-    await screen.findByText('3 of 3 selected');
+    await screen.findByText('0 of 3 selected');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+    // The pristine empty default already shows the gate (2.8).
     expect(screen.getByText('Select at least one plugin to import')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Review import' })).toBeDisabled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Select all' }));
     expect(screen.getByRole('button', { name: 'Review import' })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+    expect(screen.getByText('Select at least one plugin to import')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Review import' })).toBeDisabled();
   });
 
   it('treats a plugin-list failure as non-blocking and imports the full set', async () => {
@@ -394,6 +405,58 @@ describe('ImportView module plugin selection', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Import plugin' }));
     await waitFor(() => expect(importPlugin).toHaveBeenCalled());
     expect(importPlugin.mock.calls[0][0].selected_plugins).toBeUndefined();
+  });
+});
+
+// -------------------------- Bug 3 exploration: opt-in module selection
+//
+// **Feature: workflow-designer-bugfixes, Property 5: Bug Condition —
+// Import selection defaults to none with an explicit gate**
+//
+// **Validates: Requirements 1.6, 2.7, 2.8**
+//
+// BUG CONDITION EXPLORATION (task 7): these assertions encode the
+// EXPECTED behavior and are expected to FAIL on the unfixed code —
+// the module plugin load effect seeds every plugin selected
+// (isBugCondition3 in design.md). They validate the fix once the
+// selection seeds empty with the explicit-selection gate active.
+
+describe('ImportView module plugin selection — Bug 3 exploration (expected behavior)', () => {
+  it('seeds the loaded plugin list with no plugins selected (1.6, 2.7)', async () => {
+    listModulePlugins.mockResolvedValue(MODULE_PLUGINS_RESPONSE);
+    const { container } = render(<ImportView />);
+    await fillForm(container, 'gst-plugins-good');
+
+    // The chosen module's plugins load with NOTHING selected: the
+    // user opts in to what to import instead of opting out.
+    await screen.findByText('Plugins to import');
+    expect(screen.getByText('0 of 3 selected')).toBeInTheDocument();
+  });
+
+  it('blocks the import until an explicit selection is made (2.8)', async () => {
+    listModulePlugins.mockResolvedValue(MODULE_PLUGINS_RESPONSE);
+    const { container } = render(<ImportView />);
+    await fillForm(container, 'gst-plugins-good');
+    await screen.findByText('Plugins to import');
+
+    // Pristine empty selection: the gate message shows and the
+    // review stays blocked — no import with zero explicit opt-in.
+    expect(
+      screen.getByText('Select at least one plugin to import')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Review import' })).toBeDisabled();
+
+    // An individual check is an explicit opt-in and unblocks.
+    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+    expect(screen.getByText('1 of 3 selected')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Review import' })).toBeEnabled();
+
+    // "Select all" is the other explicit opt-in path.
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+    expect(screen.getByRole('button', { name: 'Review import' })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Select all' }));
+    expect(screen.getByText('3 of 3 selected')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Review import' })).toBeEnabled();
   });
 });
 
@@ -570,6 +633,10 @@ describe('ImportView per-architecture revisions', () => {
     const archSelect = wrapper.findMultiselect()!;
     archSelect.selectOptionByValue('arm64_jp5');
 
+    // Opt in to the whole module (the selection now defaults to none).
+    await screen.findByText('Plugins to import');
+    fireEvent.click(screen.getByRole('button', { name: 'Select all' }));
+
     // The optional expandable section lists one input per selected
     // architecture, blank inputs following the top-level revision.
     fireEvent.click(screen.getByText('Per-architecture revisions'));
@@ -601,6 +668,10 @@ describe('ImportView per-architecture revisions', () => {
     importPlugin.mockResolvedValue(IMPORTED_RESPONSE);
     const { container } = render(<ImportView />);
     await fillForm(container, 'gst-plugins-good');
+
+    // Opt in to the whole module (the selection now defaults to none).
+    await screen.findByText('Plugins to import');
+    fireEvent.click(screen.getByRole('button', { name: 'Select all' }));
 
     fireEvent.click(screen.getByText('Per-architecture revisions'));
     fireEvent.change(screen.getByLabelText('Revision for x86_64'), {

--- a/edge-cv-portal/frontend/src/pages/node-designer/ImportView.tsx
+++ b/edge-cv-portal/frontend/src/pages/node-designer/ImportView.tsx
@@ -84,6 +84,7 @@ import {
   incompatiblePlatformWarnings,
   isModuleListingUnavailable,
   PlatformWarning,
+  moduleSelectionIncomplete,
   moduleSelectionSummary,
   pluginDocsUrl,
   pluginSelectionError,
@@ -228,9 +229,9 @@ export default function ImportView() {
 
   // --- module plugin selection (import enhancement): a chosen official
   // module's individual plugins load from GET /plugin-modules?module=
-  // and the user picks the subset to import (default: all selected).
-  // Loading is non-blocking: on failure a warning shows and the import
-  // proceeds with the full plugin set.
+  // and the user opts in to the subset to import (default: none
+  // selected). Loading is non-blocking: on failure a warning shows and
+  // the import proceeds with the full plugin set.
   const [modulePlugins, setModulePlugins] = useState<ModulePluginEntry[] | null>(null);
   const [modulePluginsLoading, setModulePluginsLoading] = useState(false);
   const [modulePluginsWarning, setModulePluginsWarning] = useState<string | null>(null);
@@ -254,8 +255,8 @@ export default function ImportView() {
         }
         const plugins = response.plugins || [];
         setModulePlugins(plugins);
-        // Default: ALL plugins selected (whole-module import).
-        setSelectedModulePlugins(allPluginNames(plugins));
+        // Default: none selected — the user opts in explicitly.
+        setSelectedModulePlugins([]);
       } catch (err: any) {
         if (!cancelled) {
           // Non-blocking: selection is an enhancement, never a blocker.
@@ -313,16 +314,17 @@ export default function ImportView() {
 
   // A loaded plugin list requires at least one selected plugin; an
   // unavailable or empty list never blocks the import.
-  const moduleSelectionIncomplete =
-    source === 'module' &&
-    modulePluginNames.length > 0 &&
-    selectedModulePlugins.length === 0;
+  const selectionIncomplete = moduleSelectionIncomplete(
+    source,
+    modulePluginNames,
+    selectedModulePlugins
+  );
 
   const formComplete =
     !!selectedUseCase?.value &&
     !!effectiveRepoUrl &&
     architectures.length > 0 &&
-    !moduleSelectionIncomplete;
+    !selectionIncomplete;
 
   // Act on a settled import record (from the initial response or a
   // poll): 'failed' shows the recorded finding (4.5),
@@ -840,9 +842,10 @@ export default function ImportView() {
                   )}
                 </SpaceBetween>
               </FormField>
-              {/* Plugin selection for the chosen module (default: all).
-                  An unavailable plugin list never blocks the import:
-                  the warning shows and the full set imports. */}
+              {/* Plugin selection for the chosen module (default: none
+                  selected — the user opts in explicitly). An unavailable
+                  plugin list never blocks the import: the warning shows
+                  and the full set imports. */}
               {chosenModule && modulePluginsWarning && (
                 <Alert type="warning" header="Plugin list unavailable">
                   {modulePluginsWarning} — the import will include the
@@ -855,7 +858,7 @@ export default function ImportView() {
               {chosenModule && modulePlugins && modulePlugins.length > 0 && (
                 <FormField
                   label="Plugins to import"
-                  description="Choose which of the module's plugins to import and build; all plugins are selected by default."
+                  description="Choose which of the module's plugins to import and build. No plugins are selected by default — select individual plugins or use Select all to import the whole module."
                   errorText={
                     selectedModulePlugins.length === 0
                       ? 'Select at least one plugin to import'

--- a/edge-cv-portal/frontend/src/pages/node-designer/PortGuidancePanel.test.tsx
+++ b/edge-cv-portal/frontend/src/pages/node-designer/PortGuidancePanel.test.tsx
@@ -24,6 +24,7 @@ import {
   INPUT_OUTPUT_DISTINCTION,
   PORT_DEFINITION,
   PORT_TYPE_GUIDANCE,
+  arrangementRequirements,
 } from './portGuidance';
 import { CATEGORIES, PORT_TYPES } from './types';
 
@@ -175,6 +176,38 @@ describe('PortGuidancePanel', () => {
       />
     );
     expect(divergenceAlert()).toBeNull();
+  });
+
+  // Per-kind requirement lines (workflow-designer-bugfixes Bug 2,
+  // Requirement 2.6): the ports step states what each node kind
+  // requires for inputs and outputs.
+  it("states each category's input/output requirements (bugfixes 2.6)", () => {
+    expect(arrangementRequirements('input')).toBe(
+      'Inputs: none · Outputs: 1 × VideoFrames'
+    );
+    expect(arrangementRequirements('output')).toBe(
+      'Inputs: at least one (any port type) · Outputs: none'
+    );
+    expect(arrangementRequirements('unknown')).toBeNull();
+
+    for (const category of CATEGORIES) {
+      const { unmount } = renderPanel(category, [], []);
+      const requirements = screen.getByTestId('port-guidance-requirements');
+      expect(requirements.textContent).toContain(
+        'Typical requirement for this node kind:'
+      );
+      expect(requirements.textContent).toContain(
+        arrangementRequirements(category)!
+      );
+      expect(requirements.textContent).toMatch(/inputs/i);
+      expect(requirements.textContent).toMatch(/outputs/i);
+      unmount();
+    }
+  });
+
+  it('renders no requirements line for an unknown category (bugfixes 2.6)', () => {
+    renderPanel('unknown', [], []);
+    expect(screen.queryByTestId('port-guidance-requirements')).toBeNull();
   });
 
   it('re-arms a dismissed advisory once the declaration matches again (2.4, 2.5)', () => {

--- a/edge-cv-portal/frontend/src/pages/node-designer/PortGuidancePanel.tsx
+++ b/edge-cv-portal/frontend/src/pages/node-designer/PortGuidancePanel.tsx
@@ -38,6 +38,7 @@ import {
   PORT_DEFINITION,
   PORT_TYPE_GUIDANCE,
   PORT_TYPES,
+  arrangementRequirements,
   guidanceDivergence,
 } from './portGuidance';
 import type { NodeCategory } from './types';
@@ -69,6 +70,11 @@ export default function PortGuidancePanel({
   )
     ? CATEGORY_ARRANGEMENTS[category as NodeCategory]
     : null;
+
+  // Per-kind input/output requirements statement (workflow-designer-
+  // bugfixes Bug 2, Requirement 2.6). Purely advisory like the rest of
+  // the panel — never contributes to step gating.
+  const requirements = arrangementRequirements(category);
 
   const divergence = guidanceDivergence(category, inputs, outputs);
 
@@ -113,6 +119,13 @@ export default function PortGuidancePanel({
           data-testid="port-guidance-arrangement"
         >
           {arrangement.summary}
+        </Box>
+      )}
+
+      {requirements && (
+        <Box data-testid="port-guidance-requirements">
+          <Box variant="strong">Typical requirement for this node kind:</Box>{' '}
+          {requirements}
         </Box>
       )}
 

--- a/edge-cv-portal/frontend/src/pages/node-designer/RegistrationWizard.test.tsx
+++ b/edge-cv-portal/frontend/src/pages/node-designer/RegistrationWizard.test.tsx
@@ -579,3 +579,58 @@ describe('RegistrationWizard ports step wiring', () => {
     await screen.findByRole('button', { name: 'Add parameter' });
   });
 });
+
+/**
+ * Category-driven default ports (workflow-designer-bugfixes Bug 2,
+ * Requirements 1.4, 2.4, 2.5, 2.6).
+ *
+ * BUG CONDITION EXPLORATION (task 4): these tests encode the EXPECTED
+ * behavior and are expected to FAIL on the unfixed code — the wizard
+ * seeds one "in" input and one "out" output regardless of the selected
+ * palette category and never rewrites the untouched default rows on a
+ * category change (isBugCondition2 in the workflow-designer-bugfixes
+ * design). They validate the fix when they pass.
+ */
+describe('RegistrationWizard category-driven default ports (workflow-designer-bugfixes Bug 2)', () => {
+  it('presents no input rows and one VideoFrames output after selecting the input category on untouched defaults (1.4, 2.4, 2.5, 2.6)', async () => {
+    // A report predating pad capture: the scan applies nothing, so the
+    // port rows stay the wizard-seeded Untouched_Defaults.
+    getGstProperties.mockResolvedValue(PADS_NOT_CAPTURED);
+    const { container } = render(<RegistrationWizard />);
+    await screen.findByText('Register custom node type');
+
+    // The details step's only Select is the palette category.
+    const categorySelect = createWrapper(container).findAllSelects()[0];
+    categorySelect.openDropdown();
+    categorySelect.selectOptionByValue('input');
+    clickNext();
+    await screen.findByText('Input ports');
+
+    // Input (source) nodes: no input port rows (2.4).
+    expect(screen.getByText('No inputs declared.')).toBeInTheDocument();
+    expect(container.querySelectorAll('input[placeholder="in"]')).toHaveLength(0);
+
+    // Exactly one VideoFrames output with a non-empty name (2.4).
+    const outputNames = container.querySelectorAll('input[placeholder="out"]');
+    expect(outputNames).toHaveLength(1);
+    expect((outputNames[0] as HTMLInputElement).value.trim()).not.toBe('');
+    const typeSelects = createWrapper(container)
+      .findAllSelects()
+      .filter(
+        (select) =>
+          select.getElement().getAttribute('data-testid') !==
+          'port-scan-factory-select'
+      );
+    expect(typeSelects).toHaveLength(1);
+    expect(typeSelects[0].findTrigger().getElement().textContent).toContain(
+      'VideoFrames'
+    );
+
+    // The ports step states the category's input/output requirements
+    // (2.6) — the design's fix interface: PortGuidancePanel renders them
+    // under data-testid="port-guidance-requirements".
+    const requirements = screen.getByTestId('port-guidance-requirements');
+    expect(requirements.textContent).toMatch(/inputs/i);
+    expect(requirements.textContent).toMatch(/outputs/i);
+  });
+});

--- a/edge-cv-portal/frontend/src/pages/node-designer/RegistrationWizard.tsx
+++ b/edge-cv-portal/frontend/src/pages/node-designer/RegistrationWizard.tsx
@@ -42,7 +42,15 @@ import {
   PORT_TYPES,
   PluginVersionDetail,
 } from './types';
-import { emptyParameter, emptyPort, detailsStepErrors, parametersStepErrors, portsStepErrors } from './declaration';
+import {
+  defaultPortsForCategory,
+  detailsStepErrors,
+  emptyParameter,
+  emptyPort,
+  isDefaultPortArrangement,
+  parametersStepErrors,
+  portsStepErrors,
+} from './declaration';
 import type { ParameterForm, PortForm, WizardForm } from './declaration';
 import ParameterScanPanel, {
   ParameterScanMergeResult,
@@ -135,8 +143,7 @@ export default function RegistrationWizard() {
             name: detail.name,
             description: detail.description || '',
             category: 'preprocessing',
-            inputs: [{ ...emptyPort(), name: 'in' }],
-            outputs: [{ ...emptyPort(), name: 'out' }],
+            ...defaultPortsForCategory('preprocessing'),
             parameters: [],
             mappings: initialMappings(successfulBuildArchs(detail.artifacts), factory),
             hardwareDependent: false,
@@ -462,9 +469,19 @@ export default function RegistrationWizard() {
                   <Select
                     selectedOption={{ label: form.category, value: form.category }}
                     options={CATEGORIES.map((c) => ({ label: c, value: c }))}
-                    onChange={({ detail }) =>
-                      patch({ category: detail.selectedOption.value || form.category })
-                    }
+                    onChange={({ detail }) => {
+                      const category =
+                        detail.selectedOption.value || form.category;
+                      // Untouched default port rows follow the selected
+                      // category's typical arrangement; user-edited rows
+                      // are preserved exactly (workflow-designer-bugfixes
+                      // Bug 2, Req 2.4, 2.5, 3.6).
+                      if (isDefaultPortArrangement(form.inputs, form.outputs)) {
+                        patch({ category, ...defaultPortsForCategory(category) });
+                      } else {
+                        patch({ category });
+                      }
+                    }}
                   />
                 </FormField>
                 <FormField

--- a/edge-cv-portal/frontend/src/pages/node-designer/categoryDefaultPorts.property.test.ts
+++ b/edge-cv-portal/frontend/src/pages/node-designer/categoryDefaultPorts.property.test.ts
@@ -1,0 +1,267 @@
+/**
+ * **Feature: workflow-designer-bugfixes, Property 3: Bug Condition —
+ * Default ports follow the selected category**
+ *
+ * _For any_ palette category in `CATEGORY_ARRANGEMENTS` selected in the
+ * create wizard while the port rows are Untouched_Defaults, the wizard
+ * SHALL present default port rows whose port-type multisets exactly
+ * match that category's typical arrangement (in particular: category
+ * `input` → zero input rows and one VideoFrames output; `output` → at
+ * least one input row and zero outputs), every seeded row SHALL carry a
+ * non-empty name (so `portsStepErrors` stays clean),
+ * `guidanceDivergence(category, inputs, outputs)` SHALL be null for the
+ * seeded rows, and the ports step SHALL state that category's
+ * input/output requirements.
+ *
+ * **Validates: Requirements 1.4, 1.5, 2.4, 2.5, 2.6**
+ *
+ * BUG CONDITION EXPLORATION (workflow-designer-bugfixes task 4): this
+ * test encodes the EXPECTED behavior and is expected to FAIL on the
+ * unfixed code — the wizards seed one "in" input and one "out" output
+ * regardless of the selected palette category and never rewrite the
+ * untouched default rows when the category changes (isBugCondition2 in
+ * design.md). The failing categories are the behavioral
+ * counterexamples confirming the bug; the same test validates the fix
+ * once the wizards derive their default rows from the category.
+ *
+ * The property drives the real component (RTL over `CreateWizard`), so
+ * a failure is an observable wizard behavior, not a missing import:
+ * select the category on the details step, walk to the Ports step, and
+ * read the presented port rows back out of the DOM.
+ *
+ * Requirement 2.6 is asserted against the interface the design defines
+ * for the fix: a `data-testid="port-guidance-requirements"` element on
+ * the ports step (rendered by `PortGuidancePanel` from the new
+ * `arrangementRequirements(category)` helper) stating the category's
+ * input and output requirements.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import createWrapper from '@cloudscape-design/components/test-utils/dom';
+import * as fc from 'fast-check';
+import { createElement } from 'react';
+import CreateWizard from './CreateWizard';
+import { CATEGORY_ARRANGEMENTS, guidanceDivergence } from './portGuidance';
+import { CATEGORIES, PORT_TYPES } from './types';
+import type { PortForm } from './declaration';
+
+// ------------------------------------------------------------------ mocks
+//
+// Same wiring as CreateWizard.test.tsx: the wizard's collaborators are
+// mocked so the Ports step renders with no network access.
+
+const { navigateMock, listUseCases, createScaffoldPlugin } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  listUseCases: vi.fn(),
+  createScaffoldPlugin: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('../../services/api', () => {
+  class ApiError extends Error {
+    constructor(
+      message: string,
+      public readonly status?: number,
+      public readonly code?: string,
+      public readonly details?: Record<string, unknown>
+    ) {
+      super(message);
+      this.name = 'ApiError';
+    }
+  }
+  return { ApiError, apiService: { listUseCases } };
+});
+
+vi.mock('../../contexts/UsecaseContext', () => ({
+  useUsecase: () => ({
+    selectedUsecaseId: 'uc-1',
+    setSelectedUsecaseId: vi.fn(),
+  }),
+}));
+
+vi.mock('./api', () => ({
+  nodeDesignerApi: {
+    createScaffoldPlugin,
+    getGstProperties: vi.fn(),
+    putVersionSource: vi.fn(),
+    startBuilds: vi.fn(),
+  },
+}));
+
+vi.mock('./zip', () => ({
+  downloadZip: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listUseCases.mockResolvedValue({
+    usecases: [{ usecase_id: 'uc-1', name: 'Line A' }],
+  });
+});
+
+// ---------------------------------------------------------------- helpers
+
+/**
+ * Render the create wizard, select the palette category on the details
+ * step (the port rows stay Untouched_Defaults — the user never edits
+ * them), and walk to the Ports step.
+ */
+async function openPortsStepWithCategory(
+  category: string
+): Promise<HTMLElement> {
+  const { container } = render(createElement(CreateWizard));
+  await waitFor(() => expect(listUseCases).toHaveBeenCalled());
+
+  // Name is required to leave the details step.
+  const nameInput = container.querySelector(
+    'input[placeholder="Blur Regions"]'
+  )!;
+  fireEvent.change(nameInput, { target: { value: 'Node Under Test' } });
+
+  // Details-step selects: [0] use case, [1] palette category.
+  const categorySelect = createWrapper(container).findAllSelects()[1];
+  categorySelect.openDropdown();
+  categorySelect.selectOptionByValue(category);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+  await screen.findByText('Input ports');
+  return container;
+}
+
+/**
+ * Read the presented port rows back out of the Ports step DOM: input
+ * rows are the name inputs with placeholder "in", output rows those
+ * with placeholder "out"; the port-type selects follow in DOM order
+ * (all input types, then all output types).
+ */
+function readSeededRows(container: HTMLElement): {
+  inputs: PortForm[];
+  outputs: PortForm[];
+} {
+  const inputNames = Array.from(
+    container.querySelectorAll('input[placeholder="in"]')
+  ).map((el) => (el as HTMLInputElement).value);
+  const outputNames = Array.from(
+    container.querySelectorAll('input[placeholder="out"]')
+  ).map((el) => (el as HTMLInputElement).value);
+
+  const types = createWrapper(container)
+    .findAllSelects()
+    .map((select) => {
+      const text = select.findTrigger().getElement().textContent ?? '';
+      return PORT_TYPES.find((portType) => text.includes(portType)) ?? text.trim();
+    });
+
+  return {
+    inputs: inputNames.map((name, i) => ({ name, portType: types[i] })),
+    outputs: outputNames.map((name, i) => ({
+      name,
+      portType: types[inputNames.length + i],
+    })),
+  };
+}
+
+const multiset = (ports: readonly PortForm[]) =>
+  ports.map((port) => port.portType).sort();
+
+// --------------------------------------------------------------- property
+
+describe('Property 3: Default ports follow the selected category (bug condition exploration)', () => {
+  it(
+    'presents default port rows whose port-type multisets match the ' +
+      "category's typical arrangement, with non-empty names and no " +
+      'guidance divergence (1.4, 1.5, 2.4, 2.5)',
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.constantFrom(...CATEGORIES), async (category) => {
+          try {
+            const container = await openPortsStepWithCategory(category);
+            const { inputs, outputs } = readSeededRows(container);
+            const arrangement = CATEGORY_ARRANGEMENTS[category];
+
+            // The presented default rows' port-type multisets match the
+            // category's typical arrangement (2.4, 2.5). The output
+            // category's 'at-least-one' input side seeds at least one
+            // input row; its output side must be empty.
+            if (arrangement.inputs === 'at-least-one') {
+              expect(
+                inputs.length,
+                `category ${category}: expected at least one seeded input row`
+              ).toBeGreaterThanOrEqual(1);
+            } else {
+              expect(
+                multiset(inputs),
+                `category ${category}: seeded input port types`
+              ).toEqual([...arrangement.inputs].sort());
+            }
+            expect(
+              multiset(outputs),
+              `category ${category}: seeded output port types`
+            ).toEqual([...arrangement.outputs].sort());
+
+            // Every seeded row carries a non-empty name, so
+            // portsStepErrors stays clean on the untouched defaults.
+            for (const port of [...inputs, ...outputs]) {
+              expect(
+                port.name.trim(),
+                `category ${category}: seeded rows need non-empty names`
+              ).not.toBe('');
+            }
+
+            // The seeded rows match the arrangement, so the divergence
+            // advisory has nothing to flag.
+            expect(
+              guidanceDivergence(category, inputs, outputs),
+              `category ${category}: seeded defaults must not diverge`
+            ).toBeNull();
+          } finally {
+            cleanup();
+          }
+        }),
+        { numRuns: 10 }
+      );
+    },
+    120000
+  );
+
+  it(
+    "states the selected category's input/output requirements on the " +
+      'ports step (2.6)',
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.constantFrom(...CATEGORIES), async (category) => {
+          try {
+            await openPortsStepWithCategory(category);
+
+            // The design's fix interface: PortGuidancePanel renders the
+            // per-kind requirements under
+            // data-testid="port-guidance-requirements".
+            const requirements = screen.queryByTestId(
+              'port-guidance-requirements'
+            );
+            expect(
+              requirements,
+              `category ${category}: the ports step must state the ` +
+                "category's input/output requirements"
+            ).not.toBeNull();
+            expect(requirements!.textContent).toMatch(/inputs/i);
+            expect(requirements!.textContent).toMatch(/outputs/i);
+          } finally {
+            cleanup();
+          }
+        }),
+        { numRuns: 6 }
+      );
+    },
+    120000
+  );
+});

--- a/edge-cv-portal/frontend/src/pages/node-designer/declaration.test.ts
+++ b/edge-cv-portal/frontend/src/pages/node-designer/declaration.test.ts
@@ -8,9 +8,11 @@ import {
   architecturesStepErrors,
   buildDeclaration,
   convertParameterValue,
+  defaultPortsForCategory,
   detailsStepErrors,
   emptyParameter,
   emptyPort,
+  isDefaultPortArrangement,
   parametersStepErrors,
   portsStepErrors,
   typeIdFromName,
@@ -151,5 +153,78 @@ describe('step validation', () => {
     const errors = parametersStepErrors(form);
     expect(errors.some((e) => e.includes('description'))).toBe(true);
     expect(errors.some((e) => e.includes('example'))).toBe(true);
+  });
+});
+
+/**
+ * Category-driven default port seeds (workflow-designer-bugfixes
+ * Bug 2, Requirements 2.4, 2.5, 3.6, 3.10).
+ */
+describe('defaultPortsForCategory', () => {
+  it('seeds each palette category with its typical arrangement (2.4, 2.5)', () => {
+    expect(defaultPortsForCategory('input')).toEqual({
+      inputs: [],
+      outputs: [{ name: 'out', portType: 'VideoFrames' }],
+    });
+    expect(defaultPortsForCategory('preprocessing')).toEqual({
+      inputs: [{ name: 'in', portType: 'VideoFrames' }],
+      outputs: [{ name: 'out', portType: 'VideoFrames' }],
+    });
+    expect(defaultPortsForCategory('inference')).toEqual({
+      inputs: [{ name: 'in', portType: 'VideoFrames' }],
+      outputs: [{ name: 'out', portType: 'InferenceMeta' }],
+    });
+    expect(defaultPortsForCategory('post_processing')).toEqual({
+      inputs: [{ name: 'in', portType: 'InferenceMeta' }],
+      outputs: [{ name: 'out', portType: 'EventSignal' }],
+    });
+    expect(defaultPortsForCategory('output')).toEqual({
+      inputs: [{ name: 'in', portType: 'VideoFrames' }],
+      outputs: [],
+    });
+  });
+
+  it("falls back to the preprocessing shape (today's seeds) for unknown categories", () => {
+    expect(defaultPortsForCategory('unknown')).toEqual(
+      defaultPortsForCategory('preprocessing')
+    );
+    expect(defaultPortsForCategory('')).toEqual(
+      defaultPortsForCategory('preprocessing')
+    );
+  });
+});
+
+describe('isDefaultPortArrangement', () => {
+  it("answers true for every category's default arrangement", () => {
+    for (const category of [
+      'input',
+      'preprocessing',
+      'inference',
+      'post_processing',
+      'output',
+    ]) {
+      const { inputs, outputs } = defaultPortsForCategory(category);
+      expect(isDefaultPortArrangement(inputs, outputs)).toBe(true);
+    }
+  });
+
+  it('answers false once the rows are edited (rename, retype, add, remove)', () => {
+    const { inputs, outputs } = defaultPortsForCategory('preprocessing');
+    expect(
+      isDefaultPortArrangement(
+        [{ ...inputs[0], name: 'video' }],
+        outputs
+      )
+    ).toBe(false);
+    expect(
+      isDefaultPortArrangement(
+        [{ ...inputs[0], portType: 'EventSignal' }],
+        outputs
+      )
+    ).toBe(false);
+    expect(
+      isDefaultPortArrangement([...inputs, { name: 'aux', portType: 'VideoFrames' }], outputs)
+    ).toBe(false);
+    expect(isDefaultPortArrangement([], [])).toBe(false);
   });
 });

--- a/edge-cv-portal/frontend/src/pages/node-designer/declaration.ts
+++ b/edge-cv-portal/frontend/src/pages/node-designer/declaration.ts
@@ -8,11 +8,14 @@
  * only assemble the shape and provide the light client-side checks the
  * wizard needs for step gating.
  */
+import { CATEGORIES } from './types';
 import type {
+  NodeCategory,
   ParameterDeclaration,
   PortDeclaration,
   ScaffoldDeclaration,
 } from './types';
+import { CATEGORY_ARRANGEMENTS } from './portGuidance';
 
 // ------------------------------------------------------------- form state
 
@@ -65,6 +68,73 @@ export const emptyParameter = (): ParameterForm => ({
   example: '',
   enumValues: '',
 });
+
+// --------------------------------------------- category default ports
+
+/**
+ * The default port rows the wizards seed for one palette category,
+ * derived from the category's typical arrangement
+ * (CATEGORY_ARRANGEMENTS in portGuidance.ts;
+ * workflow-designer-bugfixes Bug 2, Requirements 2.4, 2.5):
+ *
+ * - `input`: no inputs, one VideoFrames "out"
+ * - `preprocessing`: one VideoFrames "in", one VideoFrames "out"
+ *   (byte-identical to the wizards' historical seeds)
+ * - `inference`: one VideoFrames "in", one InferenceMeta "out"
+ * - `post_processing`: one InferenceMeta "in", one EventSignal "out"
+ * - `output`: one VideoFrames "in" (the seeded representative of
+ *   "at least one input of any type"), no outputs
+ * - unknown category: the preprocessing shape (today's seeds)
+ *
+ * Every seeded row carries a non-empty name so `portsStepErrors` stays
+ * clean on the untouched defaults, and each concrete arrangement
+ * yields `guidanceDivergence === null`.
+ */
+export function defaultPortsForCategory(category: string): {
+  inputs: PortForm[];
+  outputs: PortForm[];
+} {
+  const arrangement = Object.prototype.hasOwnProperty.call(
+    CATEGORY_ARRANGEMENTS,
+    category
+  )
+    ? CATEGORY_ARRANGEMENTS[category as NodeCategory]
+    : CATEGORY_ARRANGEMENTS.preprocessing;
+  const inputs: PortForm[] =
+    arrangement.inputs === 'at-least-one'
+      ? [{ name: 'in', portType: 'VideoFrames' }]
+      : arrangement.inputs.map((portType) => ({ name: 'in', portType }));
+  const outputs: PortForm[] = arrangement.outputs.map((portType) => ({
+    name: 'out',
+    portType,
+  }));
+  return { inputs, outputs };
+}
+
+const samePortRows = (a: readonly PortForm[], b: readonly PortForm[]) =>
+  a.length === b.length &&
+  a.every(
+    (port, i) => port.name === b[i].name && port.portType === b[i].portType
+  );
+
+/**
+ * Generalized Untouched_Defaults detection (workflow-designer-bugfixes
+ * Bug 2): true exactly when the rows deep-equal
+ * `defaultPortsForCategory(c)` for some palette category `c`. Any
+ * rename, retype, addition, or removal makes the rows user-edited.
+ */
+export function isDefaultPortArrangement(
+  inputs: PortForm[],
+  outputs: PortForm[]
+): boolean {
+  return CATEGORIES.some((category) => {
+    const defaults = defaultPortsForCategory(category);
+    return (
+      samePortRows(defaults.inputs, inputs) &&
+      samePortRows(defaults.outputs, outputs)
+    );
+  });
+}
 
 // ------------------------------------------------------------ conversions
 

--- a/edge-cv-portal/frontend/src/pages/node-designer/importFlow.test.ts
+++ b/edge-cv-portal/frontend/src/pages/node-designer/importFlow.test.ts
@@ -355,6 +355,7 @@ describe('pluginSelectionError', () => {
 
 import {
   allPluginNames,
+  moduleSelectionIncomplete,
   moduleSelectionSummary,
   normalizeModuleSelection,
   selectedPluginsParam,
@@ -373,6 +374,26 @@ describe('allPluginNames', () => {
   it('lists the plugin names in listing order', () => {
     expect(allPluginNames(MODULE_PLUGINS)).toEqual(AVAILABLE);
     expect(allPluginNames([])).toEqual([]);
+  });
+});
+
+describe('moduleSelectionIncomplete', () => {
+  it('gates a loaded plugin list with nothing selected (2.8)', () => {
+    expect(moduleSelectionIncomplete('module', AVAILABLE, [])).toBe(true);
+  });
+
+  it('unblocks once at least one plugin is selected', () => {
+    expect(moduleSelectionIncomplete('module', AVAILABLE, ['rtp'])).toBe(false);
+    expect(moduleSelectionIncomplete('module', AVAILABLE, AVAILABLE)).toBe(false);
+  });
+
+  it('never blocks without an available plugin list (3.13)', () => {
+    expect(moduleSelectionIncomplete('module', [], [])).toBe(false);
+  });
+
+  it('never gates manual repository URL imports', () => {
+    expect(moduleSelectionIncomplete('manual', AVAILABLE, [])).toBe(false);
+    expect(moduleSelectionIncomplete('manual', [], [])).toBe(false);
   });
 });
 

--- a/edge-cv-portal/frontend/src/pages/node-designer/importFlow.ts
+++ b/edge-cv-portal/frontend/src/pages/node-designer/importFlow.ts
@@ -382,15 +382,35 @@ export function pluginSelectionError(
 //
 // When an official module is chosen, its individual plugins load from
 // GET /plugin-modules?module=<name> and the form offers a selection
-// (default: all) before the import. The chosen subset serializes to
-// the import request's selected_plugins; a full selection serializes
-// to nothing (absent = whole module, today's behavior). Loading the
-// list is a non-blocking enhancement: on failure the import proceeds
-// with the full set.
+// (default: none selected — the user opts in explicitly) before the
+// import. The chosen subset serializes to the import request's
+// selected_plugins; a full selection serializes to nothing (absent =
+// whole module, today's behavior). Loading the list is a non-blocking
+// enhancement: on failure the import proceeds with the full set.
 
 /** The plugin names of a module plugin list, in listing order. */
 export function allPluginNames(plugins: ModulePluginEntry[]): string[] {
   return plugins.map((plugin) => plugin.name);
+}
+
+/**
+ * The explicit-selection gate for the module import path: a loaded
+ * (non-empty) plugin list requires at least one selected plugin before
+ * the import proceeds. True exactly when the source is the module
+ * listing, plugins are available, and nothing is selected yet. An
+ * unavailable or empty plugin list never blocks (whole-module
+ * fallback), and manual repository URL imports are never gated.
+ */
+export function moduleSelectionIncomplete(
+  source: 'module' | 'manual',
+  availableNames: string[],
+  selectedNames: string[]
+): boolean {
+  return (
+    source === 'module' &&
+    availableNames.length > 0 &&
+    selectedNames.length === 0
+  );
 }
 
 /**

--- a/edge-cv-portal/frontend/src/pages/node-designer/importSelectionDefault.property.test.ts
+++ b/edge-cv-portal/frontend/src/pages/node-designer/importSelectionDefault.property.test.ts
@@ -1,0 +1,306 @@
+/**
+ * **Feature: workflow-designer-bugfixes, Property 5: Bug Condition —
+ * Import selection defaults to none with an explicit gate**
+ *
+ * _For any_ non-empty module plugin list loading in the import view
+ * (including after switching modules), the view SHALL seed the
+ * selection empty (0 of N selected) and SHALL keep the import blocked
+ * (`formComplete` false, gate message shown) until the user explicitly
+ * selects at least one plugin individually or via "Select all".
+ *
+ * **Validates: Requirements 1.6, 2.7, 2.8**
+ *
+ * BUG CONDITION EXPLORATION (workflow-designer-bugfixes task 7): this
+ * test encodes the EXPECTED behavior and is expected to FAIL on the
+ * unfixed code — the module plugin load effect in `ImportView.tsx`
+ * seeds `setSelectedModulePlugins(allPluginNames(plugins))`, so every
+ * plugin is checked on load and the import proceeds with zero explicit
+ * opt-in (isBugCondition3 in design.md). The failing plugin lists are
+ * the behavioral counterexamples confirming the bug; the same test
+ * validates the fix once the selection seeds empty and the existing
+ * gate (`moduleSelectionIncomplete` → `formComplete`) blocks the
+ * review until an explicit selection is made.
+ *
+ * The property drives the real component (RTL over `ImportView`, same
+ * mock wiring as ImportView.test.tsx), so a failure is an observable
+ * import-view behavior: choose an official module, let its plugin list
+ * load, and read the selection count, gate message, and Review-import
+ * button state back out of the DOM.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import createWrapper from '@cloudscape-design/components/test-utils/dom';
+import * as fc from 'fast-check';
+import { createElement } from 'react';
+import ImportView from './ImportView';
+import type { ModulePluginEntry } from './types';
+
+// ------------------------------------------------------------------ mocks
+//
+// Same wiring as ImportView.test.tsx: the view's collaborators are
+// mocked so the module plugin list loads with no network access.
+
+const {
+  navigateMock,
+  listUseCases,
+  listPluginModules,
+  listModulePlugins,
+  importPlugin,
+  selectImportPlugins,
+  getVersion,
+} = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  listUseCases: vi.fn(),
+  listPluginModules: vi.fn(),
+  listModulePlugins: vi.fn(),
+  importPlugin: vi.fn(),
+  selectImportPlugins: vi.fn(),
+  getVersion: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('../../services/api', () => {
+  class ApiError extends Error {
+    constructor(
+      message: string,
+      public readonly status?: number,
+      public readonly code?: string,
+      public readonly details?: Record<string, unknown>
+    ) {
+      super(message);
+      this.name = 'ApiError';
+    }
+  }
+  return { ApiError, apiService: { listUseCases } };
+});
+
+vi.mock('../../contexts/UsecaseContext', () => ({
+  useUsecase: () => ({
+    selectedUsecaseId: 'uc-1',
+    setSelectedUsecaseId: vi.fn(),
+  }),
+}));
+
+vi.mock('./api', () => ({
+  nodeDesignerApi: {
+    listPluginModules,
+    listModulePlugins,
+    importPlugin,
+    selectImportPlugins,
+    getVersion,
+  },
+}));
+
+const MODULE_A = 'gst-plugins-good';
+const MODULE_B = 'gst-plugins-bad';
+
+const MODULES = [
+  {
+    name: MODULE_A,
+    description: 'Well-maintained plugins',
+    repoUrl: 'https://gitlab.freedesktop.org/gstreamer/gst-plugins-good.git',
+    classification: 'good',
+  },
+  {
+    name: MODULE_B,
+    description: 'Plugins lacking upstream review',
+    repoUrl: 'https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad.git',
+    classification: 'bad',
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listUseCases.mockResolvedValue({
+    usecases: [{ usecase_id: 'uc-1', name: 'Line A' }],
+  });
+  listPluginModules.mockResolvedValue({
+    modules: MODULES,
+    fetchedAt: 1,
+    cached: false,
+  });
+});
+
+// ------------------------------------------------------------ generators
+
+/** Plugin-like names: lowercase alphanumerics, as the listing returns. */
+const pluginNameArb = fc.string({
+  unit: fc.constantFrom(...'abcdefghijklmnopqrstuvwxyz0123456789'.split('')),
+  minLength: 1,
+  maxLength: 12,
+});
+
+/** A NON-EMPTY module plugin list with unique names (isBugCondition3). */
+const pluginListArb: fc.Arbitrary<ModulePluginEntry[]> = fc
+  .uniqueArray(pluginNameArb, { minLength: 1, maxLength: 8 })
+  .map((names) => names.map((name) => ({ name })));
+
+// ---------------------------------------------------------------- helpers
+
+const GATE_MESSAGE = 'Select at least one plugin to import';
+
+/**
+ * Render the import view with the given per-module plugin lists,
+ * choose `moduleName` from the Module_Listing select, pick one target
+ * architecture (so only the selection gate can block the form), and
+ * wait for the module's plugin list to render.
+ */
+async function openModulePluginList(
+  pluginsByModule: Record<string, ModulePluginEntry[]>,
+  moduleName: string
+): Promise<HTMLElement> {
+  listModulePlugins.mockImplementation(async (name: string) => ({
+    module: name,
+    plugins: pluginsByModule[name] ?? [],
+    fetchedAt: 1,
+    cached: false,
+  }));
+
+  const { container } = render(createElement(ImportView));
+  await waitFor(() => expect(listPluginModules).toHaveBeenCalled());
+  const wrapper = createWrapper(container);
+
+  // Selects: [0] use case, [1] module.
+  const moduleSelect = wrapper.findAllSelects()[1];
+  moduleSelect.openDropdown();
+  moduleSelect.selectOptionByValue(moduleName);
+
+  const archSelect = wrapper.findMultiselect()!;
+  archSelect.openDropdown();
+  archSelect.selectOptionByValue('x86_64');
+
+  // The chosen module's plugin list has rendered, and the use case
+  // restored from context is selected — every formComplete condition
+  // other than the plugin selection is satisfied.
+  await screen.findByText('Plugins to import');
+  await waitFor(() => expect(screen.getByText('Line A')).toBeInTheDocument());
+  return container;
+}
+
+/** Switch the already-rendered view to another module and wait for its
+ *  plugin list to load (the selection must reseed for the new list). */
+async function switchModule(
+  container: HTMLElement,
+  moduleName: string,
+  expectedCount: number
+): Promise<void> {
+  const moduleSelect = createWrapper(container).findAllSelects()[1];
+  moduleSelect.openDropdown();
+  moduleSelect.selectOptionByValue(moduleName);
+  await waitFor(() =>
+    expect(screen.getByText(new RegExp(`of ${expectedCount} selected`))).toBeInTheDocument()
+  );
+}
+
+/** The "X of N selected" counter must read 0 selected, the gate
+ *  message must show, and the Review import button must be blocked. */
+function expectSeededEmptyAndBlocked(pluginCount: number): void {
+  // Seeded empty: 0 of N selected immediately after the list load (2.7).
+  expect(
+    screen.getByText(`0 of ${pluginCount} selected`),
+    'the module plugin selection must seed empty (0 of N selected) on load'
+  ).toBeInTheDocument();
+
+  // The explicit-selection gate shows and blocks the review (2.8):
+  // formComplete stays false until the user opts in.
+  expect(
+    screen.getByText(GATE_MESSAGE),
+    'the selection gate message must show while nothing is selected'
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: 'Review import' }),
+    'the import must stay blocked until an explicit selection is made'
+  ).toBeDisabled();
+}
+
+// --------------------------------------------------------------- property
+
+describe('Property 5: Import selection defaults to none with an explicit gate (bug condition exploration)', () => {
+  it(
+    'seeds the selection empty and blocks the import until at least one ' +
+      'plugin is explicitly selected, individually or via Select all ' +
+      '(1.6, 2.7, 2.8)',
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(pluginListArb, async (plugins) => {
+          try {
+            await openModulePluginList({ [MODULE_A]: plugins }, MODULE_A);
+
+            // Immediately after the list load: 0 of N selected,
+            // import blocked, gate message shown.
+            expectSeededEmptyAndBlocked(plugins.length);
+
+            // Explicit individual opt-in unblocks the import: the
+            // first plugin's checkbox (the plugin checkboxes precede
+            // the DeepStream toggle in DOM order).
+            fireEvent.click(screen.getAllByRole('checkbox')[0]);
+            expect(
+              screen.getByText(`1 of ${plugins.length} selected`)
+            ).toBeInTheDocument();
+            expect(screen.queryByText(GATE_MESSAGE)).not.toBeInTheDocument();
+            expect(
+              screen.getByRole('button', { name: 'Review import' })
+            ).toBeEnabled();
+
+            // Clearing re-blocks; "Select all" is the other explicit
+            // opt-in path and unblocks with the full selection.
+            fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+            expectSeededEmptyAndBlocked(plugins.length);
+            fireEvent.click(screen.getByRole('button', { name: 'Select all' }));
+            expect(
+              screen.getByText(`${plugins.length} of ${plugins.length} selected`)
+            ).toBeInTheDocument();
+            expect(
+              screen.getByRole('button', { name: 'Review import' })
+            ).toBeEnabled();
+          } finally {
+            cleanup();
+          }
+        }),
+        { numRuns: 8 }
+      );
+    },
+    120000
+  );
+
+  it(
+    'seeds the selection empty again for the new list after switching ' +
+      'modules (2.7)',
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          pluginListArb,
+          pluginListArb,
+          async (pluginsA, pluginsB) => {
+            try {
+              const container = await openModulePluginList(
+                { [MODULE_A]: pluginsA, [MODULE_B]: pluginsB },
+                MODULE_A
+              );
+              expectSeededEmptyAndBlocked(pluginsA.length);
+
+              // A selection on the first module must not leak into the
+              // next module's freshly loaded list.
+              fireEvent.click(screen.getAllByRole('checkbox')[0]);
+              await switchModule(container, MODULE_B, pluginsB.length);
+              expectSeededEmptyAndBlocked(pluginsB.length);
+            } finally {
+              cleanup();
+            }
+          }
+        ),
+        { numRuns: 6 }
+      );
+    },
+    120000
+  );
+});

--- a/edge-cv-portal/frontend/src/pages/node-designer/importSelectionPreservation.property.test.ts
+++ b/edge-cv-portal/frontend/src/pages/node-designer/importSelectionPreservation.property.test.ts
@@ -1,0 +1,528 @@
+/**
+ * **Feature: workflow-designer-bugfixes, Property 6: Preservation —
+ * Import serialization and fallbacks unchanged**
+ *
+ * _For any_ selection state, the fixed view SHALL serialize exactly as
+ * the original: a proper subset serializes to that subset as
+ * `selected_plugins`; a full selection (or, when no list is available,
+ * no selection) serializes to no `selected_plugins` parameter
+ * (whole-module import); an unavailable or empty plugin list SHALL
+ * never block the import; and the post-fetch `pending_selection`
+ * dialog SHALL keep its default-none, at-least-one-required behavior.
+ *
+ * **Validates: Requirements 3.11, 3.12, 3.13, 3.14**
+ *
+ * PRESERVATION (workflow-designer-bugfixes task 8): observation-first —
+ * these properties encode the UNFIXED behavior observed in
+ * `importFlow.ts` (`selectedPluginsParam`, `moduleSelectionSummary`,
+ * `pluginSelectionError`) and `ImportView.tsx` (non-blocking plugin-list
+ * fallback, `pending_selection` dialog). They MUST pass on the unfixed
+ * code, and MUST STILL pass unchanged after the Bug 3 fix (task 9.3):
+ * the fix only reseeds the module plugin selection default; none of the
+ * behavior asserted here may move.
+ *
+ * Pure serialization rules are property-tested directly; the
+ * component-level fallback and dialog behavior drive the real
+ * `ImportView` via RTL with the same mock wiring as ImportView.test.tsx.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import createWrapper from '@cloudscape-design/components/test-utils/dom';
+import * as fc from 'fast-check';
+import { createElement } from 'react';
+import ImportView from './ImportView';
+import { ApiError } from '../../services/api';
+import {
+  moduleSelectionSummary,
+  pluginSelectionError,
+  selectedPluginsParam,
+} from './importFlow';
+import type { EnumeratedPlugin } from './types';
+
+// ------------------------------------------------------------------ mocks
+//
+// Same wiring as ImportView.test.tsx: the view's collaborators are
+// mocked so the flows run with no network access.
+
+const {
+  navigateMock,
+  listUseCases,
+  listPluginModules,
+  listModulePlugins,
+  importPlugin,
+  selectImportPlugins,
+  getVersion,
+} = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  listUseCases: vi.fn(),
+  listPluginModules: vi.fn(),
+  listModulePlugins: vi.fn(),
+  importPlugin: vi.fn(),
+  selectImportPlugins: vi.fn(),
+  getVersion: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('../../services/api', () => {
+  class ApiError extends Error {
+    constructor(
+      message: string,
+      public readonly status?: number,
+      public readonly code?: string,
+      public readonly details?: Record<string, unknown>
+    ) {
+      super(message);
+      this.name = 'ApiError';
+    }
+  }
+  return { ApiError, apiService: { listUseCases } };
+});
+
+vi.mock('../../contexts/UsecaseContext', () => ({
+  useUsecase: () => ({
+    selectedUsecaseId: 'uc-1',
+    setSelectedUsecaseId: vi.fn(),
+  }),
+}));
+
+vi.mock('./api', () => ({
+  nodeDesignerApi: {
+    listPluginModules,
+    listModulePlugins,
+    importPlugin,
+    selectImportPlugins,
+    getVersion,
+  },
+}));
+
+const MODULE_GOOD = 'gst-plugins-good';
+
+const MODULES = [
+  {
+    name: MODULE_GOOD,
+    description: 'Well-maintained plugins',
+    repoUrl: 'https://gitlab.freedesktop.org/gstreamer/gst-plugins-good.git',
+    classification: 'good',
+  },
+];
+
+const IMPORTED_RESPONSE = {
+  plugin: { plugin_id: 'plugin-p6', version: 1, import_status: 'imported' },
+  import: { status: 'imported' },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listUseCases.mockResolvedValue({
+    usecases: [{ usecase_id: 'uc-1', name: 'Line A' }],
+  });
+  listPluginModules.mockResolvedValue({
+    modules: MODULES,
+    fetchedAt: 1,
+    cached: false,
+  });
+});
+
+// ------------------------------------------------------------ generators
+
+/** Plugin-like names: lowercase alphanumerics, as the listing returns. */
+const pluginNameArb = fc.string({
+  unit: fc.constantFrom(...'abcdefghijklmnopqrstuvwxyz0123456789'.split('')),
+  minLength: 1,
+  maxLength: 12,
+});
+
+/** An available module plugin listing (unique names, listing order). */
+const availableArb = fc.uniqueArray(pluginNameArb, {
+  minLength: 1,
+  maxLength: 20,
+});
+
+/**
+ * A listing of >= 2 plugins together with a PROPER non-empty subset of
+ * it selected in arbitrary (user click) order — the Req 3.11 case.
+ */
+const properSubsetCaseArb = fc
+  .uniqueArray(pluginNameArb, { minLength: 2, maxLength: 20 })
+  .chain((available) =>
+    fc.record({
+      available: fc.constant(available),
+      selected: fc.shuffledSubarray(available, {
+        minLength: 1,
+        maxLength: available.length - 1,
+      }),
+    })
+  );
+
+/** A listing plus extra names guaranteed NOT to be in the listing. */
+const withUnknownNamesArb = fc
+  .uniqueArray(pluginNameArb, { minLength: 2, maxLength: 24 })
+  .chain((pool) =>
+    fc
+      .integer({ min: 1, max: pool.length - 1 })
+      .chain((cut) =>
+        fc.record({
+          available: fc.constant(pool.slice(0, cut)),
+          unknown: fc.constant(pool.slice(cut)),
+          selected: fc.shuffledSubarray(pool.slice(0, cut)),
+        })
+      )
+  );
+
+/** How the unfixed summary spells a partial selection (observed:
+ *  names in listing order, capped at 8 with a "+K more" suffix). */
+const SUMMARY_MAX_NAMES = 8;
+
+// ---------------------------------------------------------------------
+// Pure serialization rules (Req 3.11, 3.12) — observed on unfixed code:
+// selectedPluginsParam returns the normalized (listing-ordered) proper
+// subset, and undefined for a full selection, an empty selection, or
+// an unavailable listing; moduleSelectionSummary mirrors that split.
+// ---------------------------------------------------------------------
+
+describe('Property 6: selected_plugins serialization unchanged (pure)', () => {
+  it('serializes a proper subset to exactly that subset in listing order (3.11)', () => {
+    fc.assert(
+      fc.property(properSubsetCaseArb, ({ available, selected }) => {
+        const chosen = new Set(selected);
+        const expected = available.filter((name) => chosen.has(name));
+
+        expect(selectedPluginsParam(selected, available)).toEqual(expected);
+
+        // The confirm-step summary spells the same subset out.
+        const shown = expected.slice(0, SUMMARY_MAX_NAMES).join(', ');
+        const more =
+          expected.length > SUMMARY_MAX_NAMES
+            ? `, +${expected.length - SUMMARY_MAX_NAMES} more`
+            : '';
+        expect(moduleSelectionSummary(selected, available)).toBe(
+          `${expected.length} of ${available.length} plugins: ${shown}${more}`
+        );
+      })
+    );
+  });
+
+  it('serializes a full selection to no selected_plugins parameter — whole-module import (3.12)', () => {
+    fc.assert(
+      fc.property(
+        availableArb.chain((available) =>
+          fc.record({
+            available: fc.constant(available),
+            // Every plugin selected, in arbitrary click order.
+            selected: fc.shuffledSubarray(available, {
+              minLength: available.length,
+            }),
+          })
+        ),
+        ({ available, selected }) => {
+          expect(selectedPluginsParam(selected, available)).toBeUndefined();
+          expect(moduleSelectionSummary(selected, available)).toBe(
+            'All plugins'
+          );
+        }
+      )
+    );
+  });
+
+  it('serializes an empty selection or an unavailable listing to no selected_plugins parameter (3.12)', () => {
+    fc.assert(
+      fc.property(availableArb, (available) => {
+        // Empty selection over an available listing.
+        expect(selectedPluginsParam([], available)).toBeUndefined();
+        expect(moduleSelectionSummary([], available)).toBe('All plugins');
+      })
+    );
+    fc.assert(
+      fc.property(fc.uniqueArray(pluginNameArb, { maxLength: 8 }), (selected) => {
+        // No listing available at all: whatever is "selected" is moot.
+        expect(selectedPluginsParam(selected, [])).toBeUndefined();
+        expect(moduleSelectionSummary(selected, [])).toBe('All plugins');
+      })
+    );
+  });
+
+  it('ignores names outside the listing: serialization is decided by the known subset alone (3.11, 3.12)', () => {
+    fc.assert(
+      fc.property(withUnknownNamesArb, ({ available, unknown, selected }) => {
+        const mixed = [...selected, ...unknown];
+        expect(selectedPluginsParam(mixed, available)).toEqual(
+          selectedPluginsParam(selected, available)
+        );
+        expect(moduleSelectionSummary(mixed, available)).toBe(
+          moduleSelectionSummary(selected, available)
+        );
+      })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------
+// pending_selection dialog validation rule (Req 3.14, pure part) —
+// observed on unfixed code: an empty selection is rejected with the
+// at-least-one gate message, names outside the enumeration are
+// rejected by name, and any non-empty enumerated subset is accepted.
+// ---------------------------------------------------------------------
+
+describe('Property 6: pending_selection at-least-one-required rule unchanged (pure)', () => {
+  const foundArb: fc.Arbitrary<EnumeratedPlugin[]> = fc
+    .uniqueArray(pluginNameArb, { minLength: 1, maxLength: 12 })
+    .map((names) => names.map((name) => ({ name, path: `gst/${name}` })));
+
+  it('rejects an empty selection with the at-least-one gate message (3.14)', () => {
+    fc.assert(
+      fc.property(foundArb, (found) => {
+        expect(pluginSelectionError([], found)).toBe(
+          'Select at least one plugin to import'
+        );
+      })
+    );
+  });
+
+  it('accepts any non-empty subset of the enumerated plugins (3.14)', () => {
+    fc.assert(
+      fc.property(
+        foundArb.chain((found) =>
+          fc.record({
+            found: fc.constant(found),
+            selected: fc.shuffledSubarray(
+              found.map((entry) => entry.name),
+              { minLength: 1 }
+            ),
+          })
+        ),
+        ({ found, selected }) => {
+          expect(pluginSelectionError(selected, found)).toBeNull();
+        }
+      )
+    );
+  });
+
+  it('rejects selections naming plugins outside the enumeration (3.14)', () => {
+    fc.assert(
+      fc.property(withUnknownNamesArb, ({ available, unknown, selected }) => {
+        const found = available.map((name) => ({
+          name,
+          path: `gst/${name}`,
+        }));
+        const mixed = [...selected, ...unknown];
+        expect(pluginSelectionError(mixed, found)).toBe(
+          `Unknown plugins: ${unknown.join(', ')}`
+        );
+      })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------
+// Component-level fallback (Req 3.13) — observed on unfixed code: a
+// module plugin list that fails to load (distinct listing-unavailable
+// code or any other error) or comes back empty never blocks the
+// import; the whole-module import proceeds with no selected_plugins.
+// These flows never render a non-empty selection list, so they are
+// independent of the Bug 3 default-seeding change and must behave
+// identically before and after the fix.
+// ---------------------------------------------------------------------
+
+type FallbackScenario = 'listing-unavailable' | 'generic-error' | 'empty-list';
+
+const fallbackScenarioArb = fc.constantFrom<FallbackScenario>(
+  'listing-unavailable',
+  'generic-error',
+  'empty-list'
+);
+
+/** Select the module and one Target_Architecture on the form view. */
+async function fillForm(container: HTMLElement): Promise<void> {
+  await waitFor(() => expect(listPluginModules).toHaveBeenCalled());
+  const wrapper = createWrapper(container);
+
+  // Selects: [0] use case, [1] module.
+  const moduleSelect = wrapper.findAllSelects()[1];
+  moduleSelect.openDropdown();
+  moduleSelect.selectOptionByValue(MODULE_GOOD);
+
+  const archSelect = wrapper.findMultiselect()!;
+  archSelect.openDropdown();
+  archSelect.selectOptionByValue('x86_64');
+
+  await waitFor(() => expect(screen.getByText('Line A')).toBeInTheDocument());
+}
+
+describe('Property 6: unavailable or empty plugin list never blocks the import (component)', () => {
+  it(
+    'keeps the whole-module import available and sends no selected_plugins (3.13)',
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(fallbackScenarioArb, async (scenario) => {
+          try {
+            if (scenario === 'listing-unavailable') {
+              listModulePlugins.mockRejectedValue(
+                new ApiError(
+                  "The plugin list for module 'gst-plugins-good' could not be retrieved",
+                  502,
+                  'MODULE_LISTING_UNAVAILABLE'
+                )
+              );
+            } else if (scenario === 'generic-error') {
+              listModulePlugins.mockRejectedValue(new Error('network down'));
+            } else {
+              listModulePlugins.mockResolvedValue({
+                module: MODULE_GOOD,
+                plugins: [],
+                fetchedAt: 1,
+                cached: false,
+              });
+            }
+            importPlugin.mockResolvedValue(IMPORTED_RESPONSE);
+
+            const { container } = render(createElement(ImportView));
+            await fillForm(container);
+            await waitFor(() =>
+              expect(listModulePlugins).toHaveBeenCalledWith(MODULE_GOOD)
+            );
+
+            if (scenario !== 'empty-list') {
+              // The failure surfaces as a non-blocking warning.
+              await screen.findByText('Plugin list unavailable');
+            }
+
+            // No selection gate: no plugin list rendered, no gate
+            // message, and the review stays available.
+            expect(
+              screen.queryByText('Select at least one plugin to import')
+            ).not.toBeInTheDocument();
+            await waitFor(() =>
+              expect(
+                screen.getByRole('button', { name: 'Review import' })
+              ).toBeEnabled()
+            );
+
+            // The whole-module import proceeds: 'All plugins' on the
+            // confirm step and no selected_plugins on the wire.
+            fireEvent.click(
+              screen.getByRole('button', { name: 'Review import' })
+            );
+            await screen.findByText('Upstream classification');
+            expect(screen.getByText('All plugins')).toBeInTheDocument();
+            fireEvent.click(
+              screen.getByRole('button', { name: 'Import plugin' })
+            );
+            await waitFor(() => expect(importPlugin).toHaveBeenCalled());
+            expect(
+              importPlugin.mock.calls[0][0].selected_plugins
+            ).toBeUndefined();
+          } finally {
+            cleanup();
+          }
+        }),
+        { numRuns: 6 }
+      );
+    },
+    120000
+  );
+});
+
+// ---------------------------------------------------------------------
+// pending_selection dialog (Req 3.14, component) — observed on unfixed
+// code: the post-fetch selection dialog seeds with NO plugins selected
+// (setSelectedPlugins([]) in settleImport) and keeps "Import selected
+// plugins" blocked until at least one plugin is checked. The module
+// plugin list resolves empty here so the flow is identical before and
+// after the Bug 3 fix (the fix touches only the module-list seeding).
+// ---------------------------------------------------------------------
+
+const enumeratedListArb: fc.Arbitrary<EnumeratedPlugin[]> = fc
+  .uniqueArray(pluginNameArb, { minLength: 1, maxLength: 6 })
+  .map((names) => names.map((name) => ({ name, path: `gst/${name}` })));
+
+describe('Property 6: pending_selection dialog default-none behavior unchanged (component)', () => {
+  it(
+    'opens with no plugins selected and requires at least one before submission (3.14)',
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(enumeratedListArb, async (found) => {
+          try {
+            listModulePlugins.mockResolvedValue({
+              module: MODULE_GOOD,
+              plugins: [],
+              fetchedAt: 1,
+              cached: false,
+            });
+            importPlugin.mockResolvedValue({
+              plugin: {
+                plugin_id: 'plugin-p6',
+                version: 1,
+                import_status: 'pending_selection',
+                plugins_found: found,
+              },
+              import: { status: 'pending_selection' },
+            });
+            selectImportPlugins.mockResolvedValue({
+              plugin: {
+                plugin_id: 'plugin-p6',
+                version: 1,
+                import_status: 'imported',
+              },
+              import: { status: 'imported' },
+            });
+
+            const { container } = render(createElement(ImportView));
+            await fillForm(container);
+            fireEvent.click(
+              screen.getByRole('button', { name: 'Review import' })
+            );
+            await screen.findByText('Upstream classification');
+            fireEvent.click(
+              screen.getByRole('button', { name: 'Import plugin' })
+            );
+
+            // The dialog opens defaulting to NO selection, with the
+            // confirmation blocked (at-least-one-required).
+            await screen.findByText('Select plugins to import');
+            expect(
+              screen.getByText(`0 of ${found.length} selected`),
+              'the pending_selection dialog must default to no plugins selected'
+            ).toBeInTheDocument();
+            expect(
+              screen.getByRole('button', { name: 'Import selected plugins' }),
+              'submission must stay blocked while nothing is selected'
+            ).toBeDisabled();
+
+            // Checking one plugin satisfies the at-least-one rule.
+            fireEvent.click(screen.getAllByRole('checkbox')[0]);
+            expect(
+              screen.getByText(`1 of ${found.length} selected`)
+            ).toBeInTheDocument();
+            expect(
+              screen.getByRole('button', { name: 'Import selected plugins' })
+            ).toBeEnabled();
+
+            // "Select none" re-blocks — the rule keeps holding.
+            fireEvent.click(
+              screen.getByRole('button', { name: 'Select none' })
+            );
+            expect(
+              screen.getByText(`0 of ${found.length} selected`)
+            ).toBeInTheDocument();
+            expect(
+              screen.getByRole('button', { name: 'Import selected plugins' })
+            ).toBeDisabled();
+          } finally {
+            cleanup();
+          }
+        }),
+        { numRuns: 6 }
+      );
+    },
+    120000
+  );
+});

--- a/edge-cv-portal/frontend/src/pages/node-designer/portDefaultsPreservation.property.test.ts
+++ b/edge-cv-portal/frontend/src/pages/node-designer/portDefaultsPreservation.property.test.ts
@@ -1,0 +1,660 @@
+/**
+ * **Feature: workflow-designer-bugfixes, Property 4: Preservation —
+ * Edited rows, advisory guidance, and Port_Scan unchanged**
+ *
+ * _For any_ port rows that are NOT Untouched_Defaults (any rename,
+ * retype, addition, or removal), the wizards SHALL leave the rows
+ * exactly unchanged across any sequence of category changes;
+ * `guidanceDivergence` and `portsStepErrors` SHALL answer identically
+ * to today for all inputs; guidance SHALL remain advisory and
+ * non-blocking, with the dismissable divergence advisory still firing;
+ * and `applySuggestions` SHALL preserve its
+ * replace-over-untouched-defaults / merge-over-edited semantics,
+ * including over today's in/out default pair. Non-input categories
+ * keep presenting their typical arrangements.
+ *
+ * **Validates: Requirements 3.6, 3.7, 3.8, 3.9, 3.10**
+ *
+ * PRESERVATION (workflow-designer-bugfixes task 5): observation-first —
+ * every property below encodes behavior observed on the UNFIXED code,
+ * so the whole file passes before the Bug 2 fix and must keep passing
+ * after it. The generated "user-edited" rows are constrained to rows
+ * that deep-equal NO palette category's default arrangement (the fix
+ * generalizes Untouched_Defaults to the per-category default shapes,
+ * so rows that coincidentally equal another category's defaults are
+ * intentionally excluded — their handling is allowed to change).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import createWrapper from '@cloudscape-design/components/test-utils/dom';
+import * as fc from 'fast-check';
+import { createElement } from 'react';
+import CreateWizard from './CreateWizard';
+import PortGuidancePanel from './PortGuidancePanel';
+import { CATEGORY_ARRANGEMENTS, guidanceDivergence } from './portGuidance';
+import { applySuggestions, isUntouchedDefaults } from './portScan';
+import { portsStepErrors } from './declaration';
+import type { PortForm, WizardForm } from './declaration';
+import type { PortSuggestion } from './portScan';
+import {
+  nonEmptyPortSuggestionsArb,
+  portListArb,
+  portNameArb,
+  portSuggestionsArb,
+  untouchedDefaultInputs,
+  untouchedDefaultOutputs,
+} from './portScanArbitraries';
+import { CATEGORIES, PORT_TYPES } from './types';
+import type { NodeCategory } from './types';
+
+// ------------------------------------------------------------------ mocks
+//
+// Same wiring as CreateWizard.test.tsx / categoryDefaultPorts: the
+// wizard's collaborators are mocked so the steps render with no
+// network access.
+
+const { navigateMock, listUseCases, createScaffoldPlugin } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  listUseCases: vi.fn(),
+  createScaffoldPlugin: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('../../services/api', () => {
+  class ApiError extends Error {
+    constructor(
+      message: string,
+      public readonly status?: number,
+      public readonly code?: string,
+      public readonly details?: Record<string, unknown>
+    ) {
+      super(message);
+      this.name = 'ApiError';
+    }
+  }
+  return { ApiError, apiService: { listUseCases } };
+});
+
+vi.mock('../../contexts/UsecaseContext', () => ({
+  useUsecase: () => ({
+    selectedUsecaseId: 'uc-1',
+    setSelectedUsecaseId: vi.fn(),
+  }),
+}));
+
+vi.mock('./api', () => ({
+  nodeDesignerApi: {
+    createScaffoldPlugin,
+    getGstProperties: vi.fn(),
+    putVersionSource: vi.fn(),
+    startBuilds: vi.fn(),
+  },
+}));
+
+vi.mock('./zip', () => ({
+  downloadZip: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listUseCases.mockResolvedValue({
+    usecases: [{ usecase_id: 'uc-1', name: 'Line A' }],
+  });
+});
+
+// ------------------------------------------- category default shapes
+
+/**
+ * The per-category default port arrangements the fix seeds (design
+ * "defaultPortsForCategory"): one 'in'/'out' row per arrangement side.
+ * Generated "user-edited" rows must deep-equal NONE of these, so the
+ * generalized Untouched_Defaults detection keeps answering false for
+ * them before AND after the fix.
+ */
+const CATEGORY_DEFAULT_SHAPES: { inputs: PortForm[]; outputs: PortForm[] }[] =
+  CATEGORIES.map((category) => {
+    const arrangement = CATEGORY_ARRANGEMENTS[category];
+    return {
+      inputs:
+        arrangement.inputs === 'at-least-one'
+          ? [{ name: 'in', portType: 'VideoFrames' }]
+          : arrangement.inputs.map((portType) => ({ name: 'in', portType })),
+      outputs: arrangement.outputs.map((portType) => ({
+        name: 'out',
+        portType,
+      })),
+    };
+  });
+
+const sameRows = (a: readonly PortForm[], b: readonly PortForm[]) =>
+  a.length === b.length &&
+  a.every(
+    (port, i) => port.name === b[i].name && port.portType === b[i].portType
+  );
+
+const matchesAnyCategoryDefaults = (
+  inputs: readonly PortForm[],
+  outputs: readonly PortForm[]
+) =>
+  CATEGORY_DEFAULT_SHAPES.some(
+    (shape) => sameRows(shape.inputs, inputs) && sameRows(shape.outputs, outputs)
+  );
+
+/** Edited row pairs: any lists that equal no category's defaults. */
+const editedRowsArb: fc.Arbitrary<{
+  inputs: PortForm[];
+  outputs: PortForm[];
+}> = fc
+  .record({ inputs: portListArb, outputs: portListArb })
+  .filter(
+    ({ inputs, outputs }) => !matchesAnyCategoryDefaults(inputs, outputs)
+  );
+
+// --------------------------------------------------------- RTL helpers
+
+/**
+ * Render the create wizard, fill the details step, and walk to the
+ * Ports step (initial category 'preprocessing', rows still defaults).
+ */
+async function openPortsStep(): Promise<HTMLElement> {
+  const { container } = render(createElement(CreateWizard));
+  await waitFor(() => expect(listUseCases).toHaveBeenCalled());
+
+  const nameInput = container.querySelector(
+    'input[placeholder="Blur Regions"]'
+  )!;
+  fireEvent.change(nameInput, { target: { value: 'Node Under Test' } });
+
+  fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+  await screen.findByText('Input ports');
+  return container;
+}
+
+/**
+ * One user edit of the port rows, applied on the Ports step. Every
+ * edit lands on rows that deep-equal NO category's default
+ * arrangement, so the rows are genuinely user-edited under both the
+ * current and the generalized Untouched_Defaults notion.
+ */
+const EDITS = [
+  'rename-input',
+  'rename-output',
+  'add-input',
+  'add-output',
+  'retype-input',
+] as const;
+type Edit = (typeof EDITS)[number];
+
+function applyEdit(container: HTMLElement, edit: Edit): void {
+  const inputNames = () =>
+    container.querySelectorAll('input[placeholder="in"]');
+  const outputNames = () =>
+    container.querySelectorAll('input[placeholder="out"]');
+  switch (edit) {
+    case 'rename-input':
+      fireEvent.change(inputNames()[0], { target: { value: 'video' } });
+      break;
+    case 'rename-output':
+      fireEvent.change(outputNames()[0], { target: { value: 'result' } });
+      break;
+    case 'add-input':
+      fireEvent.click(screen.getByRole('button', { name: 'Add input port' }));
+      fireEvent.change(inputNames()[1], { target: { value: 'aux' } });
+      break;
+    case 'add-output':
+      fireEvent.click(screen.getByRole('button', { name: 'Add output port' }));
+      fireEvent.change(outputNames()[1], { target: { value: 'extra' } });
+      break;
+    case 'retype-input': {
+      // Ports-step selects are the port-type selects in DOM order
+      // (input rows first); retype input row 0.
+      const typeSelect = createWrapper(container).findAllSelects()[0];
+      typeSelect.openDropdown();
+      typeSelect.selectOptionByValue('EventSignal');
+      break;
+    }
+  }
+}
+
+/** Read the presented port rows back out of the Ports step DOM. */
+function readRows(container: HTMLElement): {
+  inputs: PortForm[];
+  outputs: PortForm[];
+} {
+  const inputNames = Array.from(
+    container.querySelectorAll('input[placeholder="in"]')
+  ).map((el) => (el as HTMLInputElement).value);
+  const outputNames = Array.from(
+    container.querySelectorAll('input[placeholder="out"]')
+  ).map((el) => (el as HTMLInputElement).value);
+
+  const types = createWrapper(container)
+    .findAllSelects()
+    .map((select) => {
+      const text = select.findTrigger().getElement().textContent ?? '';
+      return (
+        PORT_TYPES.find((portType) => text.includes(portType)) ?? text.trim()
+      );
+    });
+
+  return {
+    inputs: inputNames.map((name, i) => ({ name, portType: types[i] })),
+    outputs: outputNames.map((name, i) => ({
+      name,
+      portType: types[inputNames.length + i],
+    })),
+  };
+}
+
+// ----------------------------------------------------- pure-fn oracles
+
+/** Order-insensitive multiset equality of port-type lists. */
+const multisetEquals = (
+  expected: readonly string[],
+  actual: readonly string[]
+) =>
+  expected.length === actual.length &&
+  [...expected].sort().every((value, i) => value === [...actual].sort()[i]);
+
+/**
+ * Independent re-statement of today's divergence rule: each side
+ * diverges unless its port-type multiset matches the arrangement
+ * ('at-least-one' diverges only when empty); both matching → null.
+ */
+function oracleDivergence(
+  category: string,
+  inputs: readonly PortForm[],
+  outputs: readonly PortForm[]
+): { inputs: boolean; outputs: boolean } | null {
+  if (!(CATEGORIES as readonly string[]).includes(category)) {
+    return null;
+  }
+  const arrangement = CATEGORY_ARRANGEMENTS[category as NodeCategory];
+  const inputsDiverge =
+    arrangement.inputs === 'at-least-one'
+      ? inputs.length === 0
+      : !multisetEquals(
+          arrangement.inputs,
+          inputs.map((port) => port.portType)
+        );
+  const outputsDiverge = !multisetEquals(
+    arrangement.outputs,
+    outputs.map((port) => port.portType)
+  );
+  return inputsDiverge || outputsDiverge
+    ? { inputs: inputsDiverge, outputs: outputsDiverge }
+    : null;
+}
+
+/** Today's portsStepErrors: one message per blank-named port, in order. */
+const oraclePortErrors = (
+  inputs: readonly PortForm[],
+  outputs: readonly PortForm[]
+) =>
+  [...inputs, ...outputs].flatMap((port, index) =>
+    port.name.trim() ? [] : [`Port ${index + 1} needs a name.`]
+  );
+
+const formWith = (
+  category: string,
+  inputs: PortForm[],
+  outputs: PortForm[]
+): WizardForm => ({
+  name: 'Node Under Test',
+  description: '',
+  category,
+  inputs,
+  outputs,
+  parameters: [],
+  architectures: ['x86_64'],
+});
+
+/** Port rows whose names may be blank (portsStepErrors inputs). */
+const loosePortListArb: fc.Arbitrary<PortForm[]> = fc.array(
+  fc.record({
+    name: fc.oneof(fc.constantFrom('', ' ', '\t'), portNameArb),
+    portType: fc.constantFrom<string>(...PORT_TYPES),
+  }),
+  { maxLength: 5 }
+);
+
+const categoryArb = fc.constantFrom<string>(...CATEGORIES);
+
+// ------------------------------------------------------------ properties
+
+describe('Property 4: Preservation — edited rows, advisory guidance, and Port_Scan unchanged', () => {
+  it(
+    'leaves user-edited port rows exactly unchanged across any sequence ' +
+      'of category changes (3.6)',
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.constantFrom(...EDITS),
+          fc.array(fc.constantFrom(...CATEGORIES), {
+            minLength: 1,
+            maxLength: 3,
+          }),
+          async (edit, categorySequence) => {
+            try {
+              const container = await openPortsStep();
+              applyEdit(container, edit);
+              const edited = readRows(container);
+
+              // The edit produced genuinely user-edited rows: they
+              // deep-equal no category's default arrangement.
+              expect(
+                matchesAnyCategoryDefaults(edited.inputs, edited.outputs)
+              ).toBe(false);
+
+              // Walk back to the details step and change the palette
+              // category through the generated sequence.
+              fireEvent.click(
+                screen.getByRole('button', { name: 'Previous' })
+              );
+              await screen.findByText('Palette category');
+              for (const category of categorySequence) {
+                const categorySelect =
+                  createWrapper(container).findAllSelects()[1];
+                categorySelect.openDropdown();
+                categorySelect.selectOptionByValue(category);
+              }
+
+              // Return to the Ports step: the edited rows survive the
+              // category changes byte-for-byte (3.6).
+              fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+              await screen.findByText('Input ports');
+              expect(readRows(container)).toEqual(edited);
+            } finally {
+              cleanup();
+            }
+          }
+        ),
+        { numRuns: 8 }
+      );
+    },
+    180000
+  );
+
+  it('guidanceDivergence answers identically to today for any category and rows (3.8, 3.9)', () => {
+    fc.assert(
+      fc.property(
+        categoryArb,
+        portListArb,
+        portListArb,
+        (category, inputs, outputs) => {
+          // The divergence rule is exactly today's multiset comparison:
+          // the advisory keeps firing for diverging declarations and
+          // stays silent for matching ones.
+          expect(guidanceDivergence(category, inputs, outputs)).toEqual(
+            oracleDivergence(category, inputs, outputs)
+          );
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+
+  it('guidanceDivergence stays null for unknown categories', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom('', 'unknown', 'Input', 'sink'),
+        portListArb,
+        portListArb,
+        (category, inputs, outputs) => {
+          expect(guidanceDivergence(category, inputs, outputs)).toBeNull();
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+
+  it(
+    'portsStepErrors answers identically to today and never gates on ' +
+      'guidance divergence (3.8)',
+    () => {
+      fc.assert(
+        fc.property(
+          categoryArb,
+          loosePortListArb,
+          loosePortListArb,
+          (category, inputs, outputs) => {
+            const form = formWith(category, inputs, outputs);
+            const errors = portsStepErrors(form);
+
+            // Exactly today's blank-name messages, in row order.
+            expect(errors).toEqual(oraclePortErrors(inputs, outputs));
+
+            // Guidance is advisory and non-blocking: when every row is
+            // named, the step is clean even for declarations diverging
+            // from the category's arrangement (any valid arrangement is
+            // accepted).
+            const allNamed = [...inputs, ...outputs].every((port) =>
+              port.name.trim()
+            );
+            if (allNamed) {
+              expect(errors).toEqual([]);
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    }
+  );
+
+  it(
+    'the dismissable divergence advisory keeps firing exactly when the ' +
+      'declaration diverges, and dismissing never blocks (3.8, 3.9)',
+    () => {
+      fc.assert(
+        fc.property(
+          categoryArb,
+          portListArb,
+          portListArb,
+          (category, inputs, outputs) => {
+            try {
+              render(
+                createElement(PortGuidancePanel, {
+                  category,
+                  inputs,
+                  outputs,
+                })
+              );
+              const alert = screen.queryByTestId(
+                'port-guidance-divergence-alert'
+              );
+              const divergence = guidanceDivergence(
+                category,
+                inputs,
+                outputs
+              );
+
+              if (divergence === null) {
+                expect(alert).toBeNull();
+              } else {
+                // The advisory fires, states it is only guidance, and
+                // dismisses away without removing the panel content.
+                expect(alert).not.toBeNull();
+                expect(alert!.textContent).toContain('This is only guidance');
+                fireEvent.click(within(alert!).getByRole('button'));
+                expect(
+                  screen.queryByTestId('port-guidance-divergence-alert')
+                ).toBeNull();
+                expect(
+                  screen.queryByTestId('port-guidance-arrangement')
+                ).not.toBeNull();
+              }
+            } finally {
+              cleanup();
+            }
+          }
+        ),
+        { numRuns: 25 }
+      );
+    }
+  );
+
+  it(
+    "non-input categories keep presenting their typical arrangements' " +
+      'expected input and output ports (3.7)',
+    () => {
+      fc.assert(
+        fc.property(
+          fc.constantFrom<NodeCategory>(
+            'preprocessing',
+            'inference',
+            'post_processing',
+            'output'
+          ),
+          (category) => {
+            try {
+              render(
+                createElement(PortGuidancePanel, {
+                  category,
+                  inputs: [],
+                  outputs: [],
+                })
+              );
+              // The arrangement box presents the category's expected
+              // input and output ports per its typical arrangement.
+              expect(
+                screen.getByTestId('port-guidance-arrangement').textContent
+              ).toBe(CATEGORY_ARRANGEMENTS[category].summary);
+            } finally {
+              cleanup();
+            }
+          }
+        ),
+        { numRuns: 8 }
+      );
+    }
+  );
+
+  it(
+    "applySuggestions keeps replacing today's untouched in/out default " +
+      'pair wholesale with the suggestions (3.10)',
+    () => {
+      fc.assert(
+        fc.property(nonEmptyPortSuggestionsArb, (suggestions) => {
+          const inputs = untouchedDefaultInputs();
+          const outputs = untouchedDefaultOutputs();
+
+          // Today's in/out default pair keeps counting as untouched.
+          expect(isUntouchedDefaults(inputs, outputs)).toBe(true);
+
+          const result = applySuggestions(
+            inputs,
+            outputs,
+            suggestions,
+            isUntouchedDefaults(inputs, outputs)
+          );
+
+          // Replacement: each side is exactly the suggestions of that
+          // direction, in order; nothing lands in alreadyDeclared.
+          expect(result.inputs).toEqual(
+            suggestions
+              .filter((s) => s.direction === 'input')
+              .map((s) => ({ name: s.name, portType: s.portType }))
+          );
+          expect(result.outputs).toEqual(
+            suggestions
+              .filter((s) => s.direction === 'output')
+              .map((s) => ({ name: s.name, portType: s.portType }))
+          );
+          expect(result.applied).toEqual(suggestions.map((s) => s.name));
+          expect(result.alreadyDeclared).toEqual([]);
+          expect(result.unconfirmed).toEqual(
+            suggestions.filter((s) => !s.confident).map((s) => s.name)
+          );
+        }),
+        { numRuns: 100 }
+      );
+    }
+  );
+
+  it(
+    'applySuggestions keeps merging additively over user-edited rows: ' +
+      'edits win, only the genuinely new names are appended (3.10)',
+    () => {
+      fc.assert(
+        fc.property(
+          editedRowsArb,
+          portSuggestionsArb,
+          ({ inputs, outputs }, suggestions) => {
+            const inputsBefore = inputs.map((port) => ({ ...port }));
+            const outputsBefore = outputs.map((port) => ({ ...port }));
+
+            // Genuinely user-edited rows keep counting as touched.
+            expect(isUntouchedDefaults(inputs, outputs)).toBe(false);
+
+            const result = applySuggestions(
+              inputs,
+              outputs,
+              suggestions,
+              isUntouchedDefaults(inputs, outputs)
+            );
+
+            // Every existing port stays unchanged and in place: the
+            // originals form the exact prefix of each merged side.
+            expect(result.inputs.slice(0, inputs.length)).toEqual(
+              inputsBefore
+            );
+            expect(result.outputs.slice(0, outputs.length)).toEqual(
+              outputsBefore
+            );
+
+            // Trimmed-name collisions are reported already declared;
+            // everything else is appended to its side in suggestion
+            // order and reported applied.
+            const declared = new Set(
+              [...inputsBefore, ...outputsBefore].map((port) =>
+                port.name.trim()
+              )
+            );
+            const colliding: PortSuggestion[] = [];
+            const fresh: PortSuggestion[] = [];
+            for (const suggestion of suggestions) {
+              const trimmed = suggestion.name.trim();
+              if (declared.has(trimmed)) {
+                colliding.push(suggestion);
+              } else {
+                declared.add(trimmed);
+                fresh.push(suggestion);
+              }
+            }
+            expect(result.alreadyDeclared).toEqual(
+              colliding.map((s) => s.name.trim())
+            );
+            expect(result.inputs.slice(inputs.length)).toEqual(
+              fresh
+                .filter((s) => s.direction === 'input')
+                .map((s) => ({ name: s.name, portType: s.portType }))
+            );
+            expect(result.outputs.slice(outputs.length)).toEqual(
+              fresh
+                .filter((s) => s.direction === 'output')
+                .map((s) => ({ name: s.name, portType: s.portType }))
+            );
+            expect(result.applied).toEqual(fresh.map((s) => s.name));
+
+            // An empty suggestion list leaves the lists identical.
+            if (suggestions.length === 0) {
+              expect(result.inputs).toEqual(inputsBefore);
+              expect(result.outputs).toEqual(outputsBefore);
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    }
+  );
+});

--- a/edge-cv-portal/frontend/src/pages/node-designer/portGuidance.ts
+++ b/edge-cv-portal/frontend/src/pages/node-designer/portGuidance.ts
@@ -118,6 +118,40 @@ export const CATEGORY_ARRANGEMENTS: Record<NodeCategory, CategoryArrangement> =
     },
   };
 
+/** One side of the per-kind requirements line (e.g. "1 × VideoFrames"). */
+function sideRequirement(arrangement: PortType[] | 'at-least-one'): string {
+  if (arrangement === 'at-least-one') {
+    return 'at least one (any port type)';
+  }
+  if (arrangement.length === 0) {
+    return 'none';
+  }
+  const counts = new Map<PortType, number>();
+  for (const portType of arrangement) {
+    counts.set(portType, (counts.get(portType) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([portType, count]) => `${count} × ${portType}`)
+    .join(', ');
+}
+
+/**
+ * Explicit per-kind input/output requirements statement for one
+ * palette category (workflow-designer-bugfixes Bug 2, Requirement
+ * 2.6), derived from CATEGORY_ARRANGEMENTS: e.g. input →
+ * "Inputs: none · Outputs: 1 × VideoFrames"; output →
+ * "Inputs: at least one (any port type) · Outputs: none". An unknown
+ * category has no arrangement, so it answers null. Pure and
+ * deterministic; purely advisory — never contributes to step gating.
+ */
+export function arrangementRequirements(category: string): string | null {
+  if (!Object.prototype.hasOwnProperty.call(CATEGORY_ARRANGEMENTS, category)) {
+    return null;
+  }
+  const arrangement = CATEGORY_ARRANGEMENTS[category as NodeCategory];
+  return `Inputs: ${sideRequirement(arrangement.inputs)} · Outputs: ${sideRequirement(arrangement.outputs)}`;
+}
+
 // ----------------------------------------------------------- divergence
 
 /** The port shape the divergence rule needs; `PortForm` satisfies it. */

--- a/edge-cv-portal/frontend/src/pages/node-designer/portScan.test.ts
+++ b/edge-cv-portal/frontend/src/pages/node-designer/portScan.test.ts
@@ -88,10 +88,23 @@ describe('isUntouchedDefaults (6.1)', () => {
     ).toBe(false);
   });
 
-  it('rejects a removed row on either side', () => {
-    expect(isUntouchedDefaults([], untouchedDefaultOutputs())).toBe(false);
-    expect(isUntouchedDefaults(untouchedDefaultInputs(), [])).toBe(false);
-  });
+  it(
+    "treats a removal landing on another category's defaults as untouched " +
+      '(generalized detection, workflow-designer-bugfixes Bug 2)',
+    () => {
+      // Untouched_Defaults is generalized to the default arrangement of
+      // any palette category (isDefaultPortArrangement): no inputs + one
+      // VideoFrames "out" equals the input category's defaults, and one
+      // VideoFrames "in" + no outputs equals the output category's —
+      // both count as untouched so Port_Scan's replace-over-defaults
+      // semantics stay coherent with the category-driven seeding.
+      expect(isUntouchedDefaults([], untouchedDefaultOutputs())).toBe(true);
+      expect(isUntouchedDefaults(untouchedDefaultInputs(), [])).toBe(true);
+
+      // A removal landing on no category's defaults stays user-edited.
+      expect(isUntouchedDefaults([], [])).toBe(false);
+    }
+  );
 });
 
 describe('removalBlockReason (6.9)', () => {

--- a/edge-cv-portal/frontend/src/pages/node-designer/portScan.ts
+++ b/edge-cv-portal/frontend/src/pages/node-designer/portScan.ts
@@ -12,6 +12,7 @@
  * selection reuses `pickElement` from `scan.ts` unchanged so the
  * Port_Scan and Parameter_Scan always agree on the factory (6.6).
  */
+import { isDefaultPortArrangement } from './declaration';
 import type { PortForm } from './declaration';
 
 /**
@@ -56,22 +57,18 @@ export interface UnmappedPad {
 
 /**
  * Untouched_Defaults detection (6.1): exactly the wizard-supplied
- * initial lists — one input named "in" and one output named "out",
- * both VideoFrames. Any rename, retype, addition, or removal makes
- * the lists user-edited.
+ * initial lists. The wizards seed the default rows from the selected
+ * palette category (defaultPortsForCategory,
+ * workflow-designer-bugfixes Bug 2), so "untouched" is generalized to
+ * the default arrangement of any category — today's in/out pair equals
+ * the preprocessing defaults and keeps counting as untouched. Any
+ * rename, retype, addition, or removal makes the lists user-edited.
  */
 export function isUntouchedDefaults(
   inputs: PortForm[],
   outputs: PortForm[]
 ): boolean {
-  return (
-    inputs.length === 1 &&
-    outputs.length === 1 &&
-    inputs[0].name === 'in' &&
-    inputs[0].portType === 'VideoFrames' &&
-    outputs[0].name === 'out' &&
-    outputs[0].portType === 'VideoFrames'
-  );
+  return isDefaultPortArrangement(inputs, outputs);
 }
 
 /** The result of applying Port_Suggestions to the port lists. */

--- a/edge-cv-portal/frontend/src/pages/workflows/NodeConfigPanel.test.tsx
+++ b/edge-cv-portal/frontend/src/pages/workflows/NodeConfigPanel.test.tsx
@@ -1008,4 +1008,263 @@ describe('NodeConfigPanel', () => {
       });
     });
   });
+
+  // ------------------------------------------------------------------------
+  // Aravis camera reference control (aravis-camera-input task 6.2,
+  // Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 7.4)
+  // ------------------------------------------------------------------------
+
+  describe('Aravis camera reference control (aravis-camera-input)', () => {
+    /** aravis_camera_source with only the camera_id parameter, so the
+     * picker's two selects (reference device + camera) are the only
+     * selects rendered. */
+    const ARAVIS: NodeTypeDescriptor = {
+      typeId: 'aravis_camera_source',
+      category: 'input',
+      displayName: 'Aravis Camera Source',
+      inputs: [],
+      outputs: [{ name: 'out', portType: 'VideoFrames' }],
+      parameters: [
+        {
+          name: 'camera_id',
+          paramType: 'string',
+          required: true,
+          default: null,
+          constraints: { minLength: 1 },
+        },
+      ],
+      mappings: [],
+      hardwareDependent: true,
+    };
+
+    const DEVICES = [
+      { device_id: 'dev-1', usecase_id: 'uc-1', thing_name: 'edge-thing-1', status: 'HEALTHY' },
+    ];
+
+    /** Two Aravis-compatible sources and two incompatible ones. */
+    const ARAVIS_REGISTRY_CAMERAS: CameraSourceEntry[] = [
+      {
+        camera_source_id: 'arv-3fe9c0d21ab4',
+        name: 'Basler line scan',
+        type: 'AravisDiscovered',
+        params: { cameraId: 'Basler-12345678', serial: '12345678', protocol: 'GigEVision' },
+        origin: 'edge-discovered',
+        sync_status: 'synced',
+        stale: false,
+        absent: false,
+      },
+      {
+        camera_source_id: 'cfg-cam1',
+        name: 'Configured Aravis cam',
+        type: 'Camera',
+        params: { cameraId: 'Aravis-Fake-GV01', gain: 12, exposure: 200000 },
+        origin: 'edge-configured',
+        sync_status: 'synced',
+        stale: true,
+        absent: false,
+      },
+      // Incompatible: V4L2-discovered hardware.
+      {
+        camera_source_id: 'disc-9f',
+        name: 'USB webcam',
+        type: 'V4L2Discovered',
+        params: { devicePath: '/dev/video5' },
+        origin: 'edge-discovered',
+        sync_status: 'synced',
+      },
+      // Incompatible: Camera-type source without a cameraId parameter.
+      {
+        camera_source_id: 'cfg-v4l2',
+        name: 'Path-only camera',
+        type: 'Camera',
+        params: { devicePath: '/dev/video2' },
+        origin: 'edge-configured',
+        sync_status: 'synced',
+      },
+    ];
+
+    beforeEach(() => {
+      listDevices.mockResolvedValue({ devices: DEVICES, count: DEVICES.length });
+      getDeviceCameras.mockResolvedValue({
+        device_id: 'dev-1',
+        state: 'synced',
+        cameras: ARAVIS_REGISTRY_CAMERAS,
+        count: ARAVIS_REGISTRY_CAMERAS.length,
+      });
+    });
+
+    /** Opens the picker's device dropdown and selects dev-1. */
+    async function selectReferenceDevice(container: HTMLElement) {
+      const [deviceSelect, cameraSelect] = createWrapper(container).findAllSelects();
+      await waitFor(() => {
+        deviceSelect.openDropdown();
+        expect(deviceSelect.findDropdown().findOptions()).toHaveLength(1);
+      });
+      deviceSelect.selectOptionByValue('dev-1');
+      await waitFor(() => expect(getDeviceCameras).toHaveBeenCalledWith('dev-1', 'uc-1'));
+      return cameraSelect;
+    }
+
+    it('renders the camera reference control for the camera_id parameter (Requirement 3.1)', () => {
+      const { container } = render(
+        <NodeConfigPanel node={builderNode(ARAVIS)} onParametersChange={vi.fn()} />
+      );
+
+      // The picker's two selects render instead of a plain text input.
+      expect(createWrapper(container).findAllSelects()).toHaveLength(2);
+      expect(container.querySelector('input[aria-label="camera_id"]')).toBeNull();
+      expect(
+        container.querySelector('input[aria-label="Manual entry for camera_id"]')
+      ).not.toBeNull();
+    });
+
+    it('renders unrelated Aravis parameters as ordinary controls, not the picker (Requirement 3.1)', () => {
+      const withGainExposure: NodeTypeDescriptor = {
+        ...ARAVIS,
+        parameters: [
+          ...ARAVIS.parameters,
+          {
+            name: 'gain',
+            paramType: 'int',
+            required: false,
+            default: 4,
+            constraints: { min: 0, max: 100 },
+          },
+          {
+            name: 'exposure',
+            paramType: 'int',
+            required: false,
+            default: 5000000,
+            constraints: { min: 0 },
+          },
+        ],
+      };
+      const { container } = render(
+        <NodeConfigPanel node={builderNode(withGainExposure)} onParametersChange={vi.fn()} />
+      );
+
+      // Only camera_id gets the reference control: still exactly the
+      // picker's two selects and one manual-entry toggle.
+      expect(createWrapper(container).findAllSelects()).toHaveLength(2);
+      expect(
+        container.querySelectorAll('input[aria-label^="Manual entry for"]')
+      ).toHaveLength(1);
+      // gain/exposure render as plain numeric inputs with their defaults.
+      expect(container.querySelector('input[aria-label="gain"]')).toHaveValue(4);
+      expect(container.querySelector('input[aria-label="exposure"]')).toHaveValue(5000000);
+    });
+
+    describe('Aravis cameraOption display fields (Requirements 3.5, 7.4)', () => {
+      it('describes the source by its camera id with name, type, and sync status', () => {
+        const option = cameraOption(ARAVIS_REGISTRY_CAMERAS[0], true);
+        expect(option.value).toBe('arv-3fe9c0d21ab4');
+        expect(option.label).toBe('Basler line scan');
+        // Aravis options describe the source by camera id, not device path.
+        expect(option.description).toBe('Basler-12345678');
+        expect(option.tags).toEqual(['AravisDiscovered', 'synced']);
+        // Fresh sources carry no staleness badge.
+        expect(option.labelTag).toBeUndefined();
+      });
+
+      it('badges stale sources and tags pending sync status', () => {
+        const stalePending = cameraOption(
+          { ...ARAVIS_REGISTRY_CAMERAS[1], sync_status: 'pending' },
+          true
+        );
+        expect(stalePending.labelTag).toBe('Stale');
+        expect(stalePending.tags).toContain('pending');
+        expect(stalePending.description).toBe('Aravis-Fake-GV01');
+      });
+
+      it('falls back to the id for nameless sources and omits the description without a camera id', () => {
+        const bare = cameraOption(
+          { camera_source_id: 'arv-bare', type: 'AravisDiscovered' },
+          true
+        );
+        expect(bare.label).toBe('arv-bare');
+        expect(bare.description).toBeUndefined();
+      });
+    });
+
+    it('offers only Aravis-compatible sources, described by camera id (Requirements 3.2, 3.5)', async () => {
+      const { container } = render(
+        <NodeConfigPanel node={builderNode(ARAVIS)} onParametersChange={vi.fn()} />
+      );
+      await waitFor(() => expect(listDevices).toHaveBeenCalledWith('uc-1'));
+
+      const cameraSelect = await selectReferenceDevice(container);
+      await waitFor(() => {
+        cameraSelect.openDropdown();
+        expect(cameraSelect.findDropdown().findOptions()).toHaveLength(2);
+      });
+
+      const dropdownText = cameraSelect.findDropdown().getElement().textContent!;
+      // Compatible entries show name, type, camera id, and sync status.
+      expect(dropdownText).toContain('Basler line scan');
+      expect(dropdownText).toContain('AravisDiscovered');
+      expect(dropdownText).toContain('Basler-12345678');
+      expect(dropdownText).toContain('synced');
+      expect(dropdownText).toContain('Configured Aravis cam');
+      expect(dropdownText).toContain('Aravis-Fake-GV01');
+      // Incompatible entries are filtered out entirely.
+      expect(dropdownText).not.toContain('USB webcam');
+      expect(dropdownText).not.toContain('Path-only camera');
+      // Staleness badge on the stale compatible source only (Req 7.4/3.5).
+      const options = cameraSelect.findDropdown().findOptions();
+      expect(options[0].getElement().textContent).not.toContain('Stale');
+      expect(options[1].getElement().textContent).toContain('Stale');
+    });
+
+    it('populates camera_id/gain/exposure and records the hint on selection (Requirement 3.3)', async () => {
+      const onParametersChange = vi.fn();
+      const onCameraSelection = vi.fn();
+      const { container } = render(
+        <NodeConfigPanel
+          node={builderNode(ARAVIS)}
+          onParametersChange={onParametersChange}
+          onCameraSelection={onCameraSelection}
+        />
+      );
+      await waitFor(() => expect(listDevices).toHaveBeenCalled());
+
+      const cameraSelect = await selectReferenceDevice(container);
+      await waitFor(() => {
+        cameraSelect.openDropdown();
+        expect(cameraSelect.findDropdown().findOptions()).toHaveLength(2);
+      });
+      cameraSelect.selectOptionByValue('cfg-cam1');
+
+      expect(onCameraSelection).toHaveBeenCalledWith(
+        'aravis_camera_source_1',
+        { camera_id: 'Aravis-Fake-GV01', gain: 12, exposure: 200000 },
+        {
+          cameraSourceId: 'cfg-cam1',
+          cameraName: 'Configured Aravis cam',
+          sourceDeviceId: 'dev-1',
+        }
+      );
+      expect(onParametersChange).not.toHaveBeenCalled();
+    });
+
+    it('retains the manual-entry toggle for a typed camera id (Requirement 3.4)', () => {
+      const onParametersChange = vi.fn();
+      const { container } = render(
+        <NodeConfigPanel node={builderNode(ARAVIS)} onParametersChange={onParametersChange} />
+      );
+
+      const toggle = container.querySelector(
+        'input[aria-label="Manual entry for camera_id"]'
+      )!;
+      fireEvent.click(toggle);
+
+      const input = container.querySelector('input[aria-label="camera_id"]')!;
+      expect(input).toBeInTheDocument();
+      expect(createWrapper(container).findAllSelects()).toHaveLength(0);
+
+      fireEvent.change(input, { target: { value: 'Aravis-Fake-GV02' } });
+      expect(onParametersChange).toHaveBeenCalledWith('aravis_camera_source_1', {
+        camera_id: 'Aravis-Fake-GV02',
+      });
+    });
+  });
 });

--- a/edge-cv-portal/frontend/src/pages/workflows/NodeConfigPanel.test.tsx
+++ b/edge-cv-portal/frontend/src/pages/workflows/NodeConfigPanel.test.tsx
@@ -163,6 +163,20 @@ const CUSTOM_PYTHON: NodeTypeDescriptor = {
   hardwareDependent: false,
 };
 
+const CUSTOM_PYTHON_PREPROCESS: NodeTypeDescriptor = {
+  typeId: 'custom_python_preprocess',
+  category: 'preprocessing',
+  displayName: 'Custom Python (Frames)',
+  inputs: [{ name: 'in', portType: 'VideoFrames' }],
+  outputs: [{ name: 'out', portType: 'VideoFrames' }],
+  parameters: [
+    { name: 'code', paramType: 'code', required: true, default: null, constraints: { minLength: 1 } },
+    { name: 'requirements', paramType: 'string', required: false, default: '', constraints: {} },
+  ],
+  mappings: [],
+  hardwareDependent: false,
+};
+
 function builderNode(
   descriptor: NodeTypeDescriptor,
   parameters: Record<string, JsonValue> = {}
@@ -362,6 +376,31 @@ describe('NodeConfigPanel', () => {
       'custom_python_1',
       expect.objectContaining({ output_port_type: 'InferenceMeta' })
     );
+  });
+
+  it('renders the code editor for the custom_python_preprocess code parameter (custom-python-frames Requirement 7.2)', () => {
+    const onParametersChange = vi.fn();
+    const code = 'def process_frame(frame, metadata):\n    return cv2.GaussianBlur(frame, (5, 5), 0)';
+    const node = builderNode(CUSTOM_PYTHON_PREPROCESS, { code });
+    const { container } = render(
+      <NodeConfigPanel node={node} onParametersChange={onParametersChange} />
+    );
+
+    // Code editor with the current code.
+    const codeEditor = container.querySelector('textarea[aria-label="code"]');
+    expect(codeEditor).toHaveValue(code);
+
+    // Edits propagate through onParametersChange.
+    fireEvent.change(codeEditor!, {
+      target: { value: 'def process_frame(frame, metadata):\n    return None' },
+    });
+    expect(onParametersChange).toHaveBeenCalledWith(
+      'custom_python_preprocess_1',
+      expect.objectContaining({ code: 'def process_frame(frame, metadata):\n    return None' })
+    );
+
+    // Fixed VideoFrames ports: no per-instance port-type pickers.
+    expect(createWrapper(container).findAllSelects()).toHaveLength(0);
   });
 
   describe('mqtt_publish AWS IoT support (dependsOn visibility)', () => {

--- a/edge-cv-portal/frontend/src/pages/workflows/NodeConfigPanel.tsx
+++ b/edge-cv-portal/frontend/src/pages/workflows/NodeConfigPanel.tsx
@@ -55,11 +55,14 @@ import { useUsecase } from '../../contexts/UsecaseContext';
 import type { Device } from '../../types';
 import type { BuilderNode } from './builderGraph';
 import {
+  applyAravisCameraSelection,
   applyCameraSelection,
   cameraDeviceValue,
   cameraDisplayName,
+  cameraIdValue,
   defaultManualEntry,
   getCameraBindingHint,
+  isAravisCompatibleCamera,
   isCameraReferenceParameter,
   type CameraBindingHint,
   type CameraSourceEntry,
@@ -641,8 +644,13 @@ function selectStatus(state: { status: AsyncOptionsState<unknown>['status'] }) {
   return state.status === 'pending' ? ('finished' as const) : state.status;
 }
 
-/** The camera dropdown option for one Camera_Source (Requirement 7.4). */
-export function cameraOption(camera: CameraSourceEntry): SelectProps.Option {
+/**
+ * The camera dropdown option for one Camera_Source (Requirement 7.4).
+ * Aravis options describe the source by its camera id instead of its
+ * device path (aravis-camera-input Requirement 3.5); name, type, sync
+ * status, and the staleness badge render identically for both flavors.
+ */
+export function cameraOption(camera: CameraSourceEntry, aravis = false): SelectProps.Option {
   const tags = [camera.type, camera.sync_status, camera.absent ? 'absent' : null].filter(
     (tag): tag is string => typeof tag === 'string' && tag !== ''
   );
@@ -651,7 +659,7 @@ export function cameraOption(camera: CameraSourceEntry): SelectProps.Option {
     label: cameraDisplayName(camera),
     // Staleness badge on the option label (Requirement 7.4).
     labelTag: camera.stale ? 'Stale' : undefined,
-    description: cameraDeviceValue(camera) ?? undefined,
+    description: (aravis ? cameraIdValue(camera) : cameraDeviceValue(camera)) ?? undefined,
     tags,
   };
 }
@@ -684,6 +692,11 @@ interface CameraReferenceFieldProps {
 function CameraReferenceField(props: CameraReferenceFieldProps) {
   const { typeId, descriptor, parameters, hint, onParametersChange, onCameraSelection } = props;
   const { selectedUsecaseId } = useUsecase();
+  // The aravis_camera_source flavor of the control (aravis-camera-input
+  // Requirements 3.2, 3.3, 3.5): options filtered to Aravis-compatible
+  // sources, described by camera id, applied through
+  // applyAravisCameraSelection. camera_source's path is untouched.
+  const isAravis = typeId === 'aravis_camera_source';
 
   const [manual, setManual] = useState(() =>
     defaultManualEntry(parameters, descriptor.name, descriptor.default, hint)
@@ -815,17 +828,24 @@ function CameraReferenceField(props: CameraReferenceFieldProps) {
     deviceOptions.find((option) => option.value === selectedDeviceId) ??
     (selectedDeviceId !== null ? { value: selectedDeviceId, label: selectedDeviceId } : null);
 
-  const cameraOptions = cameras.items.map(cameraOption);
+  // The Aravis node offers only Aravis-compatible sources (Requirement
+  // 3.2); camera_source keeps the full registry list.
+  const offeredCameras = isAravis
+    ? cameras.items.filter(isAravisCompatibleCamera)
+    : cameras.items;
+  const cameraOptions = offeredCameras.map((camera) => cameraOption(camera, isAravis));
   const selectedCameraOption =
     cameraOptions.find((option) => option.value === selectedCameraId) ?? null;
 
   const onCameraChange = (option: SelectProps.Option) => {
-    const camera = cameras.items.find((entry) => entry.camera_source_id === option.value);
+    const camera = offeredCameras.find((entry) => entry.camera_source_id === option.value);
     if (camera === undefined || selectedDeviceId === null) {
       return;
     }
     setSelectedCameraId(camera.camera_source_id);
-    const result = applyCameraSelection(parameters, camera, selectedDeviceId);
+    const result = isAravis
+      ? applyAravisCameraSelection(parameters, camera, selectedDeviceId)
+      : applyCameraSelection(parameters, camera, selectedDeviceId);
     onCameraSelection(result.parameters, result.hint);
   };
 
@@ -985,8 +1005,10 @@ export default function NodeConfigPanel({
             .filter((parameter) => isParameterVisible(parameter, descriptor.parameters, parameters))
             .map((parameter) =>
               isCameraReferenceParameter(descriptor.typeId, parameter.name) ? (
-                // The camera_source device parameter renders as the camera
-                // reference control (camera-registry-sync Requirement 7.1);
+                // The camera_source device parameter and the
+                // aravis_camera_source camera_id parameter render as the
+                // camera reference control (camera-registry-sync
+                // Requirement 7.1, aravis-camera-input Requirement 3.1);
                 // keyed by node id so switching nodes resets its state.
                 <CameraReferenceField
                   key={`${node.id}:${parameter.name}`}

--- a/edge-cv-portal/frontend/src/pages/workflows/NodePalette.test.tsx
+++ b/edge-cv-portal/frontend/src/pages/workflows/NodePalette.test.tsx
@@ -28,6 +28,7 @@ function descriptor(
 const CATALOG: NodeTypeDescriptor[] = [
   descriptor('camera_source', 'input', 'Camera source'),
   descriptor('crop', 'preprocessing', 'Crop'),
+  descriptor('custom_python_preprocess', 'preprocessing', 'Custom Python (Frames)'),
   descriptor('model_inference', 'inference', 'Model inference'),
   descriptor('inference_filter', 'post_processing', 'Inference filter'),
   descriptor('mqtt_publish', 'output', 'MQTT publish'),
@@ -49,6 +50,14 @@ describe('NodePalette', () => {
     expect(within(inputSection).getByText('Camera source')).toBeInTheDocument();
     const outputSection = screen.getByRole('region', { name: 'Output' });
     expect(within(outputSection).getByText('MQTT publish')).toBeInTheDocument();
+  });
+
+  it('renders the custom_python_preprocess node in the Preprocessing section (custom-python-frames Requirement 7.1)', () => {
+    render(<NodePalette catalog={CATALOG} />);
+    const preprocessingSection = screen.getByRole('region', { name: 'Preprocessing' });
+    expect(within(preprocessingSection).getByText('Custom Python (Frames)')).toBeInTheDocument();
+    // It appears only under Preprocessing, not in any other section.
+    expect(screen.getAllByText('Custom Python (Frames)')).toHaveLength(1);
   });
 
   it('sets the node type id as the drag payload', () => {

--- a/edge-cv-portal/frontend/src/pages/workflows/aravisCameraReference.property.test.ts
+++ b/edge-cv-portal/frontend/src/pages/workflows/aravisCameraReference.property.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Property tests for the Aravis camera picker helpers
+ * (aravis-camera-input tasks 6.3 and 6.4).
+ *
+ * **Feature: aravis-camera-input, Property 7: Aravis picker compatibility filter**
+ *
+ * For any list of Camera_Registry entries, the Aravis picker option
+ * list SHALL contain exactly the entries that are Aravis-compatible
+ * (type `AravisDiscovered`, or type `Camera` carrying a non-empty
+ * camera id parameter) — no incompatible entry offered, no compatible
+ * entry omitted.
+ *
+ * **Validates: Requirements 3.2**
+ *
+ * **Feature: aravis-camera-input, Property 8: Aravis selection populates the node and records the hint**
+ *
+ * For any Aravis-compatible Camera_Source and any prior parameter
+ * record, applying the selection SHALL set `camera_id` to the source's
+ * camera id, copy `gain` and `exposure` exactly when the source's
+ * params carry them as numbers, leave all other parameters untouched,
+ * and produce a binding hint carrying the source id, display name, and
+ * reference device id.
+ *
+ * **Validates: Requirements 3.3**
+ *
+ * The functions under test are the pure `isAravisCompatibleCamera` and
+ * `applyAravisCameraSelection` from `cameraReference.ts` — the filter
+ * feeding the Aravis picker's option list and the single place an
+ * Aravis Camera_Source is applied to an Aravis_Camera_Source_Node's
+ * parameters. Both properties assert against independent oracles that
+ * restate the specified semantics.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import {
+  applyAravisCameraSelection,
+  cameraIdValue,
+  isAravisCompatibleCamera,
+  type CameraSourceEntry,
+} from './cameraReference';
+import type { JsonValue } from './types';
+
+// --------------------------------------------------------------------------
+// Generators
+// --------------------------------------------------------------------------
+
+/** Arbitrary JSON parameter values, including nested arrays/objects. */
+const jsonValueArb: fc.Arbitrary<JsonValue> = fc.oneof(
+  { maxDepth: 2 },
+  fc.string({ unit: 'grapheme' }),
+  fc.double({ noNaN: true }),
+  fc.integer(),
+  fc.boolean(),
+  fc.constant(null),
+  fc.array(fc.oneof(fc.string(), fc.integer(), fc.boolean(), fc.constant(null)), {
+    maxLength: 3,
+  }),
+  fc.dictionary(fc.string({ maxLength: 5 }), fc.oneof(fc.string(), fc.integer()), {
+    maxKeys: 3,
+  })
+);
+
+/** Identifiers: non-empty, unicode allowed. */
+const idArb = fc.string({ unit: 'grapheme', minLength: 1, maxLength: 20 });
+
+/**
+ * The source's params record: `cameraId` either absent or carrying a
+ * value of an arbitrary JSON type (so empty strings and non-string ids
+ * are exercised), gain/exposure numeric or arbitrary, plus extra keys.
+ * The whole record may also be null or absent.
+ */
+const paramsArb: fc.Arbitrary<Record<string, JsonValue> | null | undefined> = fc.oneof(
+  fc.constant(null),
+  fc.constant(undefined),
+  fc
+    .record(
+      {
+        cameraId: fc.oneof(
+          fc.string({ unit: 'grapheme', maxLength: 30 }),
+          jsonValueArb
+        ),
+        gain: fc.oneof(fc.double({ noNaN: true }), fc.integer(), jsonValueArb),
+        exposure: fc.oneof(fc.double({ noNaN: true }), fc.integer(), jsonValueArb),
+      },
+      { requiredKeys: [] }
+    )
+    .chain((known) =>
+      fc
+        .dictionary(fc.string({ minLength: 1, maxLength: 8 }), jsonValueArb, { maxKeys: 3 })
+        .map((extra) => ({ ...extra, ...known }))
+    )
+);
+
+/**
+ * An arbitrary Camera_Registry entry of any type — Aravis-compatible
+ * types, incompatible types (V4L2Discovered, RTSP, CSI), unknown type
+ * strings, and absent/null types — with arbitrary params.
+ */
+const anyCameraArb: fc.Arbitrary<CameraSourceEntry> = fc.record(
+  {
+    camera_source_id: idArb,
+    name: fc.oneof(fc.string({ unit: 'grapheme', maxLength: 20 }), fc.constant(null)),
+    type: fc.oneof(
+      fc.constantFrom('AravisDiscovered', 'Camera', 'V4L2Discovered', 'RTSP', 'CSI', 'ICam'),
+      fc.string({ maxLength: 12 }),
+      fc.constant(null)
+    ),
+    params: paramsArb,
+    origin: fc.constantFrom('edge-configured', 'edge-discovered', 'portal-created'),
+    sync_status: fc.constantFrom('synced', 'pending', 'failed'),
+    stale: fc.boolean(),
+    absent: fc.boolean(),
+  },
+  { requiredKeys: ['camera_source_id'] }
+);
+
+/**
+ * An Aravis-compatible entry: type `AravisDiscovered` (cameraId of any
+ * shape, including absent), or type `Camera` whose params carry a
+ * non-empty string `cameraId`.
+ */
+const compatibleCameraArb: fc.Arbitrary<CameraSourceEntry> = fc.oneof(
+  anyCameraArb.map((camera) => ({ ...camera, type: 'AravisDiscovered' })),
+  fc
+    .tuple(anyCameraArb, fc.string({ unit: 'grapheme', minLength: 1, maxLength: 30 }))
+    .map(([camera, cameraId]) => ({
+      ...camera,
+      type: 'Camera',
+      params: { ...(camera.params ?? {}), cameraId },
+    }))
+);
+
+/** Prior node parameters, sometimes already carrying camera_id/gain/exposure. */
+const priorParametersArb: fc.Arbitrary<Record<string, JsonValue>> = fc
+  .dictionary(fc.string({ minLength: 1, maxLength: 8 }), jsonValueArb, { maxKeys: 4 })
+  .chain((base) =>
+    fc
+      .record(
+        {
+          camera_id: jsonValueArb,
+          gain: jsonValueArb,
+          exposure: jsonValueArb,
+        },
+        { requiredKeys: [] }
+      )
+      .map((known) => ({ ...base, ...known }))
+  );
+
+// --------------------------------------------------------------------------
+// Oracles (restate the specified semantics independently)
+// --------------------------------------------------------------------------
+
+/** Requirement 3.2 compatibility, restated from the acceptance criterion. */
+function compatibleOracle(camera: CameraSourceEntry): boolean {
+  if (camera.type === 'AravisDiscovered') {
+    return true;
+  }
+  if (camera.type !== 'Camera') {
+    return false;
+  }
+  const cameraId = (camera.params ?? {}).cameraId;
+  return typeof cameraId === 'string' && cameraId !== '';
+}
+
+/** The camera id the selection populates, restated (non-empty string). */
+function expectedCameraId(
+  camera: CameraSourceEntry,
+  prior: Record<string, JsonValue>
+): { present: boolean; value?: JsonValue } {
+  const cameraId = (camera.params ?? {}).cameraId;
+  if (typeof cameraId === 'string' && cameraId !== '') {
+    return { present: true, value: cameraId };
+  }
+  // The source carries no camera id: the prior value (or absence) is retained.
+  return Object.prototype.hasOwnProperty.call(prior, 'camera_id')
+    ? { present: true, value: prior.camera_id }
+    : { present: false };
+}
+
+// --------------------------------------------------------------------------
+// Property 7: Aravis picker compatibility filter
+// --------------------------------------------------------------------------
+
+describe('Property 7: Aravis picker compatibility filter', () => {
+  it('offers exactly the Aravis-compatible entries — soundness and completeness', () => {
+    fc.assert(
+      fc.property(fc.array(anyCameraArb, { maxLength: 12 }), (cameras) => {
+        const offered = cameras.filter(isAravisCompatibleCamera);
+
+        // Soundness: every offered entry is compatible per the oracle.
+        for (const camera of offered) {
+          expect(compatibleOracle(camera)).toBe(true);
+        }
+
+        // Completeness: no compatible entry is omitted — the offered
+        // list is exactly the oracle-filtered list, order preserved.
+        expect(offered).toEqual(cameras.filter(compatibleOracle));
+
+        // Per-entry agreement (covers entries the list filter shares).
+        for (const camera of cameras) {
+          expect(isAravisCompatibleCamera(camera)).toBe(compatibleOracle(camera));
+        }
+      }),
+      { numRuns: 100 }
+    );
+  });
+});
+
+// --------------------------------------------------------------------------
+// Property 8: Aravis selection populates the node and records the hint
+// --------------------------------------------------------------------------
+
+describe('Property 8: Aravis selection populates the node and records the hint', () => {
+  it('sets camera_id, copies numeric gain/exposure, leaves the rest untouched, and records the hint', () => {
+    fc.assert(
+      fc.property(
+        priorParametersArb,
+        compatibleCameraArb,
+        idArb,
+        (prior, camera, sourceDeviceId) => {
+          const priorSnapshot = structuredClone(prior);
+          const cameraSnapshot = structuredClone(camera);
+
+          const { parameters, hint } = applyAravisCameraSelection(
+            prior,
+            camera,
+            sourceDeviceId
+          );
+
+          // Purity: neither input is mutated.
+          expect(prior).toEqual(priorSnapshot);
+          expect(camera).toEqual(cameraSnapshot);
+
+          const params = camera.params ?? {};
+
+          // camera_id is set from the source's camera id; a source
+          // without one retains the prior value (or absence).
+          const cameraId = expectedCameraId(camera, priorSnapshot);
+          if (cameraId.present) {
+            expect(parameters.camera_id).toEqual(cameraId.value);
+          } else {
+            expect(Object.prototype.hasOwnProperty.call(parameters, 'camera_id')).toBe(
+              false
+            );
+          }
+          // Sanity: cameraIdValue agrees with the populated value when
+          // the source carries a usable id.
+          if (cameraIdValue(camera) !== null) {
+            expect(parameters.camera_id).toBe(cameraIdValue(camera));
+          }
+
+          // gain/exposure copied exactly when the source's params carry
+          // them as numbers, untouched otherwise.
+          for (const key of ['gain', 'exposure'] as const) {
+            if (typeof params[key] === 'number') {
+              expect(parameters[key]).toBe(params[key]);
+            } else if (Object.prototype.hasOwnProperty.call(priorSnapshot, key)) {
+              expect(parameters[key]).toEqual(priorSnapshot[key]);
+            } else {
+              expect(Object.prototype.hasOwnProperty.call(parameters, key)).toBe(false);
+            }
+          }
+
+          // Every other prior parameter is untouched, and no keys appear
+          // beyond the prior keys plus camera_id/gain/exposure.
+          for (const [key, value] of Object.entries(priorSnapshot)) {
+            if (key === 'camera_id' || key === 'gain' || key === 'exposure') continue;
+            expect(parameters[key]).toEqual(value);
+          }
+          const allowed = new Set([
+            ...Object.keys(priorSnapshot),
+            'camera_id',
+            'gain',
+            'exposure',
+          ]);
+          for (const key of Object.keys(parameters)) {
+            expect(allowed.has(key)).toBe(true);
+          }
+
+          // The hint carries exactly the source id, its display name
+          // (name, falling back to the id), and the reference device id.
+          expect(hint).toEqual({
+            cameraSourceId: camera.camera_source_id,
+            cameraName:
+              typeof camera.name === 'string' && camera.name !== ''
+                ? camera.name
+                : camera.camera_source_id,
+            sourceDeviceId,
+          });
+        }
+      ),
+      { numRuns: 100 }
+    );
+  });
+});

--- a/edge-cv-portal/frontend/src/pages/workflows/cameraReference.test.ts
+++ b/edge-cv-portal/frontend/src/pages/workflows/cameraReference.test.ts
@@ -9,10 +9,13 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  applyAravisCameraSelection,
   applyCameraSelection,
   cameraDeviceValue,
+  cameraIdValue,
   defaultManualEntry,
   getCameraBindingHint,
+  isAravisCompatibleCamera,
   isCameraReferenceParameter,
   type CameraSourceEntry,
 } from './cameraReference';
@@ -35,6 +38,13 @@ describe('isCameraReferenceParameter', () => {
     expect(isCameraReferenceParameter('camera_source', 'device')).toBe(true);
     expect(isCameraReferenceParameter('camera_source', 'gain')).toBe(false);
     expect(isCameraReferenceParameter('folder_source', 'device')).toBe(false);
+  });
+
+  it('matches the aravis_camera_source camera_id parameter (Requirement 3.1)', () => {
+    expect(isCameraReferenceParameter('aravis_camera_source', 'camera_id')).toBe(true);
+    expect(isCameraReferenceParameter('aravis_camera_source', 'gain')).toBe(false);
+    expect(isCameraReferenceParameter('aravis_camera_source', 'device')).toBe(false);
+    expect(isCameraReferenceParameter('camera_source', 'camera_id')).toBe(false);
   });
 });
 
@@ -82,6 +92,107 @@ describe('applyCameraSelection (Requirement 7.2)', () => {
     const input = { device: '/dev/video0' };
     applyCameraSelection(input, CAMERA, 'edge-device-1');
     expect(input).toEqual({ device: '/dev/video0' });
+  });
+});
+
+const ARAVIS_DISCOVERED: CameraSourceEntry = {
+  camera_source_id: 'arv-1a2b3c4d5e6f',
+  name: 'Basler acA1920',
+  type: 'AravisDiscovered',
+  params: { cameraId: 'Basler-40123456', serial: '40123456', protocol: 'GigEVision' },
+  origin: 'edge-discovered',
+  sync_status: 'synced',
+};
+
+describe('isAravisCompatibleCamera (Requirement 3.2)', () => {
+  it('accepts AravisDiscovered entries and Camera entries with a cameraId', () => {
+    expect(isAravisCompatibleCamera(ARAVIS_DISCOVERED)).toBe(true);
+    // The configured CAMERA fixture carries params.cameraId: 'cam-1'.
+    expect(isAravisCompatibleCamera(CAMERA)).toBe(true);
+    // AravisDiscovered is compatible even without params.
+    expect(
+      isAravisCompatibleCamera({ camera_source_id: 'arv-x', type: 'AravisDiscovered' })
+    ).toBe(true);
+  });
+
+  it('rejects other types and Camera entries without a non-empty cameraId', () => {
+    expect(isAravisCompatibleCamera({ camera_source_id: 'v4l', type: 'V4L2Discovered' })).toBe(
+      false
+    );
+    expect(
+      isAravisCompatibleCamera({ camera_source_id: 'rtsp', type: 'RTSP', params: { url: 'u' } })
+    ).toBe(false);
+    expect(isAravisCompatibleCamera({ camera_source_id: 'c', type: 'Camera' })).toBe(false);
+    expect(
+      isAravisCompatibleCamera({ camera_source_id: 'c', type: 'Camera', params: { cameraId: '' } })
+    ).toBe(false);
+    expect(
+      isAravisCompatibleCamera({ camera_source_id: 'c', type: 'Camera', params: { cameraId: 7 } })
+    ).toBe(false);
+  });
+});
+
+describe('cameraIdValue', () => {
+  it('returns the non-empty string cameraId or null', () => {
+    expect(cameraIdValue(ARAVIS_DISCOVERED)).toBe('Basler-40123456');
+    expect(cameraIdValue(CAMERA)).toBe('cam-1');
+    expect(cameraIdValue({ camera_source_id: 'x' })).toBeNull();
+    expect(cameraIdValue({ camera_source_id: 'x', params: { cameraId: '' } })).toBeNull();
+    expect(cameraIdValue({ camera_source_id: 'x', params: { cameraId: 42 } })).toBeNull();
+  });
+});
+
+describe('applyAravisCameraSelection (Requirement 3.3)', () => {
+  it('populates camera_id, gain, and exposure and records the hint', () => {
+    const source: CameraSourceEntry = {
+      ...ARAVIS_DISCOVERED,
+      params: { cameraId: 'Basler-40123456', gain: 12, exposure: 250000 },
+    };
+    const { parameters, hint } = applyAravisCameraSelection(
+      { camera_id: 'old-cam', mode: 'auto' },
+      source,
+      'edge-device-1'
+    );
+    expect(parameters).toEqual({
+      camera_id: 'Basler-40123456',
+      mode: 'auto',
+      gain: 12,
+      exposure: 250000,
+    });
+    expect(hint).toEqual({
+      cameraSourceId: 'arv-1a2b3c4d5e6f',
+      cameraName: 'Basler acA1920',
+      sourceDeviceId: 'edge-device-1',
+    });
+  });
+
+  it('skips absent or non-numeric gain/exposure and leaves other parameters untouched', () => {
+    const source: CameraSourceEntry = {
+      camera_source_id: 'arv-2',
+      name: '',
+      type: 'AravisDiscovered',
+      params: { cameraId: 'cam-9', gain: 'high' },
+    };
+    const { parameters, hint } = applyAravisCameraSelection(
+      { camera_id: '', gain: 4, custom: true },
+      source,
+      'edge-device-2'
+    );
+    expect(parameters).toEqual({ camera_id: 'cam-9', gain: 4, custom: true });
+    // Nameless sources fall back to the id for the hint's display name.
+    expect(hint.cameraName).toBe('arv-2');
+  });
+
+  it('retains the existing camera_id when the source carries none', () => {
+    const bare: CameraSourceEntry = { camera_source_id: 'arv-3', type: 'AravisDiscovered' };
+    const { parameters } = applyAravisCameraSelection({ camera_id: 'cam-kept' }, bare, 'd');
+    expect(parameters.camera_id).toBe('cam-kept');
+  });
+
+  it('does not mutate the input parameters (pure)', () => {
+    const input = { camera_id: 'cam-old' };
+    applyAravisCameraSelection(input, ARAVIS_DISCOVERED, 'edge-device-1');
+    expect(input).toEqual({ camera_id: 'cam-old' });
   });
 });
 

--- a/edge-cv-portal/frontend/src/pages/workflows/cameraReference.ts
+++ b/edge-cv-portal/frontend/src/pages/workflows/cameraReference.ts
@@ -151,10 +151,15 @@ export function getCameraBindingHint(
 /**
  * Whether a parameter renders as the camera reference control: the
  * `camera_source` node's `device` parameter, keyed off node type +
- * parameter name — no `workflow_core` schema change (Requirement 7.1).
+ * parameter name — no `workflow_core` schema change (Requirement 7.1),
+ * and the `aravis_camera_source` node's `camera_id` parameter
+ * (aravis-camera-input Requirement 3.1).
  */
 export function isCameraReferenceParameter(typeId: string, parameterName: string): boolean {
-  return typeId === 'camera_source' && parameterName === 'device';
+  return (
+    (typeId === 'camera_source' && parameterName === 'device') ||
+    (typeId === 'aravis_camera_source' && parameterName === 'camera_id')
+  );
 }
 
 // --------------------------------------------------------------------------
@@ -210,6 +215,69 @@ export function applyCameraSelection(
   const device = cameraDeviceValue(camera);
   if (device !== null) {
     next.device = device;
+  }
+  const params = camera.params ?? {};
+  if (typeof params.gain === 'number') {
+    next.gain = params.gain;
+  }
+  if (typeof params.exposure === 'number') {
+    next.exposure = params.exposure;
+  }
+  return {
+    parameters: next,
+    hint: {
+      cameraSourceId: camera.camera_source_id,
+      cameraName: cameraDisplayName(camera),
+      sourceDeviceId,
+    },
+  };
+}
+
+// --------------------------------------------------------------------------
+// Aravis picker helpers (aravis-camera-input Requirements 3.2, 3.3)
+// --------------------------------------------------------------------------
+
+/**
+ * Whether a Camera_Source is Aravis-compatible for the
+ * `aravis_camera_source` picker (Requirement 3.2): a discovered bus
+ * camera (type `AravisDiscovered`), or a configured `Camera`-type
+ * Image_Source carrying a non-empty string `cameraId` parameter.
+ */
+export function isAravisCompatibleCamera(camera: CameraSourceEntry): boolean {
+  if (camera.type === 'AravisDiscovered') {
+    return true;
+  }
+  return camera.type === 'Camera' && cameraIdValue(camera) !== null;
+}
+
+/**
+ * The Aravis camera id a Camera_Source resolves to (`params.cameraId`
+ * as a non-empty string), or null when the source carries none
+ * (Requirement 3.3 population and 3.5 display).
+ */
+export function cameraIdValue(camera: CameraSourceEntry): string | null {
+  const cameraId = (camera.params ?? {}).cameraId;
+  return typeof cameraId === 'string' && cameraId !== '' ? cameraId : null;
+}
+
+/**
+ * Apply an Aravis_Camera_Source selection to an Aravis_Camera_Source_Node's
+ * parameters (Requirement 3.3): populates `camera_id` from the source's
+ * camera id parameter (existing value retained when the source carries
+ * none), copies `gain` and `exposure` when numerically present in the
+ * source's params, leaves all other parameters untouched, and produces
+ * the standard advisory binding hint. Pure over its inputs — mirrors
+ * `applyCameraSelection`.
+ */
+export function applyAravisCameraSelection(
+  parameters: Record<string, JsonValue>,
+  camera: CameraSourceEntry,
+  sourceDeviceId: string
+): CameraSelectionResult {
+  const next: Record<string, JsonValue> = { ...parameters };
+  const cameraId = cameraIdValue(camera);
+  if (cameraId !== null) {
+    next.camera_id = cameraId;
   }
   const params = camera.params ?? {};
   if (typeof params.gain === 'number') {

--- a/edge-cv-portal/frontend/src/pages/workflows/connectionAcceptance.property.test.ts
+++ b/edge-cv-portal/frontend/src/pages/workflows/connectionAcceptance.property.test.ts
@@ -113,6 +113,43 @@ const instanceArb: fc.Arbitrary<NodeInstance> = fc.oneof(
   customPythonInstanceArb
 );
 
+/**
+ * A custom_python_preprocess-shaped node: fixed VideoFrames input and
+ * output ports with no per-instance port type override parameters
+ * (custom-python-frames Requirement 1.2), so the declared port types are
+ * always the effective ones.
+ */
+const customPythonPreprocessInstance: NodeInstance = {
+  descriptor: {
+    typeId: 'custom_python_preprocess',
+    category: 'preprocessing',
+    displayName: 'Custom Python (Frames)',
+    inputs: [{ name: 'in', portType: PORT_TYPE_VIDEO_FRAMES }],
+    outputs: [{ name: 'out', portType: PORT_TYPE_VIDEO_FRAMES }],
+    parameters: [
+      { name: 'code', paramType: 'code', required: true },
+      { name: 'requirements', paramType: 'string', required: false },
+    ],
+    mappings: [],
+    hardwareDependent: false,
+  },
+  parameters: {},
+};
+
+/** A source node instance guaranteed to declare at least one output port. */
+const sourceWithOutputArb: fc.Arbitrary<NodeInstance> = fc.oneof(
+  plainInstanceArb.filter((instance) => instance.descriptor.outputs.length > 0),
+  customPythonInstanceArb
+);
+
+/** A source node plus one of its declared output ports as the dragged handle. */
+const fixedPortScenarioArb = sourceWithOutputArb.chain((source) =>
+  fc.record({
+    source: fc.constant(source),
+    sourceHandle: fc.constantFrom(...source.descriptor.outputs.map((port) => port.name)),
+  })
+);
+
 /** Every port name declared on a node type (inputs and outputs). */
 function portNames(descriptor: NodeTypeDescriptor): string[] {
   return [...descriptor.inputs, ...descriptor.outputs].map((port) => port.name);
@@ -187,6 +224,53 @@ describe('Property 10: Connection acceptance equals port compatibility', () => {
           sourceType !== undefined &&
           targetType !== undefined &&
           arePortsCompatible(sourceType, targetType);
+
+        if (expectedAccepted) {
+          expect(reason).toBeNull();
+        } else {
+          expect(typeof reason).toBe('string');
+          expect((reason as string).length).toBeGreaterThan(0);
+        }
+      }),
+      { numRuns: 25 }
+    );
+  });
+});
+
+/**
+ * **Feature: custom-python-frames, Property 11: Designer connection acceptance for fixed VideoFrames ports**
+ *
+ * For any generated pair of nodes where the target is a
+ * `custom_python_preprocess`-shaped descriptor (fixed VideoFrames ports, no
+ * port type override parameters), the Workflow_Builder connection acceptance
+ * function accepts the connection exactly when the source output port type is
+ * compatible with VideoFrames under the declared coercion rules (VideoFrames
+ * exactly, or InferenceMeta via the declared coercion — mirroring the backend
+ * validator per Requirement 2.1) and otherwise rejects it with a reason.
+ *
+ * **Validates: Requirements 7.3**
+ */
+describe('Property 11: Designer connection acceptance for fixed VideoFrames ports', () => {
+  it('accepts a drag onto the fixed VideoFrames input iff the source output port type is compatible with VideoFrames under the declared coercion rules, with a non-empty reason otherwise', () => {
+    fc.assert(
+      fc.property(fixedPortScenarioArb, ({ source, sourceHandle }) => {
+        const sourceNode = builderNode('src', source);
+        const targetNode = builderNode('tgt', customPythonPreprocessInstance);
+        const nodes = [sourceNode, targetNode];
+
+        const reason = connectionRejectionReason(
+          { source: 'src', sourceHandle, target: 'tgt', targetHandle: 'in' },
+          nodes
+        );
+
+        // The effective source output port type (per-instance overrides
+        // applied for custom_python sources; declared type otherwise).
+        const sourceType = resolvedPorts(toWorkflowNode(sourceNode), source.descriptor).outputs[
+          sourceHandle
+        ];
+        const expectedAccepted =
+          sourceType !== undefined &&
+          arePortsCompatible(sourceType, PORT_TYPE_VIDEO_FRAMES);
 
         if (expectedAccepted) {
           expect(reason).toBeNull();

--- a/edge-cv-portal/frontend/src/pages/workflows/inlineChecks.test.ts
+++ b/edge-cv-portal/frontend/src/pages/workflows/inlineChecks.test.ts
@@ -12,6 +12,7 @@ import {
   CATEGORY_INPUT,
   CATEGORY_OUTPUT,
   CATEGORY_POST_PROCESSING,
+  CATEGORY_PREPROCESSING,
   PORT_TYPE_EVENT_SIGNAL,
   PORT_TYPE_INFERENCE_META,
   PORT_TYPE_VIDEO_FRAMES,
@@ -81,7 +82,21 @@ const CUSTOM_PYTHON: NodeTypeDescriptor = {
   hardwareDependent: false,
 };
 
-const CATALOG = [CAMERA, CAPTURE, CUSTOM_PYTHON];
+const CUSTOM_PYTHON_PREPROCESS: NodeTypeDescriptor = {
+  typeId: 'custom_python_preprocess',
+  category: CATEGORY_PREPROCESSING,
+  displayName: 'Custom Python (Frames)',
+  inputs: [{ name: 'in', portType: PORT_TYPE_VIDEO_FRAMES }],
+  outputs: [{ name: 'out', portType: PORT_TYPE_VIDEO_FRAMES }],
+  parameters: [
+    { name: 'code', paramType: 'code', required: true, default: null, constraints: { minLength: 1 } },
+    { name: 'requirements', paramType: 'string', required: false, default: '', constraints: {} },
+  ],
+  mappings: [],
+  hardwareDependent: false,
+};
+
+const CATALOG = [CAMERA, CAPTURE, CUSTOM_PYTHON, CUSTOM_PYTHON_PREPROCESS];
 
 function node(id: string, type: string, parameters: WorkflowNode['parameters'] = {}): WorkflowNode {
   return { id, type, position: { x: 0, y: 0 }, parameters };
@@ -133,6 +148,24 @@ describe('checkV4', () => {
 
   it('skips nodes with unknown types', () => {
     const graph = { nodes: [node('n1', 'not_in_catalog')], connections: [] };
+    expect(checkV4(graph, CATALOG)).toEqual([]);
+  });
+
+  it('reports a required-parameter marker for a custom_python_preprocess node without code (custom-python-frames Requirement 7.4)', () => {
+    const graph = { nodes: [node('n1', 'custom_python_preprocess')], connections: [] };
+    const findings = checkV4(graph, CATALOG);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].code).toBe(CODE_V4_MISSING_REQUIRED_PARAMETER);
+    expect(findings[0].severity).toBe('error');
+    expect(findings[0].nodeId).toBe('n1');
+    expect(findings[0].message).toContain('code');
+  });
+
+  it('reports no marker once the custom_python_preprocess code parameter has a value', () => {
+    const graph = {
+      nodes: [node('n1', 'custom_python_preprocess', { code: 'def process_frame(frame, metadata):\n    return None' })],
+      connections: [],
+    };
     expect(checkV4(graph, CATALOG)).toEqual([]);
   });
 });

--- a/edge-cv-portal/frontend/src/services/api.ts
+++ b/edge-cv-portal/frontend/src/services/api.ts
@@ -1979,11 +1979,12 @@ class ApiService {
       model_id: string;
       region: string;
       max_tokens: number;
-      temperature: number;
-      top_p: number;
+      // null means "unset": the sampling parameter is omitted at invocation.
+      temperature: number | null;
+      top_p: number | null;
       timeout_seconds: number;
     };
-    defaults: Record<string, string | number>;
+    defaults: Record<string, string | number | null>;
     max_timeout_seconds: number;
   }> {
     return this.request('/data-accounts/bedrock-configuration');
@@ -2005,8 +2006,10 @@ class ApiService {
     model_id?: string;
     region?: string;
     max_tokens?: number;
-    temperature?: number;
-    top_p?: number;
+    // An explicit null unsets the sampling parameter (the backend merges
+    // provided keys, so omitting the key keeps the current value).
+    temperature?: number | null;
+    top_p?: number | null;
     timeout_seconds?: number;
   }): Promise<{
     message: string;
@@ -2014,8 +2017,8 @@ class ApiService {
       model_id: string;
       region: string;
       max_tokens: number;
-      temperature: number;
-      top_p: number;
+      temperature: number | null;
+      top_p: number | null;
       timeout_seconds: number;
     };
   }> {

--- a/src/backend/camera_discovery/__init__.py
+++ b/src/backend/camera_discovery/__init__.py
@@ -17,6 +17,12 @@ and the periodic re-enumeration loop with absence tracking.
 Public surface for the camera-registry-sync feature (Requirements 2.1, 2.2,
 2.3, 2.4, 2.6, 11.2).
 """
+from camera_discovery.aravis import (
+    AravisDiscoveryResult,
+    DiscoveredAravisCamera,
+    aravis_stable_id,
+    enumerate_aravis,
+)
 from camera_discovery.discovery import (
     DEFAULT_INTERVAL_SECONDS,
     INTERVAL_CONFIG_KEY,
@@ -32,11 +38,15 @@ from camera_discovery.v4l2 import V4l2Io
 __all__ = [
     "DEFAULT_INTERVAL_SECONDS",
     "INTERVAL_CONFIG_KEY",
+    "AravisDiscoveryResult",
     "CameraDiscovery",
+    "DiscoveredAravisCamera",
     "DiscoveredCamera",
     "DiscoveryResult",
     "InventorySnapshot",
     "TrackedCamera",
     "V4l2Io",
+    "aravis_stable_id",
     "diff_snapshot",
+    "enumerate_aravis",
 ]

--- a/src/backend/camera_discovery/aravis.py
+++ b/src/backend/camera_discovery/aravis.py
@@ -1,0 +1,202 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Aravis (GenICam) enumeration layer for Camera_Discovery.
+
+Feature: aravis-camera-input (Requirements 2.1, 2.3, 2.6, 2.7).
+
+Mirrors the injectable pattern of :mod:`camera_discovery.v4l2`: the
+enumeration source is a zero-argument callable returning the Aravis bus
+cameras, defaulting to a lazy import of
+``edge_ml1_p_camera_management.aravis_functions.getCameras()``. Tests supply
+fake enumerators; the lazy import keeps :mod:`camera_discovery` importable
+on hosts without the ``gi``/Aravis stack (Requirement 2.7).
+
+- :func:`enumerate_aravis` never raises: an import or enumeration failure
+  yields an empty result with a failure record (Requirement 2.6), and a
+  camera with no usable identity fields is recorded in the failures list
+  and skipped rather than crashing the pass (design Error Handling).
+- :func:`aravis_stable_id` is a pure function of the bus-stable GenICam
+  identity fields (vendor, model, serial) so the derived Camera_Source
+  identifier survives reboots and bus re-enumerations; when the serial is
+  empty it falls back to including ``physical_id`` so two serial-less
+  cameras of the same model do not collide (Requirement 2.2).
+"""
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+#: Prefix of every discovered Aravis Camera_Source identifier.
+STABLE_ID_PREFIX = "arv-"
+
+#: The Aravis identity attributes mapped off each enumerated camera object
+#: (the ``model.Camera`` shape ``aravis_functions.getCameras()`` returns).
+_IDENTITY_ATTRIBUTES = (
+    "id",
+    "model",
+    "address",
+    "physical_id",
+    "protocol",
+    "serial",
+    "vendor",
+)
+
+
+@dataclass(frozen=True)
+class DiscoveredAravisCamera:
+    """One enumerated Aravis bus camera (Requirements 2.1, 2.3)."""
+
+    stable_id: str  # arv-{sha1(vendor|model|serial)[:12]}
+    camera_id: str  # the Aravis runtime id camera_manager connects by
+    model: str
+    address: str
+    physical_id: str
+    protocol: str  # e.g. "GigEVision" | "USB3Vision" | "Fake"
+    serial: str
+    vendor: str
+
+
+@dataclass
+class AravisDiscoveryResult:
+    """Outcome of one Aravis enumeration pass.
+
+    ``failures`` entries are ``{"error": ...}`` — an enumeration-level
+    failure (missing runtime, raising enumerator) or a skipped camera with
+    no usable identity. A failure never aborts the pass or raises into the
+    caller (Requirement 2.6).
+    """
+
+    cameras: List[DiscoveredAravisCamera] = field(default_factory=list)
+    failures: List[Dict[str, str]] = field(default_factory=list)
+
+
+def aravis_stable_id(
+    vendor: str, model: str, serial: str, physical_id: str = ""
+) -> str:
+    """Derive the deterministic Camera_Source id for an Aravis identity.
+
+    ``arv-{sha1(vendor|model|serial)[:12]}`` — a pure function of the
+    bus-stable GenICam identity fields, invariant under enumeration order,
+    runtime-id, and address changes (Requirement 2.2). When ``serial`` is
+    empty the key falls back to including ``physical_id`` so serial-less
+    cameras of the same model stay distinct.
+    """
+    vendor = vendor or ""
+    model = model or ""
+    serial = serial or ""
+    physical_id = physical_id or ""
+    if serial:
+        key = "|".join((vendor, model, serial))
+    else:
+        key = "|".join((vendor, model, serial, physical_id))
+    digest = hashlib.sha1(key.encode("utf-8")).hexdigest()
+    return STABLE_ID_PREFIX + digest[:12]
+
+
+def _default_enumerator() -> Sequence[Any]:
+    """Lazy default: the edge application's own bus enumeration.
+
+    Imported at call time (not module import time) so ``camera_discovery``
+    stays importable where the ``gi``/Aravis stack is absent
+    (Requirement 2.7).
+    """
+    from edge_ml1_p_camera_management import aravis_functions
+
+    return aravis_functions.getCameras()
+
+
+def _text(value: Any) -> str:
+    """Coerce an identity attribute to a plain string ('' for None)."""
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _map_camera(raw: Any) -> Optional[DiscoveredAravisCamera]:
+    """Map one enumerated camera object to a DiscoveredAravisCamera.
+
+    Returns ``None`` when the camera carries no usable identity fields —
+    neither a runtime id to connect by nor any bus-stable identity to
+    derive a stable id from (design Error Handling).
+    """
+    fields = {name: _text(getattr(raw, name, None)) for name in _IDENTITY_ATTRIBUTES}
+
+    camera_id = fields["id"]
+    has_stable_identity = any(
+        fields[name] for name in ("vendor", "model", "serial", "physical_id")
+    )
+    if not camera_id or not has_stable_identity:
+        return None
+
+    return DiscoveredAravisCamera(
+        stable_id=aravis_stable_id(
+            fields["vendor"],
+            fields["model"],
+            fields["serial"],
+            fields["physical_id"],
+        ),
+        camera_id=camera_id,
+        model=fields["model"],
+        address=fields["address"],
+        physical_id=fields["physical_id"],
+        protocol=fields["protocol"],
+        serial=fields["serial"],
+        vendor=fields["vendor"],
+    )
+
+
+def enumerate_aravis(
+    enumerator: Optional[Callable[[], Sequence[Any]]] = None,
+) -> AravisDiscoveryResult:
+    """Enumerate the Aravis bus through an injectable enumeration layer.
+
+    ``enumerator`` is a zero-argument callable returning the bus cameras
+    (objects carrying the Aravis identity attributes: ``id``, ``model``,
+    ``address``, ``physical_id``, ``protocol``, ``serial``, ``vendor``);
+    the default lazily imports ``aravis_functions.getCameras()``
+    (Requirements 2.1, 2.7).
+
+    Never raises: an import or enumeration failure yields an empty result
+    with a failure record, and a camera with no usable identity fields is
+    recorded in ``failures`` and skipped (Requirement 2.6).
+    """
+    if enumerator is None:
+        enumerator = _default_enumerator
+
+    try:
+        raw_cameras = enumerator()
+    except Exception as error:  # noqa: BLE001 - isolation per 2.6
+        logger.warning("Aravis enumeration unavailable: %s", error)
+        return AravisDiscoveryResult(failures=[{"error": str(error)}])
+
+    result = AravisDiscoveryResult()
+    for raw in raw_cameras or ():
+        try:
+            camera = _map_camera(raw)
+        except Exception as error:  # noqa: BLE001 - per-camera isolation
+            logger.warning("Failed to map Aravis camera %r: %s", raw, error)
+            result.failures.append({"error": str(error)})
+            continue
+        if camera is None:
+            message = (
+                "Skipped Aravis camera with no usable identity fields: "
+                f"{raw!r}"
+            )
+            logger.warning(message)
+            result.failures.append({"error": message})
+            continue
+        result.cameras.append(camera)
+    return result

--- a/src/backend/camera_discovery/discovery.py
+++ b/src/backend/camera_discovery/discovery.py
@@ -39,9 +39,9 @@ import logging
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 
-from camera_discovery import v4l2
+from camera_discovery import aravis, v4l2
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +184,16 @@ class CameraDiscovery:
     device); when it yields a valid ``CameraDiscoveryIntervalSeconds``
     value, that overrides the ``start()`` interval (Requirement 2.3).
 
+    ``aravis_enumerator`` is an optional zero-argument callable returning
+    the Aravis bus cameras, forwarded to
+    :func:`camera_discovery.aravis.enumerate_aravis` on every periodic
+    pass (``None`` uses that function's default lazy import of
+    ``aravis_functions.getCameras()`` — aravis-camera-input Requirements
+    2.1, 2.7). Aravis stable ids flow through the same tracked-snapshot
+    diff as V4L2 ids: same present/absent semantics, same ``absent_since``
+    timestamps, ``on_change`` only on change, one timer for both families
+    (aravis-camera-input Requirement 2.5).
+
     ``clock`` returns the current time in seconds since the epoch
     (``time.time`` by default); injectable so tests control absence
     timestamps.
@@ -194,9 +204,11 @@ class CameraDiscovery:
         v4l2_io=None,
         config_provider: Optional[Callable[[], Optional[Mapping[str, Any]]]] = None,
         clock: Callable[[], float] = time.time,
+        aravis_enumerator: Optional[Callable[[], Sequence[Any]]] = None,
     ):
         self._io = v4l2_io if v4l2_io is not None else v4l2.V4l2Io()
         self._config_provider = config_provider
+        self._aravis_enumerator = aravis_enumerator
         self._clock = clock
         self._tracked: Dict[str, TrackedCamera] = {}
         self._latest_failures: Tuple[Dict[str, str], ...] = ()
@@ -279,12 +291,26 @@ class CameraDiscovery:
         """Run one enumeration + diff pass, firing ``on_change`` if the
         inventory changed; returns the resulting tracked snapshot.
 
+        Each pass runs the V4L2 enumeration and the Aravis enumeration
+        (aravis-camera-input Requirement 2.1) and diffs the combined
+        result against the tracked inventory in one step — Aravis stable
+        ids get the identical absence semantics, and there is no second
+        timer (aravis-camera-input Requirements 2.5, 2.7). Downstream
+        consumers distinguish the families by the tracked entry's camera
+        object type (:class:`DiscoveredCamera` vs
+        :class:`camera_discovery.aravis.DiscoveredAravisCamera`).
+
         This is the loop body — callable directly by tests (and by callers
         wanting an immediate refresh). Never raises: enumeration failures
-        are already absorbed by :meth:`enumerate`, and an ``on_change``
-        callback error is logged without killing the loop (11.2).
+        are already absorbed by :meth:`enumerate` and
+        :func:`camera_discovery.aravis.enumerate_aravis`, and an
+        ``on_change`` callback error is logged without killing the loop
+        (11.2).
         """
         result = self.enumerate()
+        aravis_result = aravis.enumerate_aravis(self._aravis_enumerator)
+        result.cameras.extend(aravis_result.cameras)
+        result.failures.extend(aravis_result.failures)
         now_ms = int(self._clock() * 1000)
 
         with self._lock:

--- a/src/backend/camera_sync/__init__.py
+++ b/src/backend/camera_sync/__init__.py
@@ -43,6 +43,7 @@ from camera_sync.hooks import (
 from camera_sync.inventory import (
     ORIGIN_EDGE_CONFIGURED,
     ORIGIN_EDGE_DISCOVERED,
+    TYPE_ARAVIS_DISCOVERED,
     TYPE_V4L2_DISCOVERED,
     CameraSourceState,
     build_inventory,
@@ -76,6 +77,7 @@ __all__ = [
     "set_active_agent",
     "ORIGIN_EDGE_CONFIGURED",
     "ORIGIN_EDGE_DISCOVERED",
+    "TYPE_ARAVIS_DISCOVERED",
     "TYPE_V4L2_DISCOVERED",
     "CameraSourceState",
     "build_inventory",

--- a/src/backend/camera_sync/inventory.py
+++ b/src/backend/camera_sync/inventory.py
@@ -28,6 +28,22 @@ Edge_Sync_Agent reports to the Portal:
   never appears both merged into a configured entry and as a separate
   discovered entry.
 
+Aravis branch (feature aravis-camera-input, Requirements 2.1, 2.3, 2.4,
+7.2), structurally parallel to the device-path merge:
+
+- A configured Image_Source of type ``Camera`` whose ``cameraId`` equals a
+  tracked Aravis camera's ``camera_id`` merges into ONE entry under
+  ``cfg-{imageSourceId}``: configured params, ``capabilities.aravis``
+  identity metadata, ``discovered: True``, and the tracked absent state
+  (Requirement 2.4).
+- Unmerged Aravis cameras yield ``AravisDiscovered`` / ``edge-discovered``
+  entries under their ``arv-`` stable ids (Requirements 2.1, 2.3).
+- Families are distinguished by the tracked entry's camera object type
+  (:class:`camera_discovery.aravis.DiscoveredAravisCamera` vs
+  :class:`camera_discovery.DiscoveredCamera`); inputs containing no Aravis
+  cameras produce output identical to the pre-feature merge
+  (Requirement 7.2).
+
 ``build_inventory`` is pure: it accepts plain data (Image_Source model or
 ORM objects — anything attribute- or dict-shaped — and a
 ``DiscoveryResult`` or ``InventorySnapshot``) and returns a deterministic,
@@ -36,12 +52,22 @@ sorted list of :class:`CameraSourceState`.
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
+from camera_discovery.aravis import DiscoveredAravisCamera
+
 ORIGIN_EDGE_CONFIGURED = "edge-configured"
 ORIGIN_EDGE_DISCOVERED = "edge-discovered"
 
 #: Reported ``type`` for discovered-only hardware (design: ImageSourceType
 #: values + "V4L2Discovered").
 TYPE_V4L2_DISCOVERED = "V4L2Discovered"
+
+#: Reported ``type`` for discovered-only Aravis (GenICam) bus cameras
+#: (aravis-camera-input Requirement 2.1).
+TYPE_ARAVIS_DISCOVERED = "AravisDiscovered"
+
+#: The configured Image_Source ``type`` whose ``cameraId`` references an
+#: Aravis camera (merge key for Requirement 2.4).
+_ARAVIS_BACKED_SOURCE_TYPE = "Camera"
 
 
 @dataclass(frozen=True)
@@ -76,16 +102,22 @@ def build_inventory(image_sources, discovery_result) -> List[CameraSourceState]:
     """
     tracked = _normalize_discovery(discovery_result)
 
-    # Discovered cameras indexed by device path; a present camera wins over
-    # an absent one claiming the same path (post-renumbering leftovers).
+    # Discovered V4L2 cameras indexed by device path, and Aravis cameras
+    # indexed by camera id; a present camera wins over an absent one
+    # claiming the same key (post-renumbering leftovers).
     by_path: Dict[str, Tuple[str, Any, bool, Optional[int]]] = {}
+    by_camera_id: Dict[str, Tuple[str, Any, bool, Optional[int]]] = {}
     for stable_id in sorted(tracked):
         camera, absent, absent_since = tracked[stable_id]
-        existing = by_path.get(camera.device_path)
+        if isinstance(camera, DiscoveredAravisCamera):
+            index, key = by_camera_id, camera.camera_id
+        else:
+            index, key = by_path, camera.device_path
+        existing = index.get(key)
         if existing is not None and not existing[2]:
-            continue  # keep the present camera already claiming this path
+            continue  # keep the present camera already claiming this key
         if existing is None or (existing[2] and not absent):
-            by_path[camera.device_path] = (stable_id, camera, absent, absent_since)
+            index[key] = (stable_id, camera, absent, absent_since)
 
     merged_stable_ids = set()
     entries: List[CameraSourceState] = []
@@ -100,41 +132,87 @@ def build_inventory(image_sources, discovery_result) -> List[CameraSourceState]:
             if candidate[0] not in merged_stable_ids:
                 match = candidate
 
+        # Aravis merge by camera id (aravis-camera-input Requirement 2.4):
+        # a configured Camera-type Image_Source whose cameraId equals a
+        # tracked Aravis camera's id merges into this configured entry.
+        aravis_match = None
+        if _source_type(source) == _ARAVIS_BACKED_SOURCE_TYPE:
+            camera_id = _get(source, "cameraId")
+            if camera_id and str(camera_id) in by_camera_id:
+                candidate = by_camera_id[str(camera_id)]
+                if candidate[0] not in merged_stable_ids:
+                    aravis_match = candidate
+
         params = _configured_params(source, device_path)
+        if match is None and aravis_match is None:
+            entries.append(
+                CameraSourceState(
+                    camera_source_id=configured_camera_source_id(image_source_id),
+                    name=_get(source, "name") or "",
+                    type=_source_type(source),
+                    origin=ORIGIN_EDGE_CONFIGURED,
+                    params=params,
+                )
+            )
+            continue
+
+        capabilities: Dict[str, Any] = {}
+        absent = False
+        absent_since: Optional[int] = None
         if match is not None:
             stable_id, camera, absent, absent_since = match
             merged_stable_ids.add(stable_id)
-            entries.append(
-                CameraSourceState(
-                    camera_source_id=configured_camera_source_id(image_source_id),
-                    name=_get(source, "name") or "",
-                    type=_source_type(source),
-                    origin=ORIGIN_EDGE_CONFIGURED,
-                    params=params,
-                    capabilities=_capabilities(camera),
-                    discovered=True,
-                    absent=absent,
-                    absent_since=absent_since,
-                )
+            capabilities = _capabilities(camera)
+        if aravis_match is not None:
+            aravis_stable_id, aravis_camera, aravis_absent, aravis_absent_since = (
+                aravis_match
             )
-        else:
-            entries.append(
-                CameraSourceState(
-                    camera_source_id=configured_camera_source_id(image_source_id),
-                    name=_get(source, "name") or "",
-                    type=_source_type(source),
-                    origin=ORIGIN_EDGE_CONFIGURED,
-                    params=params,
-                )
+            merged_stable_ids.add(aravis_stable_id)
+            capabilities["aravis"] = _aravis_identity(aravis_camera)
+            if match is None:
+                absent = aravis_absent
+                absent_since = aravis_absent_since
+        entries.append(
+            CameraSourceState(
+                camera_source_id=configured_camera_source_id(image_source_id),
+                name=_get(source, "name") or "",
+                type=_source_type(source),
+                origin=ORIGIN_EDGE_CONFIGURED,
+                params=params,
+                capabilities=capabilities,
+                discovered=True,
+                absent=absent,
+                absent_since=absent_since,
             )
+        )
 
     for stable_id in sorted(tracked):
         if stable_id in merged_stable_ids:
             continue
         camera, absent, absent_since = tracked[stable_id]
-        # A camera whose path merged under a different stable id (absent
-        # leftover displaced by a present camera) still reports separately —
-        # its stable id is what bindings reference.
+        # A camera whose merge key merged under a different stable id
+        # (absent leftover displaced by a present camera) still reports
+        # separately — its stable id is what bindings reference.
+        if isinstance(camera, DiscoveredAravisCamera):
+            entries.append(
+                CameraSourceState(
+                    camera_source_id=stable_id,
+                    name=f"{camera.vendor} {camera.model}",
+                    type=TYPE_ARAVIS_DISCOVERED,
+                    origin=ORIGIN_EDGE_DISCOVERED,
+                    params={
+                        "cameraId": camera.camera_id,
+                        "serial": camera.serial,
+                        "protocol": camera.protocol,
+                        "address": camera.address,
+                    },
+                    capabilities={"aravis": _aravis_identity(camera)},
+                    discovered=True,
+                    absent=absent,
+                    absent_since=absent_since,
+                )
+            )
+            continue
         entries.append(
             CameraSourceState(
                 camera_source_id=stable_id,
@@ -229,6 +307,19 @@ def _configured_params(source, device_path: Optional[str]) -> Dict[str, Any]:
         if value is not None:
             params[param_key] = value
     return params
+
+
+def _aravis_identity(camera) -> Dict[str, Any]:
+    """The discovered Aravis identity metadata reported under
+    ``capabilities.aravis`` (aravis-camera-input Requirement 2.3)."""
+    return {
+        "model": camera.model,
+        "address": camera.address,
+        "physicalId": camera.physical_id,
+        "protocol": camera.protocol,
+        "serial": camera.serial,
+        "vendor": camera.vendor,
+    }
 
 
 def _capabilities(camera) -> Dict[str, Any]:

--- a/src/backend/workflow_engine/aravis_feed.py
+++ b/src/backend/workflow_engine/aravis_feed.py
@@ -1,0 +1,168 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Aravis frame feed planning (aravis-camera-input Requirement 6.4).
+
+``plan_aravis_feeds`` is a pure function over a compiled pipeline
+document (the ``compiled_pipeline.json`` shape, optionally carrying the
+packager's ``bindingPoints`` section) and an optional
+:class:`~workflow_engine.camera_binding.ResolutionResult`. For each
+binding point marked ``aravisBinding: true`` it determines the effective
+camera identity the executor's frame feed grabs from:
+
+- the resolution's ``aravis_assignments[node_id]["params"]`` when a
+  binding was resolved for the node (a ``cameraSourceId`` looked up in
+  the local inventory, or a constraint-valid override), else
+- the binding point's rendered ``parameters`` — the compiled-in defaults
+  that run when no binding was supplied.
+
+The effective camera id is read from the ``camera_id`` parameter (the
+node's declared name), accepting the inventory's ``cameraId`` spelling
+too. ``gain`` and ``exposure`` join the feed's config when present —
+they are the acquisition settings ``camera_manager.get_camera_frame``
+applies.
+
+Planning failures follow the executor's contained-failure discipline
+(the :class:`~workflow_engine.python_bridge.CustomPythonNodeError`
+pattern): :class:`AravisFeedError` carries the ``node_id`` so the
+executor can set ``failing_node_id`` directly. A feed whose effective
+camera id is empty or missing fails planning attributed to its node; a
+document with more than one Aravis binding point violates the
+single-appsrc Frame_Feed contract and fails with a reason naming every
+Aravis node (registration-side validation, per the design's error
+handling table).
+
+Documents with no Aravis binding points — including every pre-feature
+document without a ``bindingPoints`` section — plan zero feeds, so the
+executor takes the exact pre-feature call path (Requirement 6.6).
+
+No I/O: the camera manager and pipeline wiring live in the executor.
+"""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional
+
+#: Acquisition parameters forwarded to the camera manager when present.
+_CONFIG_PARAMS = ("gain", "exposure")
+
+#: Accepted spellings of the camera identity parameter: the node
+#: descriptor declares ``camera_id``; the ``build_inventory`` reported
+#: shape (and configured Image_Source params) spell it ``cameraId``.
+_CAMERA_ID_KEYS = ("camera_id", "cameraId")
+
+
+class AravisFeedError(Exception):
+    """An Aravis feed planning failure, identified by its node id.
+
+    ``node_id`` lets the executor set ``failing_node_id`` directly —
+    the failure fails only that workflow run (Requirement 6.5 error
+    discipline). It is ``None`` for document-level failures (the
+    multiple-Aravis-points contract violation) that no single node owns.
+    """
+
+    def __init__(self, node_id: Optional[str], message: str) -> None:
+        self.node_id = node_id
+        super().__init__(
+            "Aravis camera source '{0}': {1}".format(node_id, message)
+            if node_id is not None else message
+        )
+
+
+@dataclass(frozen=True)
+class AravisFeed:
+    """One planned frame grab: the executor calls
+    ``camera_manager.get_camera_frame(camera_id, config)`` and pushes the
+    frame into the appsrc rendered for ``node_id``."""
+
+    node_id: str
+    camera_id: str
+    config: Dict[str, Any] = field(default_factory=dict)
+
+
+def plan_aravis_feeds(document: Dict[str, Any],
+                      resolution) -> List[AravisFeed]:
+    """Plan the Aravis frame feeds for one document. Pure over its
+    inputs.
+
+    ``resolution`` is the watcher's cached
+    :class:`~workflow_engine.camera_binding.ResolutionResult` for the
+    registration, or ``None`` when bindings were never resolved (the
+    provider-fallback / unbound path) — in which case every Aravis point
+    runs on its rendered parameters (Requirement 6.4).
+
+    Raises :class:`AravisFeedError` when a feed has no usable camera id
+    (attributed to the node) or when the document carries more than one
+    Aravis binding point (single Frame_Feed contract).
+    """
+    binding_points = document.get("bindingPoints") if isinstance(document, dict) else None
+    if not binding_points:
+        # Pre-feature documents (no bindingPoints section) and documents
+        # packaged without camera input nodes: zero feeds (6.6).
+        return []
+
+    aravis_points = [point for point in binding_points
+                     if isinstance(point, Mapping)
+                     and point.get("aravisBinding") is True]
+    if not aravis_points:
+        return []
+    if len(aravis_points) > 1:
+        node_ids = ", ".join(
+            "'{0}'".format(point.get("nodeId")) for point in aravis_points)
+        raise AravisFeedError(
+            None,
+            "document declares {0} Aravis camera source binding points "
+            "({1}); the single-frame appsrc feed supports exactly one "
+            "Aravis camera source per workflow".format(
+                len(aravis_points), node_ids))
+
+    point = aravis_points[0]
+    node_id = point.get("nodeId")
+    values = _effective_values(point, node_id, resolution)
+
+    camera_id = _camera_id(values)
+    if camera_id is None:
+        raise AravisFeedError(
+            node_id,
+            "no camera id: neither the resolved binding nor the rendered "
+            "parameters carry a non-empty camera_id")
+
+    config = {name: values[name] for name in _CONFIG_PARAMS
+              if values.get(name) is not None}
+    return [AravisFeed(node_id=node_id, camera_id=camera_id, config=config)]
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+def _effective_values(point: Mapping, node_id,
+                      resolution) -> Dict[str, Any]:
+    """The assignment's params when the resolution carries one for the
+    node, else the binding point's rendered parameters (6.4)."""
+    if resolution is not None:
+        assignments = getattr(resolution, "aravis_assignments", None) or {}
+        assignment = assignments.get(node_id)
+        if isinstance(assignment, Mapping):
+            params = assignment.get("params")
+            if isinstance(params, Mapping):
+                return dict(params)
+    parameters = point.get("parameters")
+    return dict(parameters) if isinstance(parameters, Mapping) else {}
+
+
+def _camera_id(values: Mapping[str, Any]) -> Optional[str]:
+    """The effective camera id: the first non-empty string under an
+    accepted spelling, ``None`` when there is none."""
+    for key in _CAMERA_ID_KEYS:
+        value = values.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None

--- a/src/backend/workflow_engine/camera_binding.py
+++ b/src/backend/workflow_engine/camera_binding.py
@@ -37,6 +37,13 @@ same stable ids the Portal registry shows).
   never substitute into the document — they yield ``adapter_assignments``
   (node id -> resolved camera parameters) consumed by the executor when
   it connects the camera adapter to the appsrc.
+- Aravis binding points (``aravisBinding: true``, empty slots — the
+  aravis-camera-input feature, Requirements 6.1, 6.2, 6.3) likewise never
+  substitute into the document: a resolved ``cameraSourceId`` or
+  constraint-valid ``override`` binding contributes to
+  ``aravis_assignments`` (same shape as ``adapter_assignments``),
+  consumed by the executor's Aravis frame feed. Missing ids and override
+  violations follow the same invalid path as every other binding point.
 - A document without ``bindingPoints`` (every pre-feature component), or
   a registration with no bindings supplied, is returned unchanged — the
   compiled-in parameter values run exactly as before (10.5, 11.1).
@@ -53,8 +60,10 @@ STATUS_INVALID = "invalid"
 
 #: Inventory parameter keys whose values land in a differently named node
 #: parameter: the ``build_inventory`` reported shape calls the V4L2 node
-#: path ``devicePath`` while the camera_source node declares ``device``.
-_PARAM_ALIASES = {"devicePath": "device"}
+#: path ``devicePath`` while the camera_source node declares ``device``,
+#: and the Aravis camera identity ``cameraId`` while the
+#: aravis_camera_source node declares ``camera_id``.
+_PARAM_ALIASES = {"devicePath": "device", "cameraId": "camera_id"}
 
 
 @dataclass(frozen=True)
@@ -66,15 +75,19 @@ class ResolutionResult:
     ``missing`` lists every binding whose ``cameraSourceId`` has no local
     inventory entry (design shape ``{nodeId, cameraSourceId}``),
     ``adapter_assignments`` maps adapter-fed node ids to their resolved
-    camera parameters, and ``errors`` carries one human-readable reason
-    per problem (missing sources and override constraint violations) for
-    the watcher's invalid-registration reason.
+    camera parameters, ``aravis_assignments`` maps Aravis-fed node ids to
+    theirs (same shape, kept distinct so the executor can tell the JP4/5
+    camera adapter apart from the Aravis frame feed), and ``errors``
+    carries one human-readable reason per problem (missing sources and
+    override constraint violations) for the watcher's
+    invalid-registration reason.
     """
 
     document: Dict[str, Any]
     status: str
     missing: Tuple[Dict[str, str], ...] = ()
     adapter_assignments: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    aravis_assignments: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     errors: Tuple[str, ...] = ()
 
 
@@ -99,6 +112,7 @@ def resolve_bindings(document: Dict[str, Any],
     missing: List[Dict[str, str]] = []
     errors: List[str] = []
     adapter_assignments: Dict[str, Dict[str, Any]] = {}
+    aravis_assignments: Dict[str, Dict[str, Any]] = {}
 
     for point in binding_points:
         if not isinstance(point, Mapping):
@@ -133,7 +147,15 @@ def resolve_bindings(document: Dict[str, Any],
             # Unrecognized binding shape: leave the compiled defaults.
             continue
 
-        if point.get("adapterBinding") is True:
+        if point.get("aravisBinding") is True:
+            # Aravis: the executor's frame feed grabs from the camera
+            # manager; the binding selects which camera id it grabs, not
+            # an element arg (aravis-camera-input Requirements 6.1, 6.2).
+            aravis_assignments[node_id] = {
+                "cameraSourceId": camera_source_id,
+                "params": values,
+            }
+        elif point.get("adapterBinding") is True:
             # JP4/JP5: the executor's camera adapter feeds the appsrc; the
             # binding selects which camera it connects, not an element arg.
             adapter_assignments[node_id] = {
@@ -149,6 +171,7 @@ def resolve_bindings(document: Dict[str, Any],
         status=status,
         missing=tuple(missing),
         adapter_assignments=adapter_assignments,
+        aravis_assignments=aravis_assignments,
         errors=tuple(errors),
     )
 

--- a/src/backend/workflow_engine/pipeline_executor.py
+++ b/src/backend/workflow_engine/pipeline_executor.py
@@ -43,10 +43,26 @@ API thread and never on the Pipeline_Configuration path (Requirements
    the document's ``executorBindings`` to the post-run handler — the hook
    task 12.4 (output bindings) plugs into.
 
+Camera_Binding resolution and the Aravis frame feed (aravis-camera-input
+Requirements 6.4, 6.5, 6.6): an injectable ``binding_resolution_provider``
+(wired at engine startup to the watcher's ``binding_resolution()``
+accessor) supplies the registration's resolved Camera_Bindings. When a
+resolution exists the executor runs its slot-substituted document;
+provider absence or failure falls back to the on-disk document, logged,
+never failing a run for documents that don't need bindings. Before the
+pipeline starts, ``plan_aravis_feeds`` plans the document's Aravis frame
+feed; the executor grabs one frame through the camera manager and pushes
+it into the compiled appsrc through the existing
+``run_pipeline(launch_string, frame_data)`` Frame_Feed — the classic
+Camera-type execution model. Planning and grab failures fail the run
+with ``failing_node_id`` set to the Aravis node; documents with no
+Aravis binding points take the exact pre-feature call path.
+
 Any exception anywhere in a run is contained: the execution row is marked
 failed and nothing propagates (Requirement 13.7).
 """
 
+import copy
 import json
 import logging
 import os
@@ -57,6 +73,7 @@ from typing import Callable, Optional
 
 from workflow_engine import executor as executor_hook
 from workflow_engine import python_bridge, rendering
+from workflow_engine.aravis_feed import AravisFeedError, plan_aravis_feeds
 from workflow_engine.output_bindings import BedrockInferenceProcessor
 from workflow_engine.discovery import (
     COMPILED_PIPELINE_FILE,
@@ -106,6 +123,20 @@ def _default_pipeline_manager_factory():
     return GstPipelineManager()
 
 
+def _default_frame_grabber(camera_id, config):
+    """One Aravis frame through the existing Camera_Manager.
+
+    Imported lazily — exactly like ``_default_pipeline_manager_factory``
+    and ``GstPipelineManager`` — so this module (and its tests) stay
+    importable without the ``gi``/Aravis runtime. Uses the cached,
+    persistent connection model ``get_camera_frame`` provides
+    (aravis-camera-input Requirement 6.4).
+    """
+    from utils import camera_manager
+
+    return camera_manager.get_camera_frame(camera_id, config)
+
+
 class WorkflowExecutor:
     """Executes pending workflow runs dispatched by the executor hook."""
 
@@ -116,6 +147,8 @@ class WorkflowExecutor:
         post_run_handler: Optional[PostRunHandler] = None,
         bridged_pipeline_runner: Optional[Callable] = None,
         bedrock_processor: Optional[BedrockInferenceProcessor] = None,
+        binding_resolution_provider: Optional[Callable] = None,
+        frame_grabber: Optional[Callable] = None,
     ) -> None:
         if session_factory is None:
             # Imported lazily so the module is importable without the
@@ -140,6 +173,17 @@ class WorkflowExecutor:
         # merges {is_anomalous, confidence} into the tag values the
         # post-run handler gates on. Injectable for tests without boto3.
         self._bedrock_processor = bedrock_processor or BedrockInferenceProcessor()
+        # Camera_Binding resolution lookup: registration id ->
+        # Optional[ResolutionResult] (the watcher's binding_resolution()
+        # accessor in production). When it returns a resolution the run
+        # executes the resolution's substituted document; None (or a
+        # provider failure, logged) falls back to the on-disk document
+        # (aravis-camera-input Requirement 6.4).
+        self._binding_resolution_provider = binding_resolution_provider
+        # One Aravis frame per planned feed: (camera_id, config) ->
+        # {'data','height','width'}. Injectable for tests without the
+        # gi/Aravis runtime (Requirements 6.4, 6.5).
+        self._frame_grabber = frame_grabber or _default_frame_grabber
 
     def set_post_run_handler(self, handler: Optional[PostRunHandler]) -> None:
         """Register the post-pipeline output-binding processor (task 12.4)."""
@@ -185,6 +229,43 @@ class WorkflowExecutor:
             document, load_error = self._load_compiled_document(registration)
             if load_error is not None:
                 self._finish_failed(session, execution, error=load_error)
+                return
+
+            # Camera_Binding resolution (aravis-camera-input Requirement
+            # 6.4): when the provider carries a resolution for this
+            # registration, the run executes its slot-substituted document
+            # (a private copy — the watcher's cache is never mutated);
+            # otherwise the on-disk document runs exactly as before.
+            resolution = self._binding_resolution(registration)
+            if resolution is not None and isinstance(
+                getattr(resolution, "document", None), dict
+            ):
+                document = copy.deepcopy(resolution.document)
+
+            # Aravis frame feed (Requirements 6.4, 6.5, 6.6): plan the
+            # document's Aravis feed, grab its frame through the camera
+            # manager, and point the compiled appsrc at the Frame_Feed.
+            # Planning and grab failures fail this run with the Aravis
+            # node identified; Aravis-free documents plan zero feeds and
+            # take the exact pre-feature path.
+            try:
+                frame_data = self._prepare_aravis_frame_feed(
+                    document, resolution
+                )
+            except AravisFeedError as e:
+                logger.error(
+                    "Workflow execution %s failed in the Aravis frame feed "
+                    "(node %s): %s",
+                    execution_id,
+                    e.node_id or "unidentified",
+                    e,
+                )
+                self._finish_failed(
+                    session,
+                    execution,
+                    error=str(e),
+                    failing_node_id=e.node_id,
+                )
                 return
 
             # Custom_Python_Node bridges (Requirement 9.8): replace each
@@ -242,6 +323,17 @@ class WorkflowExecutor:
                     if bridge_specs:
                         tag_values = self._run_bridged(
                             registration, bridge_specs, launch_string
+                        )
+                    elif frame_data is not None:
+                        # Aravis Frame_Feed: run_pipeline locates the
+                        # appsrc, wraps the grabbed frame, pushes it and
+                        # sends EOS — the classic Camera-type execution
+                        # model (Requirement 6.4).
+                        manager = self._pipeline_manager_factory()
+                        tag_values = manager.run_pipeline(
+                            launch_string,
+                            frame_data,
+                            latency_metrics=_NullLatencyMetrics(),
                         )
                     else:
                         manager = self._pipeline_manager_factory()
@@ -344,6 +436,109 @@ class WorkflowExecutor:
         finally:
             for bridge in bridges:
                 bridge.stop()
+
+    # ------------------------------------------------------------------
+    # Camera_Binding resolution + Aravis frame feed (aravis-camera-input)
+    # ------------------------------------------------------------------
+
+    def _binding_resolution(self, registration: WorkflowRegistration):
+        """The registration's latest Camera_Binding resolution, or None.
+
+        A provider failure is logged and falls back to the on-disk
+        document — it never takes a run down for documents that don't
+        need bindings (design error-handling table)."""
+        if self._binding_resolution_provider is None:
+            return None
+        try:
+            return self._binding_resolution_provider(registration.id)
+        except Exception:  # noqa: BLE001 - provider isolation
+            logger.exception(
+                "Binding resolution provider failed for %s; running the "
+                "on-disk document",
+                registration.id,
+            )
+            return None
+
+    def _prepare_aravis_frame_feed(self, document: dict, resolution):
+        """Plan the document's Aravis feed, grab its frame, and point the
+        compiled appsrc at the Frame_Feed.
+
+        Returns the grabbed ``{'data','height','width'}`` frame, or None
+        when the document has no Aravis binding points (the pre-feature
+        path, Requirement 6.6). Raises :class:`AravisFeedError` (with the
+        node id) on planning and grab failures (Requirement 6.5).
+        """
+        feeds = plan_aravis_feeds(document, resolution)
+        if not feeds:
+            return None
+        feed = feeds[0]
+        try:
+            frame_data = self._frame_grabber(feed.camera_id, feed.config)
+        except Exception as e:  # noqa: BLE001 - attributed to the node
+            raise AravisFeedError(
+                feed.node_id,
+                "frame grab from Aravis camera '{0}' failed: {1}".format(
+                    feed.camera_id, e
+                ),
+            )
+        if not isinstance(frame_data, dict):
+            raise AravisFeedError(
+                feed.node_id,
+                "Aravis camera '{0}' returned no frame".format(feed.camera_id),
+            )
+        self._point_appsrc_at_frame_feed(document, feed, frame_data)
+        logger.info(
+            "Aravis frame feed planned for node %s: camera '%s' (%dx%d)",
+            feed.node_id,
+            feed.camera_id,
+            frame_data.get("width") or 0,
+            frame_data.get("height") or 0,
+        )
+        return frame_data
+
+    @staticmethod
+    def _point_appsrc_at_frame_feed(document: dict, feed, frame_data: dict) -> None:
+        """Aim ``GstPipelineManager``'s Frame_Feed at the node's appsrc.
+
+        ``run_pipeline`` locates the feed's appsrc by the element name
+        ``appsrc`` and derives its caps from the launch string's ``caps=``
+        clause plus the frame's width/height — exactly the classic
+        Camera-type execution model. The compiled document names the
+        element ``appsrc_{nodeId}`` and renders no caps, so the planned
+        feed's element (unique per the single-Frame_Feed contract) is
+        renamed and given base caps derived from the grabbed frame.
+        """
+        for segment in document.get("segments", []):
+            for element in segment.get("elements", []):
+                if (
+                    element.get("nodeId") == feed.node_id
+                    and element.get("factory") == "appsrc"
+                ):
+                    args = element.setdefault("args", {})
+                    args["name"] = "appsrc"
+                    args["caps"] = WorkflowExecutor._frame_caps(frame_data)
+                    return
+        raise AravisFeedError(
+            feed.node_id,
+            "compiled document renders no appsrc element for the node",
+        )
+
+    @staticmethod
+    def _frame_caps(frame_data: dict) -> str:
+        """Base appsrc caps for a grabbed frame; ``run_pipeline`` appends
+        the frame's width/height. The pixel format is derived from the
+        payload size per pixel (Aravis mono cameras produce GRAY8, color
+        pipelines RGB/RGBA), defaulting to GRAY8."""
+        formats = {1: "GRAY8", 3: "RGB", 4: "RGBA"}
+        width = frame_data.get("width") or 0
+        height = frame_data.get("height") or 0
+        data = frame_data.get("data")
+        pixel_format = "GRAY8"
+        if width and height and data is not None:
+            pixels = width * height
+            if len(data) % pixels == 0:
+                pixel_format = formats.get(len(data) // pixels, "GRAY8")
+        return "video/x-raw,format={0}".format(pixel_format)
 
     #: Placeholder the compiler leaves in bedrock_inference capture
     #: paths for the executor to resolve per run.
@@ -479,6 +674,7 @@ def register_workflow_executor(
     session_factory: Optional[Callable] = None,
     pipeline_manager_factory: Optional[Callable] = None,
     post_run_handler: Optional[PostRunHandler] = None,
+    binding_resolution_provider: Optional[Callable] = None,
 ) -> WorkflowExecutor:
     """Create a WorkflowExecutor and register it as THE executor hook.
 
@@ -489,6 +685,7 @@ def register_workflow_executor(
         session_factory=session_factory,
         pipeline_manager_factory=pipeline_manager_factory,
         post_run_handler=post_run_handler,
+        binding_resolution_provider=binding_resolution_provider,
     )
     executor_hook.set_executor(instance.execute)
     logger.info("WorkflowExecutor registered as the workflow executor")

--- a/src/backend/workflow_engine/python_bridge.py
+++ b/src/backend/workflow_engine/python_bridge.py
@@ -37,8 +37,9 @@ executor manages the bridge itself, exactly as the design prescribes:
   frame bytes. Executor -> handler headers carry ``nodeId``, ``width``,
   ``height``, ``format`` and ``metadata``; handler -> executor headers
   carry ``status`` (``ok``/``error``), ``metadata`` and the transformed
-  frame. The handler contract is ``handle(frame_bytes, metadata) ->
-  (frame_bytes, metadata)``.
+  frame. The handler contract is ``process_frame(frame, metadata)``
+  (NumPy-array based, preferred) or ``handle(frame_bytes, metadata) ->
+  (frame_bytes, metadata)`` (raw bytes).
 - **Failure containment**: non-zero exit, wall-clock timeout, memory
   exhaustion, handler exceptions, and protocol violations all raise
   :class:`CustomPythonNodeError` carrying the ``node_id`` — the executor
@@ -74,7 +75,30 @@ HANDLER_PATH_ARG = "handler-path"
 #: Per-frame wall-clock limit for one handler invocation.
 DEFAULT_WALL_CLOCK_LIMIT_SEC = 10.0
 #: Address-space bound for the handler subprocess (RLIMIT_AS).
+#: RLIMIT_AS limits *virtual* address space, not resident memory.
+#: NumPy's OpenBLAS and OpenCV both spawn one worker thread per CPU at
+#: import/first-use, and each thread's stack reservation counts against
+#: RLIMIT_AS — on many-core hosts the reservations alone exceed any
+#: reasonable cap and ``import numpy`` hangs (it does not fail cleanly).
+#: The bridge therefore caps those pools to one thread via environment
+#: variables (see ``_THREAD_CAP_ENV`` in ``_start_locked``), which was
+#: verified to let numpy + cv2 import and process 4K frames comfortably
+#: within 512 MB. The limit stays configurable per bridge via the
+#: ``memory_limit_bytes`` constructor parameter.
 DEFAULT_MEMORY_LIMIT_BYTES = 512 * 1024 * 1024
+
+#: Thread-pool caps applied to the handler subprocess environment when a
+#: memory limit is in force (values already set by the operator win).
+#: Without these, OpenBLAS (numpy) and OpenCV size their pools to the
+#: host CPU count and the per-thread stack reservations blow through
+#: RLIMIT_AS — OpenBLAS then *hangs* inside ``import numpy`` instead of
+#: failing, stalling the subprocess until the per-frame wall-clock
+#: limit kills it.
+_THREAD_CAP_ENV = {
+    "OPENBLAS_NUM_THREADS": "1",
+    "OMP_NUM_THREADS": "1",
+    "OPENCV_FOR_THREADS_NUM": "1",
+}
 
 #: Protocol sanity bounds — anything past these is a protocol violation.
 MAX_HEADER_BYTES = 1 << 20
@@ -151,21 +175,219 @@ def decode_header(raw: bytes) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Frame_Helpers module source (``dda_frames``), executed inside the handler
+# subprocess. Self-contained on purpose: it must not import LocalServer
+# modules, and it is importable standalone (exec into a fresh module
+# namespace) for direct testing. The runner registers it in ``sys.modules``
+# as ``dda_frames`` before the handler loads, so handlers can
+# ``import dda_frames`` without the node shipping extra artifact files
+# (Requirement 5.1).
+# ---------------------------------------------------------------------------
+
+HELPERS_SOURCE = r'''
+"""dda_frames — frame helpers for Custom Python handlers.
+
+Provides frame/array conversion (``to_array``/``to_bytes``), the
+current frame's caps (``frame_info``), and image loading from local
+disk or S3 (``load_image``). All functions raise ``ValueError`` with a
+descriptive message on bad input.
+"""
+
+#: Supported Pixel_Formats and their channel counts.
+FORMAT_CHANNELS = {"RGB": 3, "BGR": 3, "RGBA": 4, "GRAY8": 1}
+
+_current_frame = None
+_s3_client = None
+
+
+def _set_current(info):
+    """Set (info dict) or clear (None) the per-invocation frame context.
+
+    Called by the runner around each handler invocation; not part of the
+    public handler API.
+    """
+    global _current_frame
+    _current_frame = dict(info) if info is not None else None
+
+
+def frame_info():
+    """``{'width': int, 'height': int, 'format': str}`` for the frame
+    whose handler invocation is in progress; None outside an invocation."""
+    return dict(_current_frame) if _current_frame is not None else None
+
+
+def _require_numpy(what):
+    try:
+        import numpy
+        return numpy
+    except ImportError:
+        raise ValueError(
+            "{0}: NumPy is not importable in the handler "
+            "subprocess".format(what)
+        )
+
+
+def _require_cv2(what):
+    try:
+        import cv2
+        return cv2
+    except ImportError:
+        raise ValueError(
+            "{0}: OpenCV (cv2) is not importable in the handler "
+            "subprocess".format(what)
+        )
+
+
+def to_array(frame_bytes, width, height, format):
+    """Raw frame bytes -> NumPy uint8 array (H x W x C; H x W for GRAY8).
+
+    The row stride is ``len(frame_bytes) // height``; each row's first
+    ``width * channels`` bytes are taken, tolerating row padding in the
+    frame bytes.
+    """
+    np = _require_numpy("to_array")
+    if format not in FORMAT_CHANNELS:
+        raise ValueError(
+            "to_array: unsupported format '{0}' (supported: {1})".format(
+                format, ", ".join(sorted(FORMAT_CHANNELS))
+            )
+        )
+    if not isinstance(width, int) or not isinstance(height, int) \
+            or width <= 0 or height <= 0:
+        raise ValueError(
+            "to_array: invalid dimensions {0!r}x{1!r}".format(width, height)
+        )
+    frame_bytes = bytes(frame_bytes)
+    channels = FORMAT_CHANNELS[format]
+    row_bytes = width * channels
+    stride = len(frame_bytes) // height
+    if stride < row_bytes:
+        raise ValueError(
+            "to_array: frame bytes too short: got {0} bytes for "
+            "{1}x{2} {3}, which needs at least {4} bytes".format(
+                len(frame_bytes), width, height, format, row_bytes * height
+            )
+        )
+    rows = np.frombuffer(
+        frame_bytes[: stride * height], dtype=np.uint8
+    ).reshape(height, stride)[:, :row_bytes]
+    array = rows.copy()
+    if channels == 1:
+        return array.reshape(height, width)
+    return array.reshape(height, width, channels)
+
+
+def to_bytes(array):
+    """NumPy uint8 array -> contiguous raw frame bytes (no padding)."""
+    np = _require_numpy("to_bytes")
+    if not isinstance(array, np.ndarray):
+        raise ValueError(
+            "to_bytes: expected a NumPy array, got {0}".format(
+                type(array).__name__
+            )
+        )
+    if array.dtype != np.uint8:
+        raise ValueError(
+            "to_bytes: expected a uint8 array, got dtype {0}".format(
+                array.dtype
+            )
+        )
+    return np.ascontiguousarray(array).tobytes()
+
+
+def _decode_image(source, data):
+    np = _require_numpy("load_image: '{0}'".format(source))
+    cv2 = _require_cv2("load_image: '{0}'".format(source))
+    buffer = np.frombuffer(data, dtype=np.uint8)
+    image = cv2.imdecode(buffer, cv2.IMREAD_UNCHANGED)
+    if image is not None and image.ndim == 2 and image.dtype == np.uint8:
+        return image  # grayscale sources decode to a 2-D array
+    image = cv2.imdecode(buffer, cv2.IMREAD_COLOR)  # 8-bit BGR
+    if image is None:
+        raise ValueError(
+            "load_image: content of '{0}' could not be decoded as an "
+            "image".format(source)
+        )
+    return image
+
+
+def load_image(source, s3_client=None):
+    """Local path or ``s3://bucket/key`` -> uint8 image array in OpenCV
+    BGR channel order (single-channel images decode to a 2-D array).
+
+    Raises ``ValueError`` naming the source on a missing file, malformed
+    URI, fetch failure, undecodable content, or missing boto3.
+    ``s3_client`` is injectable for tests; by default a lazily created
+    boto3 client using the device's ambient AWS credentials.
+    """
+    source = str(source)
+    if source.startswith("s3://"):
+        remainder = source[len("s3://"):]
+        bucket, _, key = remainder.partition("/")
+        if not bucket or not key:
+            raise ValueError(
+                "load_image: malformed S3 URI '{0}' (expected "
+                "s3://bucket/key)".format(source)
+            )
+        if s3_client is None:
+            try:
+                import boto3
+            except ImportError:
+                raise ValueError(
+                    "load_image: cannot fetch '{0}': boto3 is not "
+                    "installed".format(source)
+                )
+            global _s3_client
+            if _s3_client is None:
+                _s3_client = boto3.client("s3")
+            s3_client = _s3_client
+        try:
+            response = s3_client.get_object(Bucket=bucket, Key=key)
+            data = response["Body"].read()
+        except Exception as e:
+            raise ValueError(
+                "load_image: could not fetch '{0}': {1}".format(source, e)
+            )
+    else:
+        try:
+            with open(source, "rb") as f:
+                data = f.read()
+        except (OSError, ValueError) as e:
+            raise ValueError(
+                "load_image: could not read '{0}': {1}".format(source, e)
+            )
+    return _decode_image(source, data)
+'''
+
+
+# ---------------------------------------------------------------------------
 # Runner script executed inside the subprocess (self-contained on purpose:
 # the subprocess must not depend on LocalServer being importable)
 # ---------------------------------------------------------------------------
 
-#: The handler contract: ``handler.py`` defines
-#: ``handle(frame_bytes, metadata) -> (frame_bytes, metadata)``.
-#: Returning ``None`` for the frame passes the input frame through.
-#: stdout belongs to the protocol — handlers must not print to it.
-RUNNER_SOURCE = r'''
+#: The handler contract: ``handler.py`` defines either
+#: ``process_frame(frame, metadata)`` (NumPy-array contract, preferred
+#: when both are present — Requirement 3.7) or
+#: ``handle(frame_bytes, metadata) -> (frame_bytes, metadata)`` (the
+#: pre-existing raw-bytes contract — Requirement 3.6). Returning
+#: ``None`` passes the input frame through. stdout belongs to the
+#: protocol — handlers must not print to it.
+#:
+#: The runner is assembled with ``HELPERS_SOURCE`` (embedded via repr,
+#: keeping the script self-contained for ``python -c``): it registers
+#: the ``dda_frames`` module in ``sys.modules`` before the handler
+#: loads (Requirement 5.1) and best-effort binds ``cv2``/``np``/
+#: ``numpy`` on the handler module before its code executes
+#: (Requirements 4.1-4.3).
+RUNNER_SOURCE = "_HELPERS_SOURCE = " + repr(HELPERS_SOURCE) + "\n" + r'''
+import importlib
 import importlib.util
 import json
 import os
 import struct
 import sys
 import traceback
+import types
 
 
 def _read_exact(stream, n):
@@ -189,6 +411,91 @@ def _write(stream, header, frame):
     stream.flush()
 
 
+def _load_dda_frames():
+    """Register the embedded Frame_Helpers module as ``dda_frames``
+    before the handler loads (Requirement 5.1)."""
+    module = types.ModuleType("dda_frames")
+    exec(_HELPERS_SOURCE, module.__dict__)
+    sys.modules["dda_frames"] = module
+    return module
+
+
+def _invoke_process_frame(process_frame, dda_frames, frame, metadata, info):
+    """One process_frame invocation (Requirements 3.1-3.5)."""
+    width = info.get("width")
+    height = info.get("height")
+    frame_format = info.get("format")
+    if frame_format not in dda_frames.FORMAT_CHANNELS:
+        raise ValueError(
+            "process_frame: unsupported frame format {0!r} "
+            "(supported: {1})".format(
+                frame_format,
+                ", ".join(sorted(dda_frames.FORMAT_CHANNELS)),
+            )
+        )
+    if not isinstance(width, int) or not isinstance(height, int):
+        raise ValueError(
+            "process_frame: the stream caps are missing frame "
+            "dimensions (width={0!r}, height={1!r})".format(width, height)
+        )
+    try:
+        import numpy as np
+    except ImportError:
+        raise ValueError(
+            "process_frame requires NumPy, which is not importable "
+            "in the handler subprocess"
+        )
+    array = dda_frames.to_array(frame, width, height, frame_format)
+    result = process_frame(array, metadata)
+    if result is None:
+        return frame, metadata  # pass-through (Requirement 3.3)
+    if not isinstance(result, np.ndarray):
+        raise ValueError(
+            "process_frame must return None or a NumPy array of "
+            "shape {0} and dtype {1}, got {2}".format(
+                array.shape, array.dtype, type(result).__name__
+            )
+        )
+    if result.shape != array.shape or result.dtype != array.dtype:
+        raise ValueError(
+            "process_frame returned an array of shape {0} and dtype "
+            "{1}; expected shape {2} and dtype {3}".format(
+                result.shape, result.dtype, array.shape, array.dtype
+            )
+        )
+    # Write pixel rows back into a copy of the input bytes at the
+    # original row stride: byte length and row padding are preserved
+    # so the appsrc caps stay valid (Requirement 3.2).
+    channels = dda_frames.FORMAT_CHANNELS[frame_format]
+    row_bytes = width * channels
+    stride = len(frame) // height
+    out = bytearray(frame)
+    pixels = np.ascontiguousarray(result).tobytes()
+    for row in range(height):
+        out[row * stride:row * stride + row_bytes] = (
+            pixels[row * row_bytes:(row + 1) * row_bytes]
+        )
+    return bytes(out), metadata
+
+
+def _invoke_handle(handle, frame, metadata):
+    """One handle invocation — the pre-existing raw-bytes contract,
+    unchanged in behavior (Requirement 3.6)."""
+    result = handle(frame, metadata)
+    if isinstance(result, tuple):
+        out_frame, out_meta = result
+    else:
+        out_frame, out_meta = result, {}
+    if out_frame is None:
+        out_frame = frame
+    if not isinstance(out_frame, (bytes, bytearray)):
+        raise TypeError(
+            "handle() must return frame bytes, got "
+            + type(out_frame).__name__
+        )
+    return out_frame, out_meta
+
+
 def main():
     handler_path = sys.argv[1]
     stdin = sys.stdin.buffer
@@ -196,15 +503,34 @@ def main():
     # Let the handler import siblings shipped in its python/{nodeId}/ dir.
     sys.path.insert(0, os.path.dirname(os.path.abspath(handler_path)))
     try:
+        dda_frames = _load_dda_frames()
         spec = importlib.util.spec_from_file_location(
             "dda_custom_python_handler", handler_path
         )
         module = importlib.util.module_from_spec(spec)
+        # Best-effort pre-imports before the handler code executes; an
+        # import failure leaves the binding absent, affecting only
+        # handlers that reference it (Requirements 4.1-4.3).
+        for module_name, binding in (
+            ("cv2", "cv2"),
+            ("numpy", "np"),
+            ("numpy", "numpy"),
+        ):
+            try:
+                setattr(
+                    module, binding, importlib.import_module(module_name)
+                )
+            except Exception:
+                pass
         spec.loader.exec_module(module)
+        process_frame = getattr(module, "process_frame", None)
         handle = getattr(module, "handle", None)
-        if not callable(handle):
+        process_frame = process_frame if callable(process_frame) else None
+        handle = handle if callable(handle) else None
+        if process_frame is None and handle is None:
             raise TypeError(
-                "handler.py does not define a callable "
+                "handler.py defines neither "
+                "process_frame(frame, metadata) nor "
                 "handle(frame_bytes, metadata)"
             )
     except BaseException:
@@ -223,18 +549,23 @@ def main():
         header = json.loads(raw_header.decode("utf-8"))
         frame = _read_exact(stdin, int(header.get("frameSize", 0))) or b""
         try:
-            result = handle(frame, header.get("metadata") or {})
-            if isinstance(result, tuple):
-                out_frame, out_meta = result
-            else:
-                out_frame, out_meta = result, {}
-            if out_frame is None:
-                out_frame = frame
-            if not isinstance(out_frame, (bytes, bytearray)):
-                raise TypeError(
-                    "handle() must return frame bytes, got "
-                    + type(out_frame).__name__
-                )
+            metadata = header.get("metadata") or {}
+            info = {"width": header.get("width"),
+                    "height": header.get("height"),
+                    "format": header.get("format")}
+            metadata["frame"] = info  # Requirement 3.9
+            dda_frames._set_current(info)  # Requirement 5.6
+            try:
+                if process_frame is not None:
+                    out_frame, out_meta = _invoke_process_frame(
+                        process_frame, dda_frames, frame, metadata, info
+                    )
+                else:
+                    out_frame, out_meta = _invoke_handle(
+                        handle, frame, metadata
+                    )
+            finally:
+                dda_frames._set_current(None)
             _write(stdout, {"status": "ok", "metadata": out_meta or {}},
                    bytes(out_frame))
         except BaseException:
@@ -327,6 +658,14 @@ class CustomPythonBridge:
         # runs the executor's interpreter with its default home.
         env = dict(os.environ)
         env.pop("PYTHONHOME", None)
+        if self._memory_limit_bytes:
+            # Cap the OpenBLAS/OpenMP/OpenCV thread pools so their
+            # per-thread stack reservations fit under RLIMIT_AS; an
+            # uncapped OpenBLAS hangs inside ``import numpy`` on
+            # many-core hosts (see _THREAD_CAP_ENV). Operator-set
+            # values take precedence.
+            for key, value in _THREAD_CAP_ENV.items():
+                env.setdefault(key, value)
         self._process = subprocess.Popen(
             [self._python_executable, "-c", RUNNER_SOURCE, self._handler_path],
             stdin=subprocess.PIPE,

--- a/src/backend/workflow_engine/runtime.py
+++ b/src/backend/workflow_engine/runtime.py
@@ -90,9 +90,14 @@ def start_workflow_engine() -> Optional[WorkflowWatcher]:
             from workflow_engine.pipeline_executor import register_workflow_executor
 
             # Post-run output bindings: digital output / MQTT / OPC UA
-            # (Requirements 9.4, 9.5, 9.6; task 12.4).
+            # (Requirements 9.4, 9.5, 9.6; task 12.4). The binding
+            # resolution provider hands the executor the watcher's cached
+            # Camera_Binding resolutions so runs execute the substituted
+            # document and the Aravis frame feed sees resolved
+            # assignments (aravis-camera-input Requirement 6.4).
             _executor_instance = register_workflow_executor(
-                post_run_handler=OutputBindingProcessor()
+                post_run_handler=OutputBindingProcessor(),
+                binding_resolution_provider=watcher.binding_resolution,
             )
         except Exception:  # noqa: BLE001 - never take LocalServer down
             logger.exception(

--- a/src/backend/workflow_engine/vendor/workflow_core/catalog/nodes.py
+++ b/src/backend/workflow_engine/vendor/workflow_core/catalog/nodes.py
@@ -238,6 +238,52 @@ CAMERA_SOURCE = NodeTypeDescriptor(
     hardware_dependent=True,
 )
 
+ARAVIS_CAMERA_SOURCE = NodeTypeDescriptor(
+    type_id="aravis_camera_source",
+    category=CATEGORY_INPUT,
+    display_name="Aravis Camera Source",
+    inputs=[],
+    outputs=[PortDescriptor("out", PORT_TYPE_VIDEO_FRAMES)],
+    parameters=[
+        ParameterDescriptor("camera_id", "string", required=True, default=None,
+                            constraints={"min_length": 1},
+                            description="Aravis (GenICam) camera identifier "
+                                        "as enumerated on the edge device, "
+                                        "e.g. Aravis-Fake-GV01 or "
+                                        "Basler-12345678.",
+                            examples=["Aravis-Fake-GV01", "Basler-12345678"]),
+        ParameterDescriptor("gain", "int", required=False, default=4,
+                            constraints={"min": 0, "max": 100},
+                            description="Sensor gain (0-100) applied through "
+                                        "the camera manager. Higher values "
+                                        "brighten the image but add noise; "
+                                        "e.g. 4.",
+                            examples=[4, 10]),
+        ParameterDescriptor("exposure", "int", required=False, default=5000000,
+                            constraints={"min": 0},
+                            description="Sensor exposure time in nanoseconds "
+                                        "applied through the camera manager, "
+                                        "e.g. 5000000 (5 ms).",
+                            examples=[5000000, 16000000]),
+    ],
+    # Aravis acquisition happens in the LocalServer process through the
+    # camera manager (no aravissrc element ships in the DDA images):
+    # every physical architecture compiles an appsrc-headed chain the
+    # executor feeds a camera-manager-grabbed frame into, the classic
+    # Camera-type Frame_Feed model. The appsrc name is compile-time
+    # rendered per node ({nodeId} derived by the compiler) so
+    # multi-camera documents stay addressable. Simulation: fed from the
+    # Test_Dataset like camera_source (Requirement 12.6).
+    mappings=_same_on_device_archs(
+        element_chain=[
+            _element("appsrc", name="appsrc_{nodeId}"),
+            _element("videoconvert"),
+        ],
+        plugin_dependencies=["app", "videoconvertscale"],
+    ) + [_dataset_fed_sim_source()],
+    hardware_dependent=True,
+)
+
 FOLDER_SOURCE = NodeTypeDescriptor(
     type_id="folder_source",
     category=CATEGORY_INPUT,
@@ -977,6 +1023,7 @@ CAPTURE = NodeTypeDescriptor(
 
 NODE_CATALOG = (
     CAMERA_SOURCE,
+    ARAVIS_CAMERA_SOURCE,
     FOLDER_SOURCE,
     DIGITAL_INPUT,
     DEWARP,

--- a/src/backend/workflow_engine/vendor/workflow_core/catalog/nodes.py
+++ b/src/backend/workflow_engine/vendor/workflow_core/catalog/nodes.py
@@ -437,6 +437,44 @@ FORMAT_CONVERT = NodeTypeDescriptor(
     hardware_dependent=False,
 )
 
+CUSTOM_PYTHON_PREPROCESS = NodeTypeDescriptor(
+    type_id="custom_python_preprocess",
+    category=CATEGORY_PREPROCESSING,
+    display_name="Custom Python (Frames)",
+    inputs=[PortDescriptor("in", PORT_TYPE_VIDEO_FRAMES)],
+    outputs=[PortDescriptor("out", PORT_TYPE_VIDEO_FRAMES)],
+    parameters=[
+        ParameterDescriptor("code", "code", required=True, default=None,
+                            constraints={"min_length": 1},
+                            description="Python run for every video frame. "
+                                        "Define process_frame(frame, "
+                                        "metadata) and return the processed "
+                                        "frame; frame is a NumPy uint8 array "
+                                        "(rows x cols x channels) and "
+                                        "cv2/np are pre-imported. Return "
+                                        "None to pass the frame through. "
+                                        "Helpers: import dda_frames for "
+                                        "frame_info(), load_image(path or "
+                                        "s3:// URI), to_array(), to_bytes().",
+                            examples=["def process_frame(frame, metadata):\n"
+                                      "    return cv2.GaussianBlur(frame, (5, 5), 0)"]),
+        ParameterDescriptor("requirements", "string", required=False, default="",
+                            constraints={},
+                            description="Extra pip packages the code needs, "
+                                        "one per line in requirements.txt "
+                                        "form.",
+                            examples=["scikit-image==0.24.0"]),
+    ],
+    # Same emlpython bridge element and packaged plugin dependency as the
+    # custom_python post-processing node (Requirement 1.4); the compiler
+    # derives {python_handler_path} per node id, so no compiler changes.
+    mappings=_same_on_all_archs(
+        element_chain=[_element("emlpython", **{"handler-path": "{python_handler_path}"})],
+        plugin_dependencies=["dda-emlpython"],
+    ),
+    hardware_dependent=False,
+)
+
 # --------------------------------------------------------------------------
 # Model inference node type (Requirement 2.3)
 # --------------------------------------------------------------------------
@@ -607,12 +645,19 @@ CUSTOM_PYTHON = NodeTypeDescriptor(
     parameters=[
         ParameterDescriptor("code", "code", required=True, default=None,
                             constraints={"min_length": 1},
-                            description="Python source run for every item "
-                                        "passing through the node; define "
-                                        "process(data, metadata) and return "
-                                        "the (possibly modified) data.",
-                            examples=["def process(data, metadata):\n"
-                                      "    return data"]),
+                            description="Python run for every item passing "
+                                        "through the node. Define "
+                                        "process_frame(frame, metadata) to "
+                                        "work with video frames as NumPy "
+                                        "arrays (cv2/np pre-imported; import "
+                                        "dda_frames for helpers), or "
+                                        "handle(frame_bytes, metadata) -> "
+                                        "(frame_bytes, metadata) to work "
+                                        "with raw bytes.",
+                            examples=["def process_frame(frame, metadata):\n"
+                                      "    return frame",
+                                      "def handle(frame_bytes, metadata):\n"
+                                      "    return frame_bytes, metadata"]),
         ParameterDescriptor("requirements", "string", required=False, default="",
                             constraints={},
                             description="Extra pip packages the code needs, "
@@ -938,6 +983,7 @@ NODE_CATALOG = (
     ROTATE,
     CROP,
     FORMAT_CONVERT,
+    CUSTOM_PYTHON_PREPROCESS,
     MODEL_INFERENCE,
     BEDROCK_INFERENCE,
     CUSTOM_PYTHON,

--- a/src/backend/workflow_engine/vendor/workflow_core/compiler/compiler.py
+++ b/src/backend/workflow_engine/vendor/workflow_core/compiler/compiler.py
@@ -484,6 +484,11 @@ def _effective_parameters(node: Node, descriptor: NodeTypeDescriptor) -> Dict[st
 def _derived_values(node: Node, parameters: Dict[str, Any]) -> Dict[str, Any]:
     """Placeholder values the compiler derives per node."""
     derived: Dict[str, Any] = {
+        # The node's own id, for per-node element naming in mapping
+        # templates (e.g. aravis_camera_source's appsrc name
+        # ``appsrc_{nodeId}``) so multi-node documents render unique
+        # element names.
+        "nodeId": node.id,
         # Custom Python handler artifact path (packaging layout, task 7.1).
         "python_handler_path": "python/{0}/handler.py".format(node.id),
         # Per-node element name for simulation stub sources so the test

--- a/src/backend/workflow_engine/vendor/workflow_core/serializer/models.py
+++ b/src/backend/workflow_engine/vendor/workflow_core/serializer/models.py
@@ -40,12 +40,20 @@ class Node:
 
     ``type`` is a node type id from the catalog (``workflow_core.catalog``);
     ``parameters`` maps parameter names to JSON-representable values.
+
+    ``data`` is optional advisory node data (e.g. the camera picker's
+    ``cameraBindingHint``). It is preserved through parse/serialize round
+    trips but carries no workflow semantics: validation and compilation
+    ignore it, and it is excluded from node equality / graph equivalence
+    (``compare=False``) so hinted and hint-stripped definitions remain
+    equivalent (Requirements 7.5, 11.5).
     """
 
     id: str
     type: str
     position: Position
     parameters: Dict[str, Any] = field(default_factory=dict)
+    data: Dict[str, Any] = field(default_factory=dict, compare=False)
 
 
 @dataclass
@@ -86,8 +94,8 @@ class WorkflowGraph:
         """Order-insensitive graph equivalence (Requirement 3.4).
 
         True when both graphs contain the same set of nodes (by full
-        content) and the same set of connections, regardless of list
-        ordering.
+        content, excluding advisory ``data``) and the same set of
+        connections, regardless of list ordering.
         """
         if not isinstance(other, WorkflowGraph):
             return False

--- a/src/backend/workflow_engine/vendor/workflow_core/serializer/parse.py
+++ b/src/backend/workflow_engine/vendor/workflow_core/serializer/parse.py
@@ -339,6 +339,7 @@ def _build_graph(
                 type=node_doc["type"],
                 position=Position(x=node_doc["position"]["x"], y=node_doc["position"]["y"]),
                 parameters=dict(node_doc["parameters"]),
+                data=dict(node_doc.get("data", {})),
             )
             for node_doc in document["nodes"]
         ],

--- a/src/backend/workflow_engine/vendor/workflow_core/serializer/schema.py
+++ b/src/backend/workflow_engine/vendor/workflow_core/serializer/schema.py
@@ -41,6 +41,15 @@ _NODE_SCHEMA = {
             "type": "object",
             "description": "Parameter name to JSON value; keys and value types are declared by the node type's catalog descriptor.",
         },
+        "data": {
+            "type": "object",
+            "description": (
+                "Optional advisory node data (e.g. cameraBindingHint recorded "
+                "by the Workflow_Builder camera picker). Preserved through "
+                "parse/serialize round trips but ignored by validation and "
+                "compilation (Requirements 7.5, 11.5)."
+            ),
+        },
     },
 }
 

--- a/src/backend/workflow_engine/vendor/workflow_core/serializer/serialize.py
+++ b/src/backend/workflow_engine/vendor/workflow_core/serializer/serialize.py
@@ -7,8 +7,11 @@
 - fixed whitespace (2-space indent), ASCII-escaped output.
 
 Canonical output makes the round-trip property "identical JSON structure"
-achievable (Requirement 3.4): any two serializations of equivalent graphs
-are byte-identical.
+achievable (Requirement 3.4): serializing a parsed serialization is
+byte-identical to the original serialization. Advisory node ``data``
+(excluded from graph equivalence) is preserved verbatim and omitted when
+empty, so definitions without node data serialize exactly as before the
+field existed (Requirement 11.5).
 """
 
 from __future__ import annotations
@@ -37,12 +40,7 @@ def graph_to_document(graph: WorkflowGraph) -> Dict[str, Any]:
     return {
         "schemaVersion": SCHEMA_VERSION,
         "nodes": [
-            {
-                "id": node.id,
-                "type": node.type,
-                "position": {"x": node.position.x, "y": node.position.y},
-                "parameters": dict(node.parameters),
-            }
+            _node_to_document(node)
             for node in sorted(graph.nodes, key=lambda n: n.id)
         ],
         "connections": [
@@ -54,6 +52,21 @@ def graph_to_document(graph: WorkflowGraph) -> Dict[str, Any]:
             for connection in sorted(graph.connections, key=lambda c: c.id)
         ],
     }
+
+
+def _node_to_document(node) -> Dict[str, Any]:
+    """A node's document form; advisory ``data`` is emitted only when
+    non-empty so definitions without node data serialize byte-identically
+    to before the field existed (Requirement 11.5)."""
+    document = {
+        "id": node.id,
+        "type": node.type,
+        "position": {"x": node.position.x, "y": node.position.y},
+        "parameters": dict(node.parameters),
+    }
+    if node.data:
+        document["data"] = dict(node.data)
+    return document
 
 
 def serialize(graph: WorkflowGraph) -> str:

--- a/test/backend-test/camera_discovery/test_aravis_enumeration.py
+++ b/test/backend-test/camera_discovery/test_aravis_enumeration.py
@@ -1,0 +1,210 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the injectable Aravis enumeration module.
+
+Feature: aravis-camera-input (Requirements 2.1, 2.3, 2.6, 2.7).
+
+Example tests of the injectable construction, the default lazy-import
+fallback, and failure isolation. The property tests (stable id determinism,
+enumeration completeness) live in separate ``test_property_*`` modules.
+"""
+import hashlib
+import sys
+
+from camera_discovery import (
+    AravisDiscoveryResult,
+    DiscoveredAravisCamera,
+    aravis_stable_id,
+    enumerate_aravis,
+)
+
+
+class FakeAravisCamera:
+    """The attribute shape of ``model.Camera`` from aravis_functions."""
+
+    def __init__(
+        self,
+        id="Aravis-Fake-GV01",
+        model="Fake GV Camera",
+        address="192.168.0.10",
+        physical_id="fake-phys-0",
+        protocol="Fake",
+        serial="GV01",
+        vendor="Aravis",
+    ):
+        self.id = id
+        self.model = model
+        self.address = address
+        self.physical_id = physical_id
+        self.protocol = protocol
+        self.serial = serial
+        self.vendor = vendor
+
+
+class TestInjectableConstruction:
+    def test_injected_enumerator_cameras_mapped_with_identity(self):
+        # Requirements 2.1, 2.3, 2.7: injected enumerator drives the pass,
+        # every identity field is captured on the discovered camera.
+        fake = FakeAravisCamera(
+            id="Basler-12345678",
+            model="acA1920-40gc",
+            address="192.168.1.20",
+            physical_id="00:30:53:2a:bc:de",
+            protocol="GigEVision",
+            serial="12345678",
+            vendor="Basler",
+        )
+        result = enumerate_aravis(enumerator=lambda: [fake])
+
+        assert result.failures == []
+        (camera,) = result.cameras
+        assert camera.camera_id == "Basler-12345678"
+        assert camera.model == "acA1920-40gc"
+        assert camera.address == "192.168.1.20"
+        assert camera.physical_id == "00:30:53:2a:bc:de"
+        assert camera.protocol == "GigEVision"
+        assert camera.serial == "12345678"
+        assert camera.vendor == "Basler"
+        assert camera.stable_id == aravis_stable_id(
+            "Basler", "acA1920-40gc", "12345678", "00:30:53:2a:bc:de"
+        )
+
+    def test_multiple_cameras_each_contribute_one_entry(self):
+        cams = [
+            FakeAravisCamera(id="A", serial="s1", vendor="V1"),
+            FakeAravisCamera(id="B", serial="s2", vendor="V2"),
+        ]
+        result = enumerate_aravis(enumerator=lambda: cams)
+
+        assert [c.camera_id for c in result.cameras] == ["A", "B"]
+        assert len({c.stable_id for c in result.cameras}) == 2
+
+    def test_discovered_camera_is_frozen(self):
+        result = enumerate_aravis(enumerator=lambda: [FakeAravisCamera()])
+        (camera,) = result.cameras
+        assert isinstance(camera, DiscoveredAravisCamera)
+        try:
+            camera.camera_id = "other"
+            raised = False
+        except AttributeError:
+            raised = True
+        assert raised
+
+    def test_empty_enumeration_yields_empty_result(self):
+        result = enumerate_aravis(enumerator=lambda: [])
+        assert result.cameras == []
+        assert result.failures == []
+
+
+class TestStableIdDerivation:
+    def test_stable_id_shape_and_derivation(self):
+        expected = (
+            "arv-"
+            + hashlib.sha1("Basler|acA1920|12345678".encode()).hexdigest()[:12]
+        )
+        assert aravis_stable_id("Basler", "acA1920", "12345678") == expected
+
+    def test_serial_present_ignores_physical_id(self):
+        a = aravis_stable_id("V", "M", "S", "phys-1")
+        b = aravis_stable_id("V", "M", "S", "phys-2")
+        assert a == b
+
+    def test_empty_serial_falls_back_to_physical_id(self):
+        a = aravis_stable_id("V", "M", "", "phys-1")
+        b = aravis_stable_id("V", "M", "", "phys-2")
+        assert a != b
+        assert a.startswith("arv-")
+
+
+class TestDefaultLazyImportFallback:
+    def test_missing_aravis_stack_yields_failure_record(self, monkeypatch):
+        # Requirements 2.6, 2.7: the default enumerator lazily imports the
+        # aravis_functions module; when the gi/Aravis stack is absent the
+        # result is empty with a failure record — never an exception.
+        monkeypatch.setitem(
+            sys.modules, "edge_ml1_p_camera_management.aravis_functions", None
+        )
+        monkeypatch.setitem(sys.modules, "edge_ml1_p_camera_management", None)
+
+        result = enumerate_aravis()
+
+        assert isinstance(result, AravisDiscoveryResult)
+        assert result.cameras == []
+        assert len(result.failures) == 1
+        assert "error" in result.failures[0]
+
+    def test_default_enumerator_used_when_import_succeeds(self, monkeypatch):
+        # Requirement 2.1: the default maps aravis_functions.getCameras().
+        import types
+
+        fake_module = types.SimpleNamespace(
+            getCameras=lambda: [FakeAravisCamera(id="Aravis-Fake-GV01")]
+        )
+        fake_package = types.ModuleType("edge_ml1_p_camera_management")
+        fake_package.aravis_functions = fake_module
+        monkeypatch.setitem(
+            sys.modules, "edge_ml1_p_camera_management", fake_package
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "edge_ml1_p_camera_management.aravis_functions",
+            fake_module,
+        )
+
+        result = enumerate_aravis()
+
+        assert [c.camera_id for c in result.cameras] == ["Aravis-Fake-GV01"]
+        assert result.failures == []
+
+
+class TestFailureIsolation:
+    def test_raising_enumerator_yields_failure_record_not_exception(self):
+        # Requirement 2.6
+        def broken():
+            raise RuntimeError("bus exploded")
+
+        result = enumerate_aravis(enumerator=broken)
+
+        assert result.cameras == []
+        (failure,) = result.failures
+        assert "bus exploded" in failure["error"]
+
+    def test_camera_with_no_usable_identity_recorded_and_skipped(self):
+        # Design Error Handling: no runtime id / no bus-stable identity
+        # fields -> failures list, pass continues with the good cameras.
+        no_id = FakeAravisCamera(id="")
+        no_identity = FakeAravisCamera(
+            id="ghost", model="", serial="", vendor="", physical_id=""
+        )
+        good = FakeAravisCamera(id="Good-1", serial="s-good")
+
+        result = enumerate_aravis(
+            enumerator=lambda: [no_id, good, no_identity]
+        )
+
+        assert [c.camera_id for c in result.cameras] == ["Good-1"]
+        assert len(result.failures) == 2
+        assert all("error" in f for f in result.failures)
+
+    def test_none_identity_fields_coerced_not_crashing(self):
+        cam = FakeAravisCamera(
+            id="With-Nones", address=None, protocol=None, serial=None
+        )
+        result = enumerate_aravis(enumerator=lambda: [cam])
+
+        (camera,) = result.cameras
+        assert camera.address == ""
+        assert camera.protocol == ""
+        assert camera.serial == ""
+        assert result.failures == []

--- a/test/backend-test/camera_discovery/test_discovery_aravis_wiring.py
+++ b/test/backend-test/camera_discovery/test_discovery_aravis_wiring.py
@@ -1,0 +1,249 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the Aravis wiring into the CameraDiscovery loop.
+
+Feature: aravis-camera-input (Requirements 2.1, 2.5, 2.7).
+
+Example tests of the injectable Aravis enumerator running alongside the
+V4L2 layer in each periodic pass: both families land in one tracked
+snapshot, Aravis stable ids get the identical absence semantics, an empty
+Aravis bus leaves V4L2-only behavior unchanged, and ``on_change`` fires
+only on change. The exhaustive absence property is the separate
+``test_property_*`` module (optional task 3.4).
+"""
+from fake_v4l2 import FakeDevice, FakeV4l2Io
+
+from camera_discovery import CameraDiscovery, DiscoveredCamera
+from camera_discovery.aravis import DiscoveredAravisCamera, aravis_stable_id
+from camera_discovery.discovery import diff_snapshot
+
+
+class FakeAravisCamera:
+    """The attribute shape of ``model.Camera`` from aravis_functions."""
+
+    def __init__(
+        self,
+        id="Aravis-Fake-GV01",
+        model="Fake GV Camera",
+        address="192.168.0.10",
+        physical_id="fake-phys-0",
+        protocol="Fake",
+        serial="GV01",
+        vendor="Aravis",
+    ):
+        self.id = id
+        self.model = model
+        self.address = address
+        self.physical_id = physical_id
+        self.protocol = protocol
+        self.serial = serial
+        self.vendor = vendor
+
+
+class FakeAravisBus:
+    """Mutable fake bus: the injected enumerator returns ``cameras``."""
+
+    def __init__(self, cameras=()):
+        self.cameras = list(cameras)
+
+    def __call__(self):
+        return list(self.cameras)
+
+
+class FakeClock:
+    """Injectable clock returning a controlled epoch-seconds value."""
+
+    def __init__(self, start=1_000_000.0):
+        self.now = start
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+def _v4l2_stable_ids(io):
+    return {c.stable_id for c in CameraDiscovery(v4l2_io=io).enumerate().cameras}
+
+
+class TestBothFamiliesInOnePass:
+    def test_one_pass_tracks_v4l2_and_aravis_cameras(self):
+        # Requirements 2.1, 2.7: each periodic pass runs both enumerations;
+        # the snapshot carries both families, distinguished by entry type.
+        io = FakeV4l2Io({"/dev/video0": FakeDevice(card="Cam A")})
+        bus = FakeAravisBus([FakeAravisCamera()])
+        discovery = CameraDiscovery(v4l2_io=io, aravis_enumerator=bus)
+
+        snapshot = discovery.run_once()
+
+        aravis_id = aravis_stable_id("Aravis", "Fake GV Camera", "GV01")
+        assert set(snapshot.cameras) == _v4l2_stable_ids(io) | {aravis_id}
+
+        aravis_entry = snapshot.cameras[aravis_id]
+        assert isinstance(aravis_entry.camera, DiscoveredAravisCamera)
+        assert aravis_entry.camera.camera_id == "Aravis-Fake-GV01"
+        assert aravis_entry.absent is False
+
+        v4l2_entries = [
+            entry
+            for stable_id, entry in snapshot.cameras.items()
+            if stable_id != aravis_id
+        ]
+        assert all(isinstance(e.camera, DiscoveredCamera) for e in v4l2_entries)
+        assert snapshot.failures == ()
+
+    def test_aravis_enumeration_failure_keeps_v4l2_inventory(self):
+        # Requirement 2.6 adjacent: a raising enumerator records a failure
+        # and leaves the V4L2 side of the pass intact.
+        io = FakeV4l2Io({"/dev/video0": FakeDevice(card="Cam A")})
+
+        def broken():
+            raise RuntimeError("bus exploded")
+
+        discovery = CameraDiscovery(v4l2_io=io, aravis_enumerator=broken)
+        snapshot = discovery.run_once()
+
+        assert set(snapshot.cameras) == _v4l2_stable_ids(io)
+        (failure,) = snapshot.failures
+        assert "bus exploded" in failure["error"]
+
+
+class TestAravisAbsenceMarking:
+    def test_disappeared_aravis_camera_marked_absent_not_dropped(self):
+        # Requirement 2.5: a previously discovered Aravis camera missing
+        # from a re-enumeration is marked absent with a timestamp, never
+        # deleted from the tracked set.
+        clock = FakeClock()
+        bus = FakeAravisBus([FakeAravisCamera()])
+        discovery = CameraDiscovery(
+            v4l2_io=FakeV4l2Io({}), aravis_enumerator=bus, clock=clock
+        )
+
+        discovery.run_once()
+
+        bus.cameras = []  # camera unplugged from the bus
+        clock.advance(300)
+        snapshot = discovery.run_once()
+
+        aravis_id = aravis_stable_id("Aravis", "Fake GV Camera", "GV01")
+        entry = snapshot.cameras[aravis_id]
+        assert entry.absent is True
+        assert entry.absent_since == int(clock.now * 1000)
+        assert isinstance(entry.camera, DiscoveredAravisCamera)
+
+    def test_returning_aravis_camera_loses_absence_marking(self):
+        clock = FakeClock()
+        camera = FakeAravisCamera()
+        bus = FakeAravisBus([camera])
+        discovery = CameraDiscovery(
+            v4l2_io=FakeV4l2Io({}), aravis_enumerator=bus, clock=clock
+        )
+
+        discovery.run_once()
+        bus.cameras = []
+        clock.advance(300)
+        discovery.run_once()
+        bus.cameras = [camera]
+        clock.advance(300)
+        snapshot = discovery.run_once()
+
+        aravis_id = aravis_stable_id("Aravis", "Fake GV Camera", "GV01")
+        entry = snapshot.cameras[aravis_id]
+        assert entry.absent is False
+        assert entry.absent_since is None
+
+
+class TestV4l2OnlyBehaviorUnchanged:
+    def test_empty_aravis_bus_yields_pure_v4l2_snapshot(self):
+        # Requirement 2.7: with an empty Aravis enumeration the tracked
+        # snapshot equals the pure V4L2 diff for the same devices.
+        clock = FakeClock()
+        devices = {
+            "/dev/video0": FakeDevice(card="Cam A"),
+            "/dev/video1": FakeDevice(card="Cam B"),
+        }
+        discovery = CameraDiscovery(
+            v4l2_io=FakeV4l2Io(devices),
+            aravis_enumerator=FakeAravisBus([]),
+            clock=clock,
+        )
+
+        snapshot = discovery.run_once()
+
+        v4l2_result = CameraDiscovery(v4l2_io=FakeV4l2Io(devices)).enumerate()
+        expected, _ = diff_snapshot({}, v4l2_result, int(clock.now * 1000))
+        assert dict(snapshot.cameras) == expected
+        assert snapshot.failures == ()
+
+    def test_v4l2_absence_semantics_unchanged_with_empty_aravis_bus(self):
+        clock = FakeClock()
+        io = FakeV4l2Io({"/dev/video0": FakeDevice(card="Cam A")})
+        discovery = CameraDiscovery(
+            v4l2_io=io, aravis_enumerator=FakeAravisBus([]), clock=clock
+        )
+
+        discovery.run_once()
+        del io.devices["/dev/video0"]
+        clock.advance(300)
+        snapshot = discovery.run_once()
+
+        (entry,) = snapshot.cameras.values()
+        assert entry.absent is True
+        assert entry.absent_since == int(clock.now * 1000)
+
+
+class TestOnChangeFiresOnlyOnChange:
+    def test_identical_combined_enumerations_suppress_on_change(self):
+        clock = FakeClock()
+        io = FakeV4l2Io({"/dev/video0": FakeDevice(card="Cam A")})
+        bus = FakeAravisBus([FakeAravisCamera()])
+        discovery = CameraDiscovery(
+            v4l2_io=io, aravis_enumerator=bus, clock=clock
+        )
+
+        calls = []
+        discovery._on_change = calls.append
+
+        discovery.run_once()  # empty -> two cameras: a change
+        assert len(calls) == 1
+
+        for _ in range(3):
+            clock.advance(300)
+            discovery.run_once()
+        assert len(calls) == 1
+
+    def test_aravis_bus_change_fires_on_change(self):
+        clock = FakeClock()
+        bus = FakeAravisBus([FakeAravisCamera()])
+        discovery = CameraDiscovery(
+            v4l2_io=FakeV4l2Io({}), aravis_enumerator=bus, clock=clock
+        )
+
+        calls = []
+        discovery._on_change = calls.append
+
+        discovery.run_once()
+        clock.advance(300)
+        discovery.run_once()
+        assert len(calls) == 1
+
+        bus.cameras = []  # disappearance changes the tracked inventory
+        clock.advance(300)
+        discovery.run_once()
+        assert len(calls) == 2
+
+        clock.advance(300)
+        discovery.run_once()  # repeated empty bus: suppressed again
+        assert len(calls) == 2

--- a/test/backend-test/camera_discovery/test_property_aravis_absence_marking.py
+++ b/test/backend-test/camera_discovery/test_property_aravis_absence_marking.py
@@ -1,0 +1,200 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property test for Aravis absence marking on re-enumeration.
+
+**Feature: aravis-camera-input, Property 5: Aravis absence marking on
+re-enumeration**
+
+*For any* sequence of Aravis enumeration results, a stable id present in
+an earlier result and missing from a later one SHALL be marked absent with
+an absence timestamp and SHALL never be dropped from the tracked
+inventory.
+
+Exercised end-to-end through the real
+:class:`camera_discovery.CameraDiscovery` diff/tracking: a mutable fake
+Aravis bus is injected as the enumerator, the V4L2 layer is an empty fake,
+and an injectable clock controls the absence timestamps. Each generated
+enumeration pass re-randomizes the bus's runtime attributes (Aravis
+runtime id, address, protocol) and order, so the tracked identity is the
+stable id alone.
+
+**Validates: Requirements 2.5**
+
+Runs with the hypothesis profiles registered in the root conftest
+(``fast`` = 25 examples locally, ``HYPOTHESIS_PROFILE=ci`` = 100).
+"""
+from types import SimpleNamespace
+
+from fake_v4l2 import FakeV4l2Io
+from hypothesis import given
+from hypothesis import strategies as st
+
+from camera_discovery import CameraDiscovery
+from camera_discovery.aravis import DiscoveredAravisCamera, aravis_stable_id
+
+# --- generators --------------------------------------------------------------
+
+# Printable ASCII excluding "|" (the stable id derivation's join character),
+# matching real GenICam identity strings.
+_TEXT_ALPHABET = st.characters(
+    min_codepoint=32, max_codepoint=126, exclude_characters="|"
+)
+
+_VENDORS = st.text(alphabet=_TEXT_ALPHABET, min_size=1, max_size=24)
+_MODELS = st.text(alphabet=_TEXT_ALPHABET, min_size=1, max_size=24)
+_SERIALS = st.text(alphabet=_TEXT_ALPHABET, max_size=24)  # may be empty
+_PHYSICAL_IDS = st.text(alphabet=_TEXT_ALPHABET, min_size=1, max_size=24)
+
+# Runtime attributes the bus does NOT keep stable across enumerations.
+_RUNTIME_IDS = st.text(alphabet=_TEXT_ALPHABET, min_size=1, max_size=32)
+_ADDRESSES = st.text(alphabet=_TEXT_ALPHABET, max_size=32)
+_PROTOCOLS = st.sampled_from(["GigEVision", "USB3Vision", "Fake"])
+
+def _stable_id_key(identity):
+    """Uniqueness key: the stable id an identity tuple derives."""
+    vendor, model, serial, physical_id = identity
+    return aravis_stable_id(vendor, model, serial, physical_id)
+
+
+# A small pool of bus-stable identities, unique by the stable id they
+# derive (so distinct pool members are distinct tracked entries).
+_IDENTITY_POOL = st.lists(
+    st.tuples(_VENDORS, _MODELS, _SERIALS, _PHYSICAL_IDS),
+    min_size=1,
+    max_size=5,
+    unique_by=_stable_id_key,
+)
+
+
+@st.composite
+def _enumeration_sequences(draw):
+    """A sequence of fake Aravis bus passes over a shared identity pool.
+
+    Each pass enumerates a random subset of the pool (so identities
+    appear, disappear, and return) in a re-randomized order, with fresh
+    runtime id / address / protocol values per pass.
+    """
+    pool = draw(_IDENTITY_POOL)
+    pass_count = draw(st.integers(min_value=2, max_value=6))
+
+    passes = []
+    for _ in range(pass_count):
+        subset = [
+            identity for identity in draw(st.permutations(pool))
+            if draw(st.booleans())
+        ]
+        passes.append(
+            [
+                SimpleNamespace(
+                    id=draw(_RUNTIME_IDS),
+                    model=model,
+                    address=draw(_ADDRESSES),
+                    physical_id=physical_id,
+                    protocol=draw(_PROTOCOLS),
+                    serial=serial,
+                    vendor=vendor,
+                )
+                for vendor, model, serial, physical_id in subset
+            ]
+        )
+    return passes
+
+
+# --- fakes -------------------------------------------------------------------
+
+
+class _MutableBus:
+    """Injectable Aravis enumerator returning whatever ``cameras`` holds."""
+
+    def __init__(self):
+        self.cameras = []
+
+    def __call__(self):
+        return list(self.cameras)
+
+
+class _FakeClock:
+    """Injectable epoch-seconds clock (controls absence timestamps)."""
+
+    def __init__(self, start):
+        self.now = float(start)
+
+    def __call__(self):
+        return self.now
+
+
+# --- property ----------------------------------------------------------------
+
+
+@given(
+    passes=_enumeration_sequences(),
+    start_seconds=st.integers(min_value=0, max_value=2_000_000_000),
+)
+def test_aravis_absence_marking_on_re_enumeration(passes, start_seconds):
+    """**Feature: aravis-camera-input, Property 5: Aravis absence marking
+    on re-enumeration**
+
+    **Validates: Requirements 2.5**
+    """
+    bus = _MutableBus()
+    clock = _FakeClock(start_seconds)
+    discovery = CameraDiscovery(
+        v4l2_io=FakeV4l2Io({}), aravis_enumerator=bus, clock=clock
+    )
+
+    seen_ids = set()
+    expected_absent_since = {}  # stable id -> epoch ms of first miss, or None
+
+    for step, cameras in enumerate(passes):
+        bus.cameras = cameras
+        clock.now = float(start_seconds + step * 300)
+        now_ms = int(clock.now * 1000)
+
+        snapshot = discovery.run_once()
+
+        present_ids = {
+            aravis_stable_id(c.vendor, c.model, c.serial, c.physical_id)
+            for c in cameras
+        }
+        seen_ids |= present_ids
+
+        # Update the expected absence model: a present id carries no
+        # absence timestamp; an id missing this pass gets stamped with the
+        # timestamp of the enumeration that first noticed the miss and
+        # keeps it while it stays missing.
+        for stable_id in present_ids:
+            expected_absent_since[stable_id] = None
+        for stable_id in seen_ids - present_ids:
+            if expected_absent_since[stable_id] is None:
+                expected_absent_since[stable_id] = now_ms
+
+        # Never dropped: the tracked inventory is exactly every stable id
+        # ever enumerated (2.5 — marked absent rather than deleted).
+        assert set(snapshot.cameras) == seen_ids
+
+        for stable_id, entry in snapshot.cameras.items():
+            assert isinstance(entry.camera, DiscoveredAravisCamera)
+            assert entry.camera.stable_id == stable_id
+            if stable_id in present_ids:
+                # Enumerated this pass: present, no absence marking (a
+                # returning camera loses its marking).
+                assert entry.absent is False
+                assert entry.absent_since is None
+            else:
+                # Present in an earlier result, missing from this one:
+                # marked absent with the absence timestamp of the pass
+                # that first noticed the disappearance, retained across
+                # further misses.
+                assert entry.absent is True
+                assert entry.absent_since == expected_absent_since[stable_id]

--- a/test/backend-test/camera_discovery/test_property_aravis_enumeration_completeness.py
+++ b/test/backend-test/camera_discovery/test_property_aravis_enumeration_completeness.py
@@ -1,0 +1,254 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property test for Aravis enumeration completeness with identity capture.
+
+**Feature: aravis-camera-input, Property 2: Aravis discovery enumeration
+completeness with identity capture**
+
+*For any* set of enumerated Aravis cameras, every camera SHALL contribute
+to exactly one inventory entry, and every discovered-only entry SHALL have
+type ``AravisDiscovered``, origin ``edge-discovered``, and
+parameters/capabilities carrying all of the camera's identity fields (id,
+model, address, physical id, protocol, serial, vendor).
+
+Exercised over generated fake Aravis buses (unicode names, duplicate
+models, empty serials) at each layer that owns a piece of the property:
+
+- :func:`camera_discovery.aravis.enumerate_aravis` and the real
+  :class:`camera_discovery.CameraDiscovery` tracked snapshot guarantee the
+  one-entry-per-camera contribution with all identity fields captured;
+- the ``AravisDiscovered`` / ``edge-discovered`` typing lives in
+  ``camera_sync.build_inventory`` (read-only import), asserted over the
+  snapshot with no configured Image_Sources so every camera is a
+  discovered-only entry.
+
+**Validates: Requirements 2.1, 2.3**
+
+Runs with the hypothesis profiles registered in the root conftest
+(``fast`` = 25 examples locally, ``HYPOTHESIS_PROFILE=ci`` = 100).
+"""
+from types import SimpleNamespace
+
+from fake_v4l2 import FakeV4l2Io
+from hypothesis import given
+from hypothesis import strategies as st
+
+from camera_discovery import CameraDiscovery
+from camera_discovery.aravis import (
+    DiscoveredAravisCamera,
+    aravis_stable_id,
+    enumerate_aravis,
+)
+from camera_sync.inventory import (
+    ORIGIN_EDGE_DISCOVERED,
+    TYPE_ARAVIS_DISCOVERED,
+    build_inventory,
+)
+
+# --- generators --------------------------------------------------------------
+
+# Full-unicode identity strings (hypothesis' default text alphabet excludes
+# surrogates): real GenICam vendors/models are not ASCII-only.
+_UNICODE_NAMES = st.text(min_size=1, max_size=24)
+_SERIALS = st.text(max_size=24)  # may be empty (serial-less cameras)
+_ADDRESSES = st.text(max_size=32)
+_PROTOCOLS = st.sampled_from(["GigEVision", "USB3Vision", "Fake"])
+_RUNTIME_IDS = st.text(min_size=1, max_size=32)
+
+
+def _stable_id_key(identity):
+    """Uniqueness key: the stable id an identity tuple derives."""
+    vendor, model, serial, physical_id = identity
+    return aravis_stable_id(vendor, model, serial, physical_id)
+
+
+@st.composite
+def _fake_buses(draw):
+    """A fake Aravis bus: 1..6 cameras with unicode identity strings,
+    models drawn from a small shared pool (forcing duplicate models),
+    possibly empty serials, and unique runtime ids.
+
+    Identities are unique by the stable id they derive, so every bus
+    camera is a distinct tracked entry.
+    """
+    model_pool = draw(st.lists(_UNICODE_NAMES, min_size=1, max_size=2, unique=True))
+    identities = draw(
+        st.lists(
+            st.tuples(
+                _UNICODE_NAMES,               # vendor
+                st.sampled_from(model_pool),  # model (duplicates likely)
+                _SERIALS,                     # serial (may be empty)
+                _UNICODE_NAMES,               # physical_id
+            ),
+            min_size=1,
+            max_size=6,
+            unique_by=_stable_id_key,
+        )
+    )
+    runtime_ids = draw(
+        st.lists(
+            _RUNTIME_IDS,
+            min_size=len(identities),
+            max_size=len(identities),
+            unique=True,
+        )
+    )
+    return [
+        SimpleNamespace(
+            id=runtime_id,
+            model=model,
+            address=draw(_ADDRESSES),
+            physical_id=physical_id,
+            protocol=draw(_PROTOCOLS),
+            serial=serial,
+            vendor=vendor,
+        )
+        for runtime_id, (vendor, model, serial, physical_id) in zip(
+            runtime_ids, identities
+        )
+    ]
+
+
+def _identity_fields(raw):
+    """The full Aravis identity of a fake bus camera, keyed by the
+    DiscoveredAravisCamera field names."""
+    return {
+        "camera_id": raw.id,
+        "model": raw.model,
+        "address": raw.address,
+        "physical_id": raw.physical_id,
+        "protocol": raw.protocol,
+        "serial": raw.serial,
+        "vendor": raw.vendor,
+    }
+
+
+def _captured_fields(camera: DiscoveredAravisCamera):
+    return {
+        "camera_id": camera.camera_id,
+        "model": camera.model,
+        "address": camera.address,
+        "physical_id": camera.physical_id,
+        "protocol": camera.protocol,
+        "serial": camera.serial,
+        "vendor": camera.vendor,
+    }
+
+
+# --- properties ---------------------------------------------------------------
+
+
+@given(bus=_fake_buses())
+def test_every_camera_enumerated_exactly_once_with_all_identity_fields(bus):
+    """**Feature: aravis-camera-input, Property 2: Aravis discovery
+    enumeration completeness with identity capture**
+
+    **Validates: Requirements 2.1, 2.3**
+    """
+    result = enumerate_aravis(lambda: list(bus))
+
+    assert result.failures == []
+    # Exactly one enumerated camera per bus camera.
+    assert len(result.cameras) == len(bus)
+
+    by_camera_id = {camera.camera_id: camera for camera in result.cameras}
+    assert len(by_camera_id) == len(bus)
+
+    for raw in bus:
+        camera = by_camera_id[raw.id]
+        # All identity fields captured verbatim (2.3).
+        assert _captured_fields(camera) == _identity_fields(raw)
+        assert camera.stable_id == aravis_stable_id(
+            raw.vendor, raw.model, raw.serial, raw.physical_id
+        )
+
+
+@given(bus=_fake_buses())
+def test_every_camera_contributes_exactly_one_tracked_snapshot_entry(bus):
+    """**Feature: aravis-camera-input, Property 2: Aravis discovery
+    enumeration completeness with identity capture**
+
+    **Validates: Requirements 2.1, 2.3**
+    """
+    discovery = CameraDiscovery(
+        v4l2_io=FakeV4l2Io({}), aravis_enumerator=lambda: list(bus)
+    )
+    snapshot = discovery.run_once()
+
+    assert snapshot.failures == ()
+    # Exactly one tracked entry per bus camera, keyed by its stable id.
+    assert set(snapshot.cameras) == {
+        aravis_stable_id(raw.vendor, raw.model, raw.serial, raw.physical_id)
+        for raw in bus
+    }
+    assert len(snapshot.cameras) == len(bus)
+
+    by_camera_id = {
+        entry.camera.camera_id: entry for entry in snapshot.cameras.values()
+    }
+    for raw in bus:
+        entry = by_camera_id[raw.id]
+        assert isinstance(entry.camera, DiscoveredAravisCamera)
+        assert _captured_fields(entry.camera) == _identity_fields(raw)
+        assert entry.absent is False
+
+
+@given(bus=_fake_buses())
+def test_discovered_only_entries_carry_type_origin_and_identity(bus):
+    """**Feature: aravis-camera-input, Property 2: Aravis discovery
+    enumeration completeness with identity capture**
+
+    **Validates: Requirements 2.1, 2.3**
+    """
+    discovery = CameraDiscovery(
+        v4l2_io=FakeV4l2Io({}), aravis_enumerator=lambda: list(bus)
+    )
+    snapshot = discovery.run_once()
+
+    # No configured Image_Sources: every camera is a discovered-only entry.
+    entries = build_inventory([], snapshot)
+
+    # Exactly one inventory entry per bus camera (2.1).
+    assert len(entries) == len(bus)
+    assert {entry.camera_source_id for entry in entries} == {
+        aravis_stable_id(raw.vendor, raw.model, raw.serial, raw.physical_id)
+        for raw in bus
+    }
+
+    by_camera_id = {entry.params["cameraId"]: entry for entry in entries}
+    for raw in bus:
+        entry = by_camera_id[raw.id]
+
+        # Discovered-only typing (2.1).
+        assert entry.type == TYPE_ARAVIS_DISCOVERED
+        assert entry.origin == ORIGIN_EDGE_DISCOVERED
+        assert entry.discovered is True
+
+        # Parameters and capability metadata carry the full identity (2.3).
+        assert entry.params == {
+            "cameraId": raw.id,
+            "serial": raw.serial,
+            "protocol": raw.protocol,
+            "address": raw.address,
+        }
+        assert entry.capabilities == {
+            "aravis": {
+                "model": raw.model,
+                "address": raw.address,
+                "physicalId": raw.physical_id,
+                "protocol": raw.protocol,
+                "serial": raw.serial,
+                "vendor": raw.vendor,
+            }
+        }

--- a/test/backend-test/camera_discovery/test_property_aravis_stable_id.py
+++ b/test/backend-test/camera_discovery/test_property_aravis_stable_id.py
@@ -1,0 +1,199 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property test for the Aravis stable Camera_Source id derivation.
+
+**Feature: aravis-camera-input, Property 3: Aravis stable id determinism**
+
+*For any* Aravis camera identity (vendor, model, serial), the derived
+stable id SHALL be a pure function of those fields — invariant under bus
+enumeration order, runtime id changes, and address changes — and distinct
+identities within an enumeration SHALL derive distinct stable ids.
+
+Exercised both directly on the pure :func:`camera_discovery.aravis
+.aravis_stable_id` derivation and end-to-end through
+:func:`camera_discovery.aravis.enumerate_aravis` over fake buses whose
+runtime attributes (Aravis runtime id, address, protocol) and enumeration
+order are re-randomized between passes.
+
+**Validates: Requirements 2.2**
+
+Runs with the hypothesis profiles registered in the root conftest
+(``fast`` = 25 examples locally, ``HYPOTHESIS_PROFILE=ci`` = 100).
+"""
+from types import SimpleNamespace
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from camera_discovery.aravis import (
+    STABLE_ID_PREFIX,
+    aravis_stable_id,
+    enumerate_aravis,
+)
+
+# --- generators --------------------------------------------------------------
+
+# Printable ASCII excluding "|", matching real GenICam vendor/model/serial
+# strings (the derivation joins its identity fields with "|", and no bus
+# reports a pipe inside an identity field).
+_TEXT_ALPHABET = st.characters(
+    min_codepoint=32, max_codepoint=126, exclude_characters="|"
+)
+
+_VENDORS = st.text(alphabet=_TEXT_ALPHABET, min_size=1, max_size=24)
+_MODELS = st.text(alphabet=_TEXT_ALPHABET, min_size=1, max_size=24)
+_SERIALS = st.text(alphabet=_TEXT_ALPHABET, max_size=24)  # may be empty (2.2 fallback)
+_PHYSICAL_IDS = st.text(alphabet=_TEXT_ALPHABET, min_size=1, max_size=24)
+
+# Bus-stable identity: (vendor, model, serial, physical_id).
+_IDENTITIES = st.tuples(_VENDORS, _MODELS, _SERIALS, _PHYSICAL_IDS)
+
+# Runtime attributes the Aravis bus does NOT keep stable across reconnects.
+_RUNTIME_IDS = st.text(alphabet=_TEXT_ALPHABET, min_size=1, max_size=32)
+_ADDRESSES = st.text(alphabet=_TEXT_ALPHABET, max_size=32)
+_PROTOCOLS = st.sampled_from(["GigEVision", "USB3Vision", "Fake"])
+
+
+def _identity_key(identity):
+    """The bus-stable identity the derivation keys on.
+
+    ``physical_id`` participates only through the empty-serial fallback,
+    so two identities differing only in ``physical_id`` while carrying the
+    same non-empty serial are the SAME identity to the derivation.
+    """
+    vendor, model, serial, physical_id = identity
+    if serial:
+        return (vendor, model, serial)
+    return (vendor, model, serial, physical_id)
+
+
+# Distinct identities as an enumeration would report them.
+_ENUMERATED_IDENTITIES = st.lists(
+    _IDENTITIES, min_size=1, max_size=6, unique_by=_identity_key
+)
+
+
+@st.composite
+def _fake_bus_passes(draw):
+    """Two enumeration passes over the same identities where everything
+    non-identity changes between passes: enumeration order, Aravis runtime
+    id, address, and protocol."""
+    identities = draw(_ENUMERATED_IDENTITIES)
+
+    def fake_pass(ordered):
+        return [
+            SimpleNamespace(
+                id=draw(_RUNTIME_IDS),
+                model=model,
+                address=draw(_ADDRESSES),
+                physical_id=physical_id,
+                protocol=draw(_PROTOCOLS),
+                serial=serial,
+                vendor=vendor,
+            )
+            for vendor, model, serial, physical_id in ordered
+        ]
+
+    first = fake_pass(identities)
+    second = fake_pass(draw(st.permutations(identities)))
+    return identities, first, second
+
+
+# --- properties ---------------------------------------------------------------
+
+
+@given(identity=_IDENTITIES, other_physical_id=_PHYSICAL_IDS)
+def test_stable_id_is_a_pure_function_of_the_identity_fields(
+    identity, other_physical_id
+):
+    """**Feature: aravis-camera-input, Property 3: Aravis stable id
+    determinism**
+
+    **Validates: Requirements 2.2**
+    """
+    vendor, model, serial, physical_id = identity
+
+    stable_id = aravis_stable_id(vendor, model, serial, physical_id)
+
+    # Deterministic: re-deriving the same identity yields the same id.
+    assert aravis_stable_id(vendor, model, serial, physical_id) == stable_id
+
+    # Shape: arv- prefix followed by a 12-hex-digit digest.
+    assert stable_id.startswith(STABLE_ID_PREFIX)
+    digest = stable_id[len(STABLE_ID_PREFIX):]
+    assert len(digest) == 12
+    assert all(char in "0123456789abcdef" for char in digest)
+
+    if serial:
+        # With a serial present the id is a function of (vendor, model,
+        # serial) only — physical_id never participates.
+        assert aravis_stable_id(vendor, model, serial, other_physical_id) == stable_id
+    elif other_physical_id != physical_id:
+        # Empty-serial fallback: physical_id keeps two serial-less
+        # cameras of the same vendor/model distinct.
+        assert aravis_stable_id(vendor, model, serial, other_physical_id) != stable_id
+
+
+@given(bus=_fake_bus_passes())
+def test_stable_id_invariant_under_bus_order_runtime_id_and_address_changes(bus):
+    """**Feature: aravis-camera-input, Property 3: Aravis stable id
+    determinism**
+
+    **Validates: Requirements 2.2**
+    """
+    identities, first_pass, second_pass = bus
+
+    first = enumerate_aravis(lambda: first_pass)
+    second = enumerate_aravis(lambda: second_pass)
+    assert first.failures == []
+    assert second.failures == []
+    assert len(first.cameras) == len(second.cameras) == len(identities)
+
+    def ids_by_identity(result):
+        return {
+            _identity_key(
+                (camera.vendor, camera.model, camera.serial, camera.physical_id)
+            ): camera.stable_id
+            for camera in result.cameras
+        }
+
+    first_ids = ids_by_identity(first)
+    second_ids = ids_by_identity(second)
+
+    # Invariance: the identity -> stable id mapping survives enumeration
+    # reordering and runtime id / address / protocol churn (2.2).
+    assert first_ids == second_ids
+
+    # The enumerated id equals the pure derivation of the identity fields
+    # alone — runtime attributes cannot have participated.
+    for camera in first.cameras:
+        assert camera.stable_id == aravis_stable_id(
+            camera.vendor, camera.model, camera.serial, camera.physical_id
+        )
+
+
+@given(bus=_fake_bus_passes())
+def test_distinct_identities_within_an_enumeration_derive_distinct_ids(bus):
+    """**Feature: aravis-camera-input, Property 3: Aravis stable id
+    determinism**
+
+    **Validates: Requirements 2.2**
+    """
+    identities, first_pass, _ = bus
+
+    result = enumerate_aravis(lambda: first_pass)
+    assert result.failures == []
+
+    stable_ids = [camera.stable_id for camera in result.cameras]
+    assert len(set(stable_ids)) == len(identities)

--- a/test/backend-test/camera_sync/test_build_inventory_aravis.py
+++ b/test/backend-test/camera_sync/test_build_inventory_aravis.py
@@ -1,0 +1,342 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the Aravis branch of the ``build_inventory`` merge.
+
+Feature: aravis-camera-input (Requirements 2.1, 2.3, 2.4, 7.2).
+"""
+from camera_discovery import (
+    DiscoveredAravisCamera,
+    DiscoveredCamera,
+    DiscoveryResult,
+    InventorySnapshot,
+    TrackedCamera,
+    aravis_stable_id,
+)
+from camera_sync import (
+    ORIGIN_EDGE_CONFIGURED,
+    ORIGIN_EDGE_DISCOVERED,
+    TYPE_ARAVIS_DISCOVERED,
+    CameraSourceState,
+    build_inventory,
+)
+
+
+def make_aravis_camera(camera_id="Aravis-Fake-GV01", model="Fake GV",
+                       address="192.168.1.20", physical_id="eth0",
+                       protocol="GigEVision", serial="SN-0001",
+                       vendor="Aravis"):
+    return DiscoveredAravisCamera(
+        stable_id=aravis_stable_id(vendor, model, serial, physical_id),
+        camera_id=camera_id,
+        model=model,
+        address=address,
+        physical_id=physical_id,
+        protocol=protocol,
+        serial=serial,
+        vendor=vendor,
+    )
+
+
+def make_v4l2_camera(stable_id="disc-000000000001", device_path="/dev/video0",
+                     card_name="Fake Cam", bus_info="usb-0000:00:14.0-1",
+                     driver="uvcvideo", kind="v4l2", formats=None):
+    return DiscoveredCamera(
+        stable_id=stable_id,
+        device_path=device_path,
+        card_name=card_name,
+        bus_info=bus_info,
+        driver=driver,
+        kind=kind,
+        formats=formats if formats is not None else [
+            {"pixel_format": "YUYV", "resolutions": [[1920, 1080], [1280, 720]]}
+        ],
+    )
+
+
+def make_camera_image_source(image_source_id="is-1", name="Line 1 cam",
+                             camera_id="Aravis-Fake-GV01", type_="Camera",
+                             gain=4, exposure=5000000):
+    return {
+        "imageSourceId": image_source_id,
+        "name": name,
+        "type": type_,
+        "cameraId": camera_id,
+        "imageSourceConfiguration": {"gain": gain, "exposure": exposure},
+    }
+
+
+class TestConfiguredAravisMergeByCameraId:
+    def test_camera_id_match_merges_into_one_configured_entry(self):
+        """Requirement 2.4: configured Camera + discovered Aravis by
+        cameraId -> ONE entry under cfg-{imageSourceId}."""
+        camera = make_aravis_camera()
+        source = make_camera_image_source(camera_id=camera.camera_id)
+
+        entries = build_inventory([source], DiscoveryResult(cameras=[camera]))
+
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.camera_source_id == "cfg-is-1"
+        assert entry.type == "Camera"
+        assert entry.origin == ORIGIN_EDGE_CONFIGURED
+        assert entry.discovered is True
+        assert entry.absent is False
+        # Configured params retained (cameraId, gain, exposure).
+        assert entry.params["cameraId"] == camera.camera_id
+        assert entry.params["gain"] == 4
+        assert entry.params["exposure"] == 5000000
+        # Discovered identity metadata under capabilities.aravis.
+        assert entry.capabilities["aravis"] == {
+            "model": "Fake GV",
+            "address": "192.168.1.20",
+            "physicalId": "eth0",
+            "protocol": "GigEVision",
+            "serial": "SN-0001",
+            "vendor": "Aravis",
+        }
+
+    def test_merged_camera_contributes_to_exactly_one_entry(self):
+        camera = make_aravis_camera()
+        source = make_camera_image_source(camera_id=camera.camera_id)
+
+        entries = build_inventory([source], DiscoveryResult(cameras=[camera]))
+
+        ids = [entry.camera_source_id for entry in entries]
+        assert camera.stable_id not in ids  # merged, not duplicated
+        assert len(ids) == len(set(ids))
+
+    def test_non_matching_camera_id_reports_separately(self):
+        camera = make_aravis_camera()
+        source = make_camera_image_source(camera_id="Other-Camera-99")
+
+        entries = build_inventory([source], DiscoveryResult(cameras=[camera]))
+
+        by_id = {entry.camera_source_id: entry for entry in entries}
+        assert set(by_id) == {"cfg-is-1", camera.stable_id}
+        assert by_id["cfg-is-1"].discovered is False
+        assert by_id["cfg-is-1"].capabilities == {}
+
+    def test_non_camera_type_source_never_merges_by_camera_id(self):
+        camera = make_aravis_camera()
+        source = make_camera_image_source(
+            camera_id=camera.camera_id, type_="Folder"
+        )
+
+        entries = build_inventory([source], DiscoveryResult(cameras=[camera]))
+
+        by_id = {entry.camera_source_id: entry for entry in entries}
+        assert set(by_id) == {"cfg-is-1", camera.stable_id}
+        assert by_id["cfg-is-1"].discovered is False
+
+
+class TestDiscoveredOnlyAravisEntry:
+    def test_discovered_only_entry_shape(self):
+        """Requirements 2.1, 2.3: unmerged Aravis camera -> AravisDiscovered
+        / edge-discovered entry with identity params and capabilities."""
+        camera = make_aravis_camera()
+
+        entries = build_inventory([], DiscoveryResult(cameras=[camera]))
+
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.camera_source_id == camera.stable_id
+        assert entry.camera_source_id.startswith("arv-")
+        assert entry.name == "Aravis Fake GV"
+        assert entry.type == TYPE_ARAVIS_DISCOVERED
+        assert entry.origin == ORIGIN_EDGE_DISCOVERED
+        assert entry.discovered is True
+        assert entry.absent is False
+        assert entry.absent_since is None
+        assert entry.params == {
+            "cameraId": "Aravis-Fake-GV01",
+            "serial": "SN-0001",
+            "protocol": "GigEVision",
+            "address": "192.168.1.20",
+        }
+        assert entry.capabilities == {
+            "aravis": {
+                "model": "Fake GV",
+                "address": "192.168.1.20",
+                "physicalId": "eth0",
+                "protocol": "GigEVision",
+                "serial": "SN-0001",
+                "vendor": "Aravis",
+            }
+        }
+
+    def test_absent_state_propagates_from_snapshot(self):
+        camera = make_aravis_camera()
+        snapshot = InventorySnapshot(
+            cameras={
+                camera.stable_id: TrackedCamera(
+                    camera=camera, absent=True, absent_since=1729990000000
+                )
+            }
+        )
+
+        entries = build_inventory([], snapshot)
+
+        assert len(entries) == 1
+        assert entries[0].absent is True
+        assert entries[0].absent_since == 1729990000000
+
+    def test_absent_state_propagates_into_merged_configured_entry(self):
+        camera = make_aravis_camera()
+        source = make_camera_image_source(camera_id=camera.camera_id)
+        snapshot = InventorySnapshot(
+            cameras={
+                camera.stable_id: TrackedCamera(
+                    camera=camera, absent=True, absent_since=1729990000000
+                )
+            }
+        )
+
+        entries = build_inventory([source], snapshot)
+
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.camera_source_id == "cfg-is-1"
+        assert entry.discovered is True
+        assert entry.absent is True
+        assert entry.absent_since == 1729990000000
+
+
+class TestNoAravisOutputIdentity:
+    def test_no_aravis_inputs_produce_pre_feature_output(self):
+        """Requirement 7.2: expectation captured from the pre-feature
+        build_inventory behavior for the same configured + V4L2 inputs."""
+        present = make_v4l2_camera()
+        gone = make_v4l2_camera(
+            stable_id="disc-000000000002",
+            device_path="/dev/video2",
+            card_name="Gone Cam",
+            bus_info="usb-0000:00:14.0-2",
+            formats=[],
+        )
+        sources = [
+            {
+                "imageSourceId": "is-1",
+                "name": "Line 1 cam",
+                "type": "Camera",
+                "cameraId": "cam-1",
+                "imageSourceConfiguration": {
+                    "gain": 4, "exposure": 5000000, "device": "/dev/video0"
+                },
+            },
+            {
+                "imageSourceId": "is-2",
+                "name": "Folder source",
+                "type": "Folder",
+                "imageSourceConfiguration": {},
+            },
+        ]
+        snapshot = InventorySnapshot(
+            cameras={
+                present.stable_id: TrackedCamera(camera=present),
+                gone.stable_id: TrackedCamera(
+                    camera=gone, absent=True, absent_since=1729990000000
+                ),
+            }
+        )
+
+        entries = build_inventory(sources, snapshot)
+
+        # Captured verbatim from the pre-feature implementation's output.
+        assert entries == [
+            CameraSourceState(
+                camera_source_id="cfg-is-1",
+                name="Line 1 cam",
+                type="Camera",
+                origin="edge-configured",
+                params={
+                    "devicePath": "/dev/video0",
+                    "cameraId": "cam-1",
+                    "gain": 4,
+                    "exposure": 5000000,
+                },
+                capabilities={
+                    "formats": [
+                        {
+                            "pixelFormat": "YUYV",
+                            "resolutions": [[1920, 1080], [1280, 720]],
+                        }
+                    ],
+                    "driver": "uvcvideo",
+                    "busInfo": "usb-0000:00:14.0-1",
+                    "kind": "v4l2",
+                },
+                discovered=True,
+                absent=False,
+                absent_since=None,
+            ),
+            CameraSourceState(
+                camera_source_id="cfg-is-2",
+                name="Folder source",
+                type="Folder",
+                origin="edge-configured",
+                params={},
+                capabilities={},
+                discovered=False,
+                absent=False,
+                absent_since=None,
+            ),
+            CameraSourceState(
+                camera_source_id="disc-000000000002",
+                name="Gone Cam",
+                type="V4L2Discovered",
+                origin="edge-discovered",
+                params={"devicePath": "/dev/video2"},
+                capabilities={
+                    "formats": [],
+                    "driver": "uvcvideo",
+                    "busInfo": "usb-0000:00:14.0-2",
+                    "kind": "v4l2",
+                },
+                discovered=True,
+                absent=True,
+                absent_since=1729990000000,
+            ),
+        ]
+
+
+class TestMixedFamilies:
+    def test_v4l2_and_aravis_families_report_side_by_side(self):
+        """Aravis entries join the inventory without disturbing the V4L2
+        path merge; every discovered camera contributes exactly once."""
+        v4l2_camera = make_v4l2_camera()
+        aravis_camera = make_aravis_camera()
+        v4l2_source = {
+            "imageSourceId": "is-1",
+            "name": "V4L2 cam",
+            "type": "Camera",
+            "cameraId": "cam-1",
+            "imageSourceConfiguration": {"device": "/dev/video0"},
+        }
+        aravis_source = make_camera_image_source(
+            image_source_id="is-2",
+            name="GenICam cam",
+            camera_id=aravis_camera.camera_id,
+        )
+
+        entries = build_inventory(
+            [v4l2_source, aravis_source],
+            DiscoveryResult(cameras=[v4l2_camera, aravis_camera]),
+        )
+
+        by_id = {entry.camera_source_id: entry for entry in entries}
+        assert set(by_id) == {"cfg-is-1", "cfg-is-2"}
+        assert by_id["cfg-is-1"].capabilities["driver"] == "uvcvideo"
+        assert "aravis" not in by_id["cfg-is-1"].capabilities
+        assert by_id["cfg-is-2"].capabilities["aravis"]["vendor"] == "Aravis"
+        assert all(entry.discovered for entry in entries)

--- a/test/backend-test/camera_sync/test_property_aravis_configured_discovered_merge.py
+++ b/test/backend-test/camera_sync/test_property_aravis_configured_discovered_merge.py
@@ -1,0 +1,230 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property test for the Aravis branch of the ``build_inventory`` merge.
+
+**Feature: aravis-camera-input, Property 4: Configured/discovered Aravis
+merge by camera id**
+
+*For any* combination of configured Image_Sources and discovered Aravis
+cameras, each ``Camera``-type Image_Source whose ``cameraId`` equals a
+discovered camera's id SHALL yield exactly one inventory entry under the
+configured identifier combining configured parameters with discovered
+identity metadata, and no discovered Aravis camera SHALL contribute to
+more than one entry.
+
+**Validates: Requirements 2.4**
+
+Generators mirror the real input space (same conventions as the sibling
+V4L2 merge property in test_property_configured_discovered_merge.py):
+Image_Source ids are unique (SQLite primary keys) and each source
+references at most one camera id; the Aravis bus reports at most one
+camera per runtime id, with identities unique by the stable id they
+derive. Camera ids are drawn from a small shared pool so configured /
+discovered cameraId overlap occurs frequently.
+
+Runs with the hypothesis profiles registered in the root conftest
+(``fast`` = 25 examples locally, ``HYPOTHESIS_PROFILE=ci`` = 100).
+"""
+from hypothesis import given
+from hypothesis import strategies as st
+
+from camera_discovery import DiscoveredAravisCamera, DiscoveryResult, aravis_stable_id
+from camera_sync import (
+    ORIGIN_EDGE_CONFIGURED,
+    ORIGIN_EDGE_DISCOVERED,
+    TYPE_ARAVIS_DISCOVERED,
+    build_inventory,
+)
+
+# --- generators --------------------------------------------------------------
+
+# Small shared camera-id pool so configured and discovered ids collide often.
+_CAMERA_IDS = st.integers(min_value=0, max_value=9).map(
+    lambda n: "cam-{}".format(n)
+)
+
+# Full-unicode identity strings: real GenICam vendors/models are not
+# ASCII-only (same alphabet as the discovery-side Aravis property tests).
+_NAMES = st.text(min_size=1, max_size=24)
+_SERIALS = st.text(max_size=24)  # may be empty (serial-less cameras)
+_ADDRESSES = st.text(max_size=32)
+_PROTOCOLS = st.sampled_from(["GigEVision", "USB3Vision", "Fake"])
+
+_SOURCE_NAMES = st.text(
+    alphabet=st.characters(min_codepoint=32, max_codepoint=126),
+    min_size=1,
+    max_size=31,
+)
+
+
+def _stable_id_key(identity):
+    """Uniqueness key: the stable id an identity tuple derives."""
+    vendor, model, serial, physical_id = identity
+    return aravis_stable_id(vendor, model, serial, physical_id)
+
+
+@st.composite
+def _discovered_aravis_cameras(draw):
+    """Discovered Aravis cameras with unique runtime camera ids (drawn
+    from the shared pool) and identities unique by derived stable id."""
+    camera_ids = draw(st.lists(_CAMERA_IDS, unique=True, max_size=5))
+    identities = draw(
+        st.lists(
+            st.tuples(_NAMES, _NAMES, _SERIALS, _NAMES),
+            min_size=len(camera_ids),
+            max_size=len(camera_ids),
+            unique_by=_stable_id_key,
+        )
+    )
+    return [
+        DiscoveredAravisCamera(
+            stable_id=aravis_stable_id(vendor, model, serial, physical_id),
+            camera_id=camera_id,
+            model=model,
+            address=draw(_ADDRESSES),
+            physical_id=physical_id,
+            protocol=draw(_PROTOCOLS),
+            serial=serial,
+            vendor=vendor,
+        )
+        for camera_id, (vendor, model, serial, physical_id) in zip(
+            camera_ids, identities
+        )
+    ]
+
+
+@st.composite
+def _image_sources(draw):
+    """Configured Image_Sources with unique ids, each referencing one
+    camera id (unique among the sources, drawn from the shared pool).
+    Types mix ``Camera`` (Aravis-backed, merge-eligible) with other
+    source types that must never merge by camera id."""
+    camera_ids = draw(st.lists(_CAMERA_IDS, unique=True, max_size=4))
+    sources = []
+    for index, camera_id in enumerate(camera_ids):
+        configuration = {}
+        if draw(st.booleans()):
+            configuration["gain"] = draw(st.integers(min_value=0, max_value=100))
+        if draw(st.booleans()):
+            configuration["exposure"] = draw(
+                st.integers(min_value=1, max_value=10_000_000)
+            )
+        sources.append(
+            {
+                "imageSourceId": "is-{}".format(index),
+                "name": draw(_SOURCE_NAMES),
+                "type": draw(st.sampled_from(["Camera", "Folder"])),
+                "cameraId": camera_id,
+                "imageSourceConfiguration": configuration,
+            }
+        )
+    return sources
+
+
+def _identity(camera):
+    """The discovered identity metadata ``build_inventory`` reports under
+    ``capabilities.aravis``."""
+    return {
+        "model": camera.model,
+        "address": camera.address,
+        "physicalId": camera.physical_id,
+        "protocol": camera.protocol,
+        "serial": camera.serial,
+        "vendor": camera.vendor,
+    }
+
+
+# --- property ----------------------------------------------------------------
+
+
+@given(sources=_image_sources(), cameras=_discovered_aravis_cameras())
+def test_configured_discovered_aravis_merge_by_camera_id(sources, cameras):
+    """**Feature: aravis-camera-input, Property 4: Configured/discovered
+    Aravis merge by camera id**
+
+    **Validates: Requirements 2.4**
+    """
+    entries = build_inventory(sources, DiscoveryResult(cameras=cameras))
+
+    cameras_by_id = {camera.camera_id: camera for camera in cameras}
+    matched_camera_ids = {
+        source["cameraId"]
+        for source in sources
+        if source["type"] == "Camera"
+    } & set(cameras_by_id)
+
+    # One entry per merged configured/discovered pair, plus one per
+    # unmatched member of either set.
+    assert len(entries) == len(sources) + len(cameras) - len(matched_camera_ids)
+
+    by_id = {entry.camera_source_id: entry for entry in entries}
+    assert len(by_id) == len(entries)  # ids are unique
+
+    # Every configured Image_Source reports under its cfg- id carrying its
+    # configured parameters.
+    for source in sources:
+        entry = by_id["cfg-" + source["imageSourceId"]]
+        configuration = source["imageSourceConfiguration"]
+
+        assert entry.origin == ORIGIN_EDGE_CONFIGURED
+        assert entry.name == source["name"]
+        assert entry.type == source["type"]
+        assert entry.params.get("cameraId") == source["cameraId"]
+        if "gain" in configuration:
+            assert entry.params["gain"] == configuration["gain"]
+        if "exposure" in configuration:
+            assert entry.params["exposure"] == configuration["exposure"]
+
+        if source["type"] == "Camera" and source["cameraId"] in cameras_by_id:
+            # cameraId match: exactly ONE entry under the configured
+            # identifier, combining configured parameters with the
+            # discovered identity metadata (2.4).
+            camera = cameras_by_id[source["cameraId"]]
+            assert entry.discovered is True
+            assert entry.capabilities == {"aravis": _identity(camera)}
+            assert entry.absent is False
+            assert entry.absent_since is None
+        else:
+            # Non-matching (or non-Camera-type) configured source reports
+            # undiscovered, with no discovered metadata attached.
+            assert entry.discovered is False
+            assert entry.capabilities == {}
+
+    # No discovered Aravis camera contributes to more than one entry: a
+    # merged camera never also reports under its stable id, an unmerged
+    # camera reports exactly once as a discovered-only entry, and each
+    # camera's identity metadata appears in exactly one entry.
+    for camera in cameras:
+        if camera.camera_id in matched_camera_ids:
+            assert camera.stable_id not in by_id
+        else:
+            entry = by_id[camera.stable_id]
+            assert entry.type == TYPE_ARAVIS_DISCOVERED
+            assert entry.origin == ORIGIN_EDGE_DISCOVERED
+            assert entry.name == "{} {}".format(camera.vendor, camera.model)
+            assert entry.discovered is True
+            assert entry.params == {
+                "cameraId": camera.camera_id,
+                "serial": camera.serial,
+                "protocol": camera.protocol,
+                "address": camera.address,
+            }
+            assert entry.capabilities == {"aravis": _identity(camera)}
+
+        contributions = [
+            entry
+            for entry in entries
+            if entry.capabilities.get("aravis") == _identity(camera)
+        ]
+        assert len(contributions) == 1

--- a/test/backend-test/camera_sync/test_property_aravis_failure_isolation.py
+++ b/test/backend-test/camera_sync/test_property_aravis_failure_isolation.py
@@ -1,0 +1,189 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property test for Aravis failure isolation and no-Aravis identity.
+
+**Feature: aravis-camera-input, Property 6: Aravis failure isolation and
+no-Aravis identity**
+
+*For any* configured and V4L2-discovered inventory, building the inventory
+with a failing or unavailable Aravis enumerator SHALL produce entries
+identical to the pre-feature output for the same inputs, record the
+failure, and raise no exception.
+
+**Validates: Requirements 2.6, 7.2**
+
+The failing pass runs the REAL discovery layer (``CameraDiscovery`` over
+the fake V4L2 ioctl layer with a raising Aravis enumerator) into the REAL
+``build_inventory``. The pre-feature oracle is ``build_inventory`` over a
+snapshot produced from the identical V4L2 devices with an Aravis
+enumerator returning zero cameras — by Requirement 7.2 (pinned verbatim by
+test_build_inventory_aravis.py's no-Aravis identity test) that output is
+the pre-feature output for the same configured + V4L2 inputs.
+
+Runs with the hypothesis profiles registered in the root conftest
+(``fast`` = 25 examples locally, ``HYPOTHESIS_PROFILE=ci`` = 100).
+"""
+import sys
+from pathlib import Path
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from camera_discovery import CameraDiscovery
+from camera_sync import build_inventory
+
+# The fake V4L2 ioctl layer lives beside the camera_discovery suites
+# (test/backend-test/camera_discovery is not a package, so pytest's
+# rootdir-based sys.path insertion does not cover it from here).
+_FAKES_DIR = str(Path(__file__).resolve().parent.parent / "camera_discovery")
+if _FAKES_DIR not in sys.path:
+    sys.path.insert(0, _FAKES_DIR)
+
+from fake_v4l2 import FakeDevice, FakeV4l2Io  # noqa: E402
+
+# --- generators --------------------------------------------------------------
+
+# Small shared path pool so configured and discovered paths collide often
+# (same convention as test_property_configured_discovered_merge.py).
+_DEVICE_PATHS = st.integers(min_value=0, max_value=9).map(
+    lambda n: "/dev/video{}".format(n)
+)
+
+# ASCII identity strings: the V4L2 capability struct fields are fixed-size
+# 32-byte buffers.
+_TEXT = st.text(
+    alphabet=st.characters(min_codepoint=32, max_codepoint=126),
+    min_size=1,
+    max_size=31,
+)
+
+_FOURCCS = st.sampled_from(["YUYV", "MJPG", "NV12", "RG10"])
+
+_RESOLUTIONS = st.lists(
+    st.tuples(
+        st.integers(min_value=1, max_value=8192),
+        st.integers(min_value=1, max_value=8192),
+    ),
+    min_size=1,
+    max_size=3,
+    unique=True,
+)
+
+
+@st.composite
+def _fake_devices(draw):
+    """A ``{path: FakeDevice}`` map of capture nodes with unique device
+    paths and unique bus infos (hence unique discovery stable ids)."""
+    paths = draw(st.lists(_DEVICE_PATHS, unique=True, max_size=4))
+    devices = {}
+    for index, path in enumerate(paths):
+        formats = draw(
+            st.lists(
+                st.tuples(_FOURCCS, _RESOLUTIONS),
+                max_size=2,
+                unique_by=lambda fmt: fmt[0],
+            )
+        )
+        devices[path] = FakeDevice(
+            driver=draw(st.sampled_from(["uvcvideo", "tegra-video"])),
+            card=draw(_TEXT),
+            bus_info="usb-0000:00:14.0-{}".format(index),
+            formats=formats,
+        )
+    return devices
+
+
+@st.composite
+def _image_sources(draw):
+    """Configured Image_Sources with unique ids; each references at most
+    one device path (unique among the sources), some reference none."""
+    device_paths = draw(st.lists(_DEVICE_PATHS, unique=True, max_size=4))
+    pathless_count = draw(st.integers(min_value=0, max_value=2))
+    devices = list(device_paths) + [None] * pathless_count
+
+    sources = []
+    for index, device in enumerate(devices):
+        configuration = {}
+        if device is not None:
+            configuration["device"] = device
+        if draw(st.booleans()):
+            configuration["gain"] = draw(st.integers(min_value=0, max_value=48))
+        if draw(st.booleans()):
+            configuration["exposure"] = draw(
+                st.integers(min_value=1, max_value=10_000_000)
+            )
+        sources.append(
+            {
+                "imageSourceId": "is-{}".format(index),
+                "name": draw(_TEXT),
+                "type": draw(st.sampled_from(["Camera", "ICam", "NvidiaCSI"])),
+                "cameraId": draw(_TEXT),
+                "imageSourceConfiguration": configuration,
+            }
+        )
+    return sources
+
+
+# A raising enumerator (bus failure) and an unavailable runtime (the
+# lazy-import failure mode surfaces as ImportError).
+_ERRORS = st.sampled_from(
+    [
+        RuntimeError("aravis bus enumeration failed"),
+        ImportError("No module named 'gi'"),
+    ]
+)
+
+
+# --- property ----------------------------------------------------------------
+
+
+@given(devices=_fake_devices(), sources=_image_sources(), error=_ERRORS)
+def test_aravis_failure_isolation_and_no_aravis_identity(
+    devices, sources, error
+):
+    """**Feature: aravis-camera-input, Property 6: Aravis failure isolation
+    and no-Aravis identity**
+
+    **Validates: Requirements 2.6, 7.2**
+    """
+
+    def raising_enumerator():
+        raise error
+
+    # Discovery pass with the failing/unavailable Aravis enumerator over
+    # the configured + V4L2 inventory. Nothing may raise (2.6).
+    failing_discovery = CameraDiscovery(
+        v4l2_io=FakeV4l2Io(devices), aravis_enumerator=raising_enumerator
+    )
+    snapshot = failing_discovery.run_once()
+
+    # Pre-feature oracle: the identical V4L2 devices with zero Aravis
+    # cameras (Requirement 7.2 makes this the pre-feature output).
+    baseline_discovery = CameraDiscovery(
+        v4l2_io=FakeV4l2Io(devices), aravis_enumerator=lambda: []
+    )
+    baseline_snapshot = baseline_discovery.run_once()
+
+    # The failure is recorded at the discovery layer (2.6); the clean pass
+    # records none.
+    assert {"error": str(error)} in list(snapshot.failures)
+    assert baseline_snapshot.failures == ()
+
+    # The tracked V4L2 inventory is untouched by the Aravis failure.
+    assert snapshot.cameras == baseline_snapshot.cameras
+
+    # The reported inventory is identical to the pre-feature output for
+    # the same configured + V4L2 inputs (7.2).
+    entries = build_inventory(sources, snapshot)
+    assert entries == build_inventory(sources, baseline_snapshot)

--- a/test/backend-test/workflow_engine/test_property_aravis_binding_resolution.py
+++ b/test/backend-test/workflow_engine/test_property_aravis_binding_resolution.py
@@ -1,0 +1,326 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property test for device-side Aravis binding resolution.
+
+**Feature: aravis-camera-input, Property 13: Device-side Aravis binding
+resolution**
+
+*For any* compiled document with Aravis binding points, binding map, and
+local inventory: a ``cameraSourceId`` binding matching an inventory entry
+yields an Aravis assignment whose ``camera_id`` is the entry's camera id
+and leaves the document's segments unchanged; a constraint-valid override
+binding yields an assignment from the override values; a
+``cameraSourceId`` with no inventory entry marks the resolution invalid
+recording the missing id; and a constraint-violating override marks the
+resolution invalid with a reason.
+
+**Validates: Requirements 6.1, 6.2, 6.3**
+
+Generators mirror the real input space: the packager emits one
+``aravisBinding: true`` binding point per Aravis_Camera_Source_Node with
+empty slots and rendered ``camera_id``/``gain``/``exposure`` parameters;
+the local inventory is the ``build_inventory`` merge shape, where an
+Aravis-backed entry's params carry ``cameraId`` (discovered-only
+``AravisDiscovered`` entries with serial/protocol/address, configured
+``Camera`` entries with optional gain/exposure). Overrides are drawn on
+both sides of the vendored aravis_camera_source catalog constraints
+(camera_id ``min_length: 1``, gain ``0-100``, exposure ``min: 0``).
+
+Runs with the hypothesis profiles registered in this directory's conftest
+(``engine-fast`` = 25 examples locally, ``HYPOTHESIS_PROFILE=ci`` = 100).
+"""
+import copy
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from camera_sync import CameraSourceState
+from workflow_engine.camera_binding import (
+    STATUS_INVALID,
+    STATUS_RESOLVED,
+    resolve_bindings,
+)
+
+# --- generators --------------------------------------------------------------
+
+_VALID_GAIN = st.integers(min_value=0, max_value=100)
+_VALID_EXPOSURE = st.integers(min_value=0, max_value=10_000_000)
+
+#: Aravis runtime camera ids as camera_manager connects by.
+_CAMERA_IDS = st.sampled_from(
+    ["Aravis-Fake-GV01", "Basler-12345678", "Allied-9A3F", "Lucid-224400"]
+)
+
+
+@st.composite
+def _inventories(draw):
+    """Local Camera_Source inventories in the ``build_inventory`` shape:
+    unique stable ids, ``cameraId`` always present (the Aravis identity
+    every Aravis-backed entry carries), never a literal ``camera_id`` key
+    and never ``None`` values. Entries are either discovered-only
+    ``AravisDiscovered`` or configured ``Camera`` merges."""
+    entries = []
+    for index in range(draw(st.integers(min_value=0, max_value=3))):
+        camera_id = "{0}-{1}".format(draw(_CAMERA_IDS), index)
+        if draw(st.booleans()):
+            # Discovered-only Aravis entry (identity params from discovery).
+            entries.append(
+                CameraSourceState(
+                    camera_source_id="arv-{:012x}".format(index),
+                    name="Vendor Model {}".format(index),
+                    type="AravisDiscovered",
+                    origin="edge-discovered",
+                    params={
+                        "cameraId": camera_id,
+                        "serial": "SN{:04d}".format(index),
+                        "protocol": draw(st.sampled_from(
+                            ["GigEVision", "USB3Vision", "Fake"])),
+                        "address": "192.168.1.{}".format(10 + index),
+                    },
+                )
+            )
+        else:
+            # Configured Camera-type Image_Source merged by cameraId.
+            params = {"cameraId": camera_id}
+            if draw(st.booleans()):
+                params["gain"] = draw(_VALID_GAIN)
+            if draw(st.booleans()):
+                params["exposure"] = draw(_VALID_EXPOSURE)
+            entries.append(
+                CameraSourceState(
+                    camera_source_id="cfg-is-{}".format(index),
+                    name="Camera {}".format(index),
+                    type="Camera",
+                    origin="edge-configured",
+                    params=params,
+                )
+            )
+    return entries
+
+
+@st.composite
+def _valid_overrides(draw):
+    """Non-empty overrides satisfying every aravis_camera_source
+    constraint (camera_id min_length 1, gain 0-100, exposure >= 0)."""
+    override = {}
+    if draw(st.booleans()):
+        override["camera_id"] = draw(_CAMERA_IDS)
+    if draw(st.booleans()):
+        override["gain"] = draw(_VALID_GAIN)
+    if not override or draw(st.booleans()):
+        override["exposure"] = draw(_VALID_EXPOSURE)
+    return override
+
+
+@st.composite
+def _invalid_overrides(draw):
+    """Overrides violating exactly one aravis_camera_source catalog
+    constraint."""
+    kind = draw(st.sampled_from(
+        ["empty-camera-id", "gain-high", "gain-negative",
+         "exposure-negative", "undeclared"]))
+    if kind == "empty-camera-id":
+        return {"camera_id": ""}
+    if kind == "gain-high":
+        return {"gain": draw(st.integers(min_value=101, max_value=10**6))}
+    if kind == "gain-negative":
+        return {"gain": draw(st.integers(min_value=-(10**6), max_value=-1))}
+    if kind == "exposure-negative":
+        return {"exposure": draw(st.integers(min_value=-(10**6), max_value=-1))}
+    return {"bogus": draw(st.integers(min_value=0, max_value=10))}
+
+
+@st.composite
+def _resolution_cases(draw):
+    """A compiled document with Aravis binding points, a bindings map, a
+    local inventory, and the per-node binding variant used to model the
+    expected outcome."""
+    inventory = draw(_inventories())
+
+    # Document skeleton: rendered segments/elements. Aravis binding
+    # points declare no slots, so every arg must survive resolution
+    # unchanged.
+    segments = []
+    for s in range(draw(st.integers(min_value=1, max_value=3))):
+        elements = []
+        for e in range(draw(st.integers(min_value=1, max_value=3))):
+            elements.append({
+                "type": "appsrc" if e == 0 else "videoconvert",
+                "args": {
+                    "name": "appsrc_n{}-{}".format(s, e),
+                    "extra": "keep-{}-{}".format(s, e),
+                },
+            })
+        segments.append({"elements": elements})
+    document = {"schemaVersion": 1, "segments": segments}
+
+    # Aravis binding points: unique node ids, aravisBinding true, empty
+    # slots, rendered camera_id/gain/exposure parameters (the packager's
+    # defaults-overlaid values).
+    binding_points = []
+    for index in range(draw(st.integers(min_value=1, max_value=4))):
+        binding_points.append({
+            "nodeId": "n{}".format(index),
+            "nodeType": "aravis_camera_source",
+            "aravisBinding": True,
+            "slots": [],
+            "parameters": {
+                "camera_id": draw(_CAMERA_IDS),
+                "gain": draw(_VALID_GAIN),
+                "exposure": draw(_VALID_EXPOSURE),
+            },
+        })
+    document["bindingPoints"] = binding_points
+
+    # Bindings: each Aravis point independently unbound, bound to a
+    # present inventory id, bound to a missing id, or overridden with
+    # valid or constraint-violating values.
+    variant_options = ["unbound", "missing",
+                       "override-valid", "override-invalid"]
+    if inventory:
+        variant_options += ["present", "present"]  # weight toward 6.1
+
+    bindings = {}
+    variants = {}
+    for point in binding_points:
+        node_id = point["nodeId"]
+        variant = draw(st.sampled_from(variant_options))
+        variants[node_id] = variant
+        if variant == "unbound":
+            continue
+        if variant == "present":
+            entry = draw(st.sampled_from(inventory))
+            bindings[node_id] = {"cameraSourceId": entry.camera_source_id}
+        elif variant == "missing":
+            bindings[node_id] = {
+                "cameraSourceId": "arv-gone-{}".format(node_id)}
+        elif variant == "override-valid":
+            bindings[node_id] = {"override": draw(_valid_overrides())}
+        else:
+            bindings[node_id] = {"override": draw(_invalid_overrides())}
+
+    # A stray binding for a node with no binding point must have no effect.
+    if draw(st.booleans()):
+        bindings["stray-node"] = {"cameraSourceId": "arv-gone-stray"}
+
+    return document, bindings, inventory, variants
+
+
+# --- expected-outcome model ---------------------------------------------------
+
+
+def _model_resolved_values(entry):
+    """Requirement 6.1: the bound source's resolved parameter values,
+    with the reported ``cameraId`` resolving the node's ``camera_id``
+    parameter through ``_PARAM_ALIASES``. Exact because the inventory
+    generator never emits ``None`` values or a literal ``camera_id``
+    key."""
+    values = dict(entry.params)
+    values["camera_id"] = values["cameraId"]
+    return values
+
+
+# --- property ----------------------------------------------------------------
+
+
+@given(case=_resolution_cases())
+def test_device_side_aravis_binding_resolution(case):
+    """**Feature: aravis-camera-input, Property 13: Device-side Aravis
+    binding resolution**
+
+    **Validates: Requirements 6.1, 6.2, 6.3**
+    """
+    document, bindings, inventory, variants = case
+    snapshot = copy.deepcopy(document)
+    inventory_by_id = {entry.camera_source_id: entry for entry in inventory}
+
+    result = resolve_bindings(document, bindings, inventory)
+
+    # The input document is never mutated.
+    assert document == snapshot
+
+    # 6.1: Aravis binding points never substitute element arguments —
+    # the resolved document's segments are unchanged (and so is the
+    # whole document, since Aravis points declare no slots).
+    assert result.document["segments"] == snapshot["segments"]
+    assert result.document == snapshot
+
+    # Model the expected outcome per binding point, in document order.
+    expected_missing = []
+    expected_missing_errors = []
+    invalid_override_nodes = []
+    expected_assignments = {}
+
+    for point in snapshot["bindingPoints"]:
+        node_id = point["nodeId"]
+        variant = variants[node_id]
+        if variant == "unbound":
+            continue  # unbound point: rendered parameters run as-is
+        binding = bindings[node_id]
+
+        if variant == "missing":
+            # 6.3: absent id -> invalid with the missing source recorded.
+            camera_source_id = binding["cameraSourceId"]
+            expected_missing.append(
+                {"nodeId": node_id, "cameraSourceId": camera_source_id})
+            expected_missing_errors.append(
+                "missing camera source {}".format(camera_source_id))
+            continue
+        if variant == "override-invalid":
+            # 6.2: constraint-violating override -> invalid with a reason.
+            invalid_override_nodes.append(node_id)
+            continue
+
+        if variant == "present":
+            # 6.1: the entry's resolved values; camera_id is the entry's
+            # Aravis camera id.
+            camera_source_id = binding["cameraSourceId"]
+            values = _model_resolved_values(inventory_by_id[camera_source_id])
+        else:  # override-valid, 6.2: the override values, no lookup.
+            camera_source_id = None
+            values = dict(binding["override"])
+
+        expected_assignments[node_id] = {
+            "cameraSourceId": camera_source_id, "params": values}
+
+    # 6.1 / 6.2: exactly the resolved and overridden Aravis points yield
+    # assignments, and a cameraSourceId assignment's camera_id is the
+    # bound entry's camera id.
+    assert result.aravis_assignments == expected_assignments
+    for node_id, variant in variants.items():
+        if variant == "present":
+            entry = inventory_by_id[bindings[node_id]["cameraSourceId"]]
+            assignment = result.aravis_assignments[node_id]
+            assert assignment["params"]["camera_id"] == entry.params["cameraId"]
+
+    # Aravis points never contribute adapter assignments.
+    assert result.adapter_assignments == {}
+
+    # 6.3: every missing id reported, in binding-point order, with a
+    # reason identifying the missing Camera_Source.
+    assert result.missing == tuple(expected_missing)
+    for error in expected_missing_errors:
+        assert error in result.errors
+
+    # 6.2: each constraint-violating override is reported against its node.
+    for node_id in invalid_override_nodes:
+        assert any("'{}'".format(node_id) in error for error in result.errors)
+
+    # Invalid exactly when something failed to resolve; a resolved result
+    # carries no errors and the registration is runnable.
+    if expected_missing or invalid_override_nodes:
+        assert result.status == STATUS_INVALID
+    else:
+        assert result.status == STATUS_RESOLVED
+        assert result.errors == ()

--- a/test/backend-test/workflow_engine/test_property_aravis_feed_plan_precedence.py
+++ b/test/backend-test/workflow_engine/test_property_aravis_feed_plan_precedence.py
@@ -1,0 +1,223 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property test for Aravis feed plan precedence.
+
+**Feature: aravis-camera-input, Property 14: Aravis feed plan precedence**
+
+*For any* compiled document with Aravis binding points and any optional
+resolution result, the planned feed for each node SHALL use the
+resolution's Aravis assignment values when present and the binding
+point's rendered parameters otherwise.
+
+**Validates: Requirements 6.4**
+
+Generators mirror the real input space: the packager emits exactly one
+``aravisBinding: true`` binding point per Aravis_Camera_Source_Node with
+empty slots and rendered ``camera_id``/``gain``/``exposure`` parameters
+(the single-appsrc Frame_Feed contract admits one Aravis point per
+document), surrounded by any number of non-Aravis binding points; the
+resolution is ``None`` (bindings never resolved), a ``ResolutionResult``
+with no assignment for the node (unbound point), or one carrying an
+Aravis assignment whose params come from the inventory lookup (spelled
+``cameraId``) or a manual override (spelled ``camera_id``), plus stray
+assignments for unrelated node ids.
+
+Runs with the hypothesis profiles registered in this directory's conftest
+(``engine-fast`` = 25 examples locally, ``HYPOTHESIS_PROFILE=ci`` = 100).
+"""
+import copy
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from workflow_engine.aravis_feed import AravisFeed, plan_aravis_feeds
+from workflow_engine.camera_binding import (
+    STATUS_RESOLVED,
+    ResolutionResult,
+)
+
+# --- generators --------------------------------------------------------------
+
+_VALID_GAIN = st.integers(min_value=0, max_value=100)
+_VALID_EXPOSURE = st.integers(min_value=0, max_value=10_000_000)
+
+#: Aravis runtime camera ids as camera_manager connects by.
+_CAMERA_IDS = st.sampled_from(
+    ["Aravis-Fake-GV01", "Basler-12345678", "Allied-9A3F", "Lucid-224400"]
+)
+
+#: Acquisition parameters the executor forwards to the camera manager.
+_CONFIG_PARAMS = ("gain", "exposure")
+
+
+@st.composite
+def _rendered_parameters(draw):
+    """The packager's defaults-overlaid rendered parameter values: a
+    non-empty ``camera_id`` plus optional ``gain``/``exposure``."""
+    parameters = {"camera_id": draw(_CAMERA_IDS)}
+    if draw(st.booleans()):
+        parameters["gain"] = draw(_VALID_GAIN)
+    if draw(st.booleans()):
+        parameters["exposure"] = draw(_VALID_EXPOSURE)
+    return parameters
+
+
+@st.composite
+def _assignment_params(draw):
+    """Resolved Aravis assignment params: the inventory-lookup shape
+    spells the identity ``cameraId`` (build_inventory reported params),
+    the override shape spells it ``camera_id`` (the descriptor's name);
+    both may carry it, in which case ``camera_id`` wins. ``gain`` /
+    ``exposure`` are optional and may be ``None`` (treated as absent)."""
+    params = {}
+    spelling = draw(st.sampled_from(["camera_id", "cameraId", "both"]))
+    if spelling in ("camera_id", "both"):
+        params["camera_id"] = draw(_CAMERA_IDS)
+    if spelling in ("cameraId", "both"):
+        params["cameraId"] = draw(_CAMERA_IDS)
+    for name in _CONFIG_PARAMS:
+        choice = draw(st.sampled_from(["absent", "present", "none"]))
+        if choice == "present":
+            params[name] = draw(_VALID_GAIN if name == "gain"
+                                else _VALID_EXPOSURE)
+        elif choice == "none":
+            params[name] = None
+    return params
+
+
+@st.composite
+def _non_aravis_points(draw):
+    """Binding points of other camera node families — never planned as
+    Aravis feeds."""
+    points = []
+    for index in range(draw(st.integers(min_value=0, max_value=2))):
+        points.append({
+            "nodeId": "v4l2-n{}".format(index),
+            "nodeType": "camera_source",
+            "parameters": {"device": "/dev/video{}".format(index)},
+            "slots": [{"param": "device", "segment": 0,
+                       "element": 0, "arg": "device"}],
+        })
+    return points
+
+
+@st.composite
+def _plan_cases(draw):
+    """A compiled document with exactly one Aravis binding point among
+    optional non-Aravis points, and an optional resolution: ``None``, a
+    resolution without an assignment for the node, or one carrying an
+    Aravis assignment (plus stray assignments for other node ids)."""
+    node_id = "n{}".format(draw(st.integers(min_value=1, max_value=9)))
+    rendered = draw(_rendered_parameters())
+    aravis_point = {
+        "nodeId": node_id,
+        "nodeType": "aravis_camera_source",
+        "parameters": rendered,
+        "slots": [],
+        "aravisBinding": True,
+    }
+
+    points = draw(_non_aravis_points())
+    points.insert(draw(st.integers(min_value=0, max_value=len(points))),
+                  aravis_point)
+    document = {
+        "schemaVersion": 1,
+        "segments": [{"elements": [
+            {"nodeId": node_id, "type": "appsrc",
+             "args": {"name": "appsrc_{}".format(node_id)}},
+            {"nodeId": node_id, "type": "videoconvert", "args": {}},
+        ]}],
+        "bindingPoints": points,
+    }
+
+    variant = draw(st.sampled_from(["none", "no-assignment", "assignment"]))
+    assignment_params = None
+    if variant == "none":
+        resolution = None
+    else:
+        assignments = {}
+        # Stray assignments for unrelated node ids never leak into the
+        # node's plan.
+        if draw(st.booleans()):
+            assignments["other-node"] = {
+                "cameraSourceId": "arv-aaaaaaaaaaaa",
+                "params": {"cameraId": draw(_CAMERA_IDS)},
+            }
+        if variant == "assignment":
+            assignment_params = draw(_assignment_params())
+            # Keep the effective camera id usable: the precedence
+            # property is about which values run, not the error path.
+            if not any(isinstance(assignment_params.get(key), str)
+                       and assignment_params.get(key)
+                       for key in ("camera_id", "cameraId")):
+                assignment_params["camera_id"] = draw(_CAMERA_IDS)
+            assignments[node_id] = {
+                "cameraSourceId": draw(st.one_of(
+                    st.none(), st.just("cfg-is-1"))),
+                "params": assignment_params,
+            }
+        resolution = ResolutionResult(
+            document=document,
+            status=STATUS_RESOLVED,
+            aravis_assignments=assignments,
+        )
+
+    return document, resolution, node_id, rendered, assignment_params
+
+
+# --- expected-outcome model ---------------------------------------------------
+
+
+def _model_feed(node_id, effective):
+    """Requirement 6.4: the feed runs the effective values — camera id
+    from the first non-empty accepted spelling, gain/exposure joining
+    the config exactly when present and not ``None``."""
+    camera_id = None
+    for key in ("camera_id", "cameraId"):
+        value = effective.get(key)
+        if isinstance(value, str) and value:
+            camera_id = value
+            break
+    config = {name: effective[name] for name in _CONFIG_PARAMS
+              if effective.get(name) is not None}
+    return AravisFeed(node_id=node_id, camera_id=camera_id, config=config)
+
+
+# --- property ----------------------------------------------------------------
+
+
+@given(case=_plan_cases())
+def test_aravis_feed_plan_precedence(case):
+    """**Feature: aravis-camera-input, Property 14: Aravis feed plan
+    precedence**
+
+    **Validates: Requirements 6.4**
+    """
+    document, resolution, node_id, rendered, assignment_params = case
+    snapshot = copy.deepcopy(document)
+
+    feeds = plan_aravis_feeds(document, resolution)
+
+    # Pure over its inputs: the document is never mutated.
+    assert document == snapshot
+
+    # 6.4 precedence: the assignment's values when the resolution
+    # carries one for the node, else the rendered parameters.
+    effective = (assignment_params if assignment_params is not None
+                 else rendered)
+    assert feeds == [_model_feed(node_id, effective)]
+
+    # The planned feed targets the Aravis node, never a non-Aravis
+    # point or a stray-assignment node id.
+    assert feeds[0].node_id == node_id

--- a/test/backend-test/workflow_engine/test_property_aravis_free_execution_identity.py
+++ b/test/backend-test/workflow_engine/test_property_aravis_free_execution_identity.py
@@ -1,0 +1,302 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property test for Aravis-free execution identity.
+
+**Feature: aravis-camera-input, Property 15: Aravis-free execution identity**
+
+*For any* compiled document containing no Aravis binding point — including
+every legacy document without a ``bindingPoints`` section — zero Aravis
+feeds SHALL be planned and the executor SHALL invoke the pipeline manager
+through the exact pre-feature call path:
+``run_pipeline(launch_string, latency_metrics=...)`` with no ``frame_data``
+argument, no frame grab, and the launch string rendered from the on-disk
+document.
+
+**Validates: Requirements 6.6**
+
+Generators mirror the real Aravis-free input space: legacy documents
+(``bindingPoints`` absent entirely), documents with an empty
+``bindingPoints`` list, and documents whose binding points belong to
+other camera families (slot-substituted ``camera_source`` points,
+``adapterBinding: true`` points, ``csiSensorBinding: true`` points, and
+points carrying ``aravisBinding: false``) — never ``aravisBinding: true``.
+The binding-resolution provider is absent, returns ``None``, or raises
+(the provider-fallback path); each variant must leave the pre-feature
+call shape untouched.
+
+Runs with the hypothesis profiles registered in this directory's conftest
+(``engine-fast`` = 25 examples locally, ``HYPOTHESIS_PROFILE=ci`` = 100).
+"""
+import itertools
+import shutil
+import tempfile
+import time
+from unittest.mock import patch
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from workflow_engine_test_utils import (
+    DEVICE_ARCH,
+    make_session_factory,
+    write_artifact_set,
+)
+
+from workflow_engine import gst_plugins, rendering
+from workflow_engine.aravis_feed import plan_aravis_feeds
+from workflow_engine.models import WorkflowExecution, WorkflowRegistration
+from workflow_engine.pipeline_executor import (
+    EXECUTION_STATUS_COMPLETED,
+    EXECUTION_STATUS_PENDING,
+    WorkflowExecutor,
+)
+
+# --- generators --------------------------------------------------------------
+
+#: Launch-safe factories the pre-feature executor runs unmodified (no
+#: emlpython bridge rewriting, no {work_dir} resolution, no appsrc).
+_FACTORIES = st.sampled_from(
+    ["videotestsrc", "videoconvert", "videoscale", "queue", "fakesink"]
+)
+
+#: Launch-safe argument values (identifier-shaped, no quoting needed).
+_ARGS = st.dictionaries(
+    keys=st.sampled_from(["num-buffers", "silent", "qos"]),
+    values=st.one_of(st.integers(min_value=0, max_value=30), st.booleans()),
+    max_size=2,
+)
+
+
+@st.composite
+def _segments(draw):
+    """1..2 segments of 1..3 elements each — always a non-empty render."""
+    segments = []
+    node_counter = itertools.count(1)
+    for index in range(draw(st.integers(min_value=1, max_value=2))):
+        elements = []
+        for _ in range(draw(st.integers(min_value=1, max_value=3))):
+            node_id = (
+                "n{0}".format(next(node_counter))
+                if draw(st.booleans()) else None
+            )
+            elements.append({
+                "nodeId": node_id,
+                "factory": draw(_FACTORIES),
+                "args": draw(_ARGS),
+            })
+        segments.append({"name": "s{0}".format(index), "elements": elements})
+    return segments
+
+
+@st.composite
+def _non_aravis_binding_points(draw):
+    """Binding points of the other camera families — never
+    ``aravisBinding: true``."""
+    points = []
+    for index in range(draw(st.integers(min_value=1, max_value=3))):
+        kind = draw(st.sampled_from(
+            ["slots", "adapter", "csi", "aravis-false"]))
+        point = {
+            "nodeId": "cam-n{0}".format(index),
+            "nodeType": "camera_source",
+            "parameters": {"device": "/dev/video{0}".format(index)},
+            "slots": [],
+        }
+        if kind == "slots":
+            point["slots"] = [{"param": "device", "segment": 0,
+                               "element": 0, "arg": "device"}]
+        elif kind == "adapter":
+            point["adapterBinding"] = True
+        elif kind == "csi":
+            point["csiSensorBinding"] = True
+        else:
+            # The marker present but not True is not an Aravis point.
+            point["aravisBinding"] = draw(st.sampled_from([False, None, 0]))
+        points.append(point)
+    return points
+
+
+@st.composite
+def _aravis_free_documents(draw):
+    """A compiled_pipeline.json with no Aravis binding point: the legacy
+    shape (no ``bindingPoints`` at all), an empty list, or non-Aravis
+    points only."""
+    document = {
+        "schemaVersion": 1,
+        "workflowId": "wf-1",
+        "workflowVersion": "3",
+        "targetArch": DEVICE_ARCH,
+        "segments": draw(_segments()),
+        "executorBindings": [],
+        "pluginDependencies": [],
+    }
+    variant = draw(st.sampled_from(["legacy", "empty", "non-aravis"]))
+    if variant == "empty":
+        document["bindingPoints"] = []
+    elif variant == "non-aravis":
+        document["bindingPoints"] = draw(_non_aravis_binding_points())
+    return document
+
+
+#: Binding-resolution provider variants: absent (pre-feature wiring),
+#: returning None (no resolution cached), raising (provider isolation).
+_PROVIDER_VARIANTS = st.sampled_from(["absent", "none", "raises"])
+
+
+# --- fakes -------------------------------------------------------------------
+
+
+class FakePipelineManager:
+    """Records every run_pipeline call exactly as made, so the
+    pre-feature call shape (no frame_data argument at all) is
+    distinguishable from an explicit frame push."""
+
+    def __init__(self):
+        self.calls = []
+
+    def run_pipeline(self, pipeline_str, *args, **kwargs):
+        self.calls.append((pipeline_str, args, kwargs))
+        return {}
+
+
+class FakeCameraManager:
+    """Callable frame grabber recording calls — must never be called."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, camera_id, config):
+        self.calls.append((camera_id, dict(config)))
+        return {"data": b"\x00" * 8, "width": 4, "height": 2}
+
+
+def _make_provider(variant, calls):
+    if variant == "absent":
+        return None
+    if variant == "none":
+        def provider(registration_id):
+            calls.append(registration_id)
+            return None
+        return provider
+
+    def raising_provider(registration_id):
+        calls.append(registration_id)
+        raise RuntimeError("watcher is gone")
+    return raising_provider
+
+
+# --- shared per-module state (one sqlite database, unique rows per example) ---
+
+_SESSION_FACTORY = None
+_IDS = itertools.count(1)
+
+
+def _session_factory():
+    global _SESSION_FACTORY
+    if _SESSION_FACTORY is None:
+        _SESSION_FACTORY = make_session_factory()
+    return _SESSION_FACTORY
+
+
+def _seed_run(session_factory, artifact_path, sequence):
+    registration_id = "wf-1:3:{0}".format(sequence)
+    execution_id = "exec-{0}".format(sequence)
+    session = session_factory()
+    try:
+        session.add(WorkflowRegistration(
+            id=registration_id,
+            workflow_id="wf-1",
+            version="3",
+            arch=DEVICE_ARCH,
+            artifact_path=str(artifact_path),
+            status="registered",
+            registered_at=int(time.time()),
+        ))
+        session.add(WorkflowExecution(
+            id=execution_id,
+            registration_id=registration_id,
+            started_at=int(time.time()),
+            status=EXECUTION_STATUS_PENDING,
+        ))
+        session.commit()
+    finally:
+        session.close()
+    return registration_id, execution_id
+
+
+def _get_execution(session_factory, execution_id):
+    session = session_factory()
+    try:
+        return session.get(WorkflowExecution, execution_id)
+    finally:
+        session.close()
+
+
+# --- property ----------------------------------------------------------------
+
+
+@given(document=_aravis_free_documents(), provider_variant=_PROVIDER_VARIANTS)
+@settings(deadline=None)
+def test_aravis_free_execution_identity(document, provider_variant):
+    """**Feature: aravis-camera-input, Property 15: Aravis-free
+    execution identity**
+
+    **Validates: Requirements 6.6**
+    """
+    # Zero feeds planned, resolution or not (6.6).
+    assert plan_aravis_feeds(document, None) == []
+
+    session_factory = _session_factory()
+    sequence = next(_IDS)
+    root = tempfile.mkdtemp(prefix="aravis-free-identity-")
+    try:
+        artifact_path = write_artifact_set(root, compiled=document)
+        registration_id, execution_id = _seed_run(
+            session_factory, artifact_path, sequence
+        )
+
+        provider_calls = []
+        provider = _make_provider(provider_variant, provider_calls)
+        grabber = FakeCameraManager()
+        manager = FakePipelineManager()
+        executor = WorkflowExecutor(
+            session_factory=session_factory,
+            pipeline_manager_factory=lambda: manager,
+            binding_resolution_provider=provider,
+            frame_grabber=grabber,
+        )
+
+        with patch.object(gst_plugins, "_scan_registry", return_value=True):
+            executor.execute(execution_id)
+
+        # The camera manager is never touched (no Aravis feed exists).
+        assert grabber.calls == []
+
+        # The exact pre-feature call path: one run_pipeline call, the
+        # on-disk document's rendered launch string, NO frame_data
+        # positional at all, latency_metrics the only keyword.
+        assert len(manager.calls) == 1
+        launch, args, kwargs = manager.calls[0]
+        assert launch == rendering.render_launch_string(document)
+        assert args == ()
+        assert set(kwargs) == {"latency_metrics"}
+
+        # A consulted provider is called with the registration id; its
+        # absence, None, or failure never alters the run's outcome.
+        if provider is not None:
+            assert provider_calls == [registration_id]
+        row = _get_execution(session_factory, execution_id)
+        assert row.status == EXECUTION_STATUS_COMPLETED
+    finally:
+        shutil.rmtree(root, ignore_errors=True)

--- a/test/backend-test/workflow_engine/test_property_camera_binding_resolution.py
+++ b/test/backend-test/workflow_engine/test_property_camera_binding_resolution.py
@@ -213,10 +213,13 @@ def _resolution_cases(draw):
 def _model_resolved_values(entry):
     """Requirement 10.1: the bound source's resolved parameter values,
     with the reported ``devicePath`` resolving the node's ``device``
-    parameter. Exact because the inventory generator never emits ``None``
-    values or a literal ``device`` key."""
+    parameter (and ``cameraId`` aliasing ``camera_id``, the
+    aravis-camera-input addition to ``_PARAM_ALIASES``). Exact because
+    the inventory generator never emits ``None`` values or a literal
+    ``device``/``camera_id`` key."""
     values = dict(entry.params)
     values["device"] = values["devicePath"]
+    values["camera_id"] = values["cameraId"]
     return values
 
 

--- a/test/backend-test/workflow_engine/test_property_frame_helpers.py
+++ b/test/backend-test/workflow_engine/test_property_frame_helpers.py
@@ -1,0 +1,291 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based tests for the ``dda_frames`` Frame_Helpers module.
+
+Each test exec's ``HELPERS_SOURCE`` (the module source the Python_Runner
+injects into handler subprocesses as ``dda_frames``) into a fresh module
+namespace, exactly as the runner does, and exercises the helper API
+directly.
+
+Covers:
+
+- **Feature: custom-python-frames, Property 7: Frame/array conversion
+  round trip** — Validates: Requirements 5.2, 5.3, 5.4, 5.5
+- **Feature: custom-python-frames, Property 8: Disk image load round
+  trip** — Validates: Requirements 6.1, 6.3
+- **Feature: custom-python-frames, Property 9: S3 image load round
+  trip** — Validates: Requirements 6.2
+- **Feature: custom-python-frames, Property 10: load_image failures
+  identify the source** — Validates: Requirements 6.4
+"""
+import io
+import os
+import tempfile
+import types
+
+import cv2
+import numpy as np
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from hypothesis.extra import numpy as hnp
+
+from workflow_engine.python_bridge import HELPERS_SOURCE
+
+FORMAT_CHANNELS = {"RGB": 3, "BGR": 3, "RGBA": 4, "GRAY8": 1}
+
+#: Filesystem/S3-safe name alphabet (no separators, no null bytes).
+_NAME_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789-_"
+
+
+def load_helpers():
+    """Exec HELPERS_SOURCE into a fresh module namespace, as the runner
+    does when it registers ``dda_frames`` in ``sys.modules``."""
+    module = types.ModuleType("dda_frames")
+    exec(HELPERS_SOURCE, module.__dict__)
+    return module
+
+
+def encode_png(array):
+    ok, encoded = cv2.imencode(".png", array)
+    assert ok, "cv2.imencode failed for a plain uint8 array"
+    return encoded.tobytes()
+
+
+# ---------------------------------------------------------------------------
+# Feature: custom-python-frames, Property 7: Frame/array conversion round trip
+#
+# For any frame dimensions, supported Pixel_Format, and pixel content,
+# to_bytes(to_array(frame_bytes, width, height, format)) equals the original
+# unpadded frame bytes, and to_array of padded frame bytes returns the same
+# array as to_array of the unpadded bytes; for any unsupported format string
+# or byte string shorter than the dimensions require, to_array raises an
+# error describing the format or size problem.
+#
+# **Validates: Requirements 5.2, 5.3, 5.4, 5.5**
+# ---------------------------------------------------------------------------
+
+
+@given(
+    width=st.integers(min_value=1, max_value=32),
+    height=st.integers(min_value=1, max_value=32),
+    fmt=st.sampled_from(sorted(FORMAT_CHANNELS)),
+    padding=st.integers(min_value=0, max_value=16),
+    bad_fmt=st.text(min_size=1, max_size=12).filter(
+        lambda s: s not in FORMAT_CHANNELS
+    ),
+    data=st.data(),
+)
+def test_property_7_frame_array_conversion_round_trip(
+    width, height, fmt, padding, bad_fmt, data
+):
+    """**Feature: custom-python-frames, Property 7: Frame/array
+    conversion round trip**
+
+    **Validates: Requirements 5.2, 5.3, 5.4, 5.5**
+    """
+    helpers = load_helpers()
+    channels = FORMAT_CHANNELS[fmt]
+    row_bytes = width * channels
+    size = row_bytes * height
+    pixels = data.draw(st.binary(min_size=size, max_size=size))
+
+    # Round trip: to_bytes(to_array(...)) == unpadded input (Req 5.2-5.4).
+    array = helpers.to_array(pixels, width, height, fmt)
+    expected_shape = (
+        (height, width) if fmt == "GRAY8" else (height, width, channels)
+    )
+    assert array.shape == expected_shape
+    assert array.dtype == np.uint8
+    assert helpers.to_bytes(array) == pixels
+
+    # Row padding tolerated: padded and unpadded bytes decode equal (5.2).
+    pad = data.draw(
+        st.binary(min_size=padding * height, max_size=padding * height)
+    )
+    padded = b"".join(
+        pixels[i * row_bytes:(i + 1) * row_bytes]
+        + pad[i * padding:(i + 1) * padding]
+        for i in range(height)
+    )
+    assert np.array_equal(
+        helpers.to_array(padded, width, height, fmt), array
+    )
+
+    # Unsupported format: ValueError naming the format (Req 5.5).
+    with pytest.raises(ValueError) as bad_format_error:
+        helpers.to_array(pixels, width, height, bad_fmt)
+    assert bad_fmt in str(bad_format_error.value)
+
+    # Short buffer: ValueError describing the size shortfall (Req 5.5).
+    with pytest.raises(ValueError) as short_error:
+        helpers.to_array(pixels[: size - 1], width, height, fmt)
+    assert "too short" in str(short_error.value)
+
+
+# ---------------------------------------------------------------------------
+# Feature: custom-python-frames, Property 8: Disk image load round trip
+#
+# For any uint8 BGR image array written losslessly to a PNG file with
+# cv2.imwrite, dda_frames.load_image of that path returns an array equal to
+# the original.
+#
+# **Validates: Requirements 6.1, 6.3**
+# ---------------------------------------------------------------------------
+
+
+@given(data=st.data())
+def test_property_8_disk_image_load_round_trip(data):
+    """**Feature: custom-python-frames, Property 8: Disk image load
+    round trip**
+
+    **Validates: Requirements 6.1, 6.3**
+    """
+    height = data.draw(st.integers(min_value=1, max_value=32))
+    width = data.draw(st.integers(min_value=1, max_value=32))
+    array = data.draw(hnp.arrays(np.uint8, (height, width, 3)))
+    helpers = load_helpers()
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        path = os.path.join(tmp_dir, "image.png")
+        assert cv2.imwrite(path, array)
+        loaded = helpers.load_image(path)
+        assert loaded.dtype == np.uint8
+        assert np.array_equal(loaded, array)
+
+
+# ---------------------------------------------------------------------------
+# Feature: custom-python-frames, Property 9: S3 image load round trip
+#
+# For any bucket name, object key, and uint8 BGR image array PNG-encoded and
+# served by an injected fake S3 client,
+# dda_frames.load_image("s3://bucket/key", s3_client=fake) requests exactly
+# that bucket and key and returns an array equal to the original.
+#
+# **Validates: Requirements 6.2**
+# ---------------------------------------------------------------------------
+
+
+class FakeS3Client:
+    """get_object stub serving fixed bytes and recording requests."""
+
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = []
+
+    def get_object(self, Bucket, Key):
+        self.calls.append((Bucket, Key))
+        return {"Body": io.BytesIO(self.payload)}
+
+
+@given(
+    bucket=st.text(alphabet=_NAME_ALPHABET, min_size=1, max_size=30),
+    key=st.text(alphabet=_NAME_ALPHABET + "/.", min_size=1, max_size=40),
+    data=st.data(),
+)
+def test_property_9_s3_image_load_round_trip(bucket, key, data):
+    """**Feature: custom-python-frames, Property 9: S3 image load round
+    trip**
+
+    **Validates: Requirements 6.2**
+    """
+    height = data.draw(st.integers(min_value=1, max_value=16))
+    width = data.draw(st.integers(min_value=1, max_value=16))
+    array = data.draw(hnp.arrays(np.uint8, (height, width, 3)))
+    helpers = load_helpers()
+    fake = FakeS3Client(encode_png(array))
+
+    loaded = helpers.load_image(
+        "s3://{0}/{1}".format(bucket, key), s3_client=fake
+    )
+
+    assert fake.calls == [(bucket, key)]
+    assert np.array_equal(loaded, array)
+
+
+# ---------------------------------------------------------------------------
+# Feature: custom-python-frames, Property 10: load_image failures identify
+# the source
+#
+# For any failing source — a non-existent local path, a malformed s3:// URI,
+# an S3 client raising on fetch, or existing content that does not decode as
+# an image — dda_frames.load_image raises an error whose message contains
+# the source.
+#
+# **Validates: Requirements 6.4**
+# ---------------------------------------------------------------------------
+
+
+class RaisingS3Client:
+    """get_object stub that always fails, like a denied/absent object."""
+
+    def get_object(self, Bucket, Key):
+        raise RuntimeError("simulated S3 failure for {0}/{1}".format(
+            Bucket, Key
+        ))
+
+
+@given(
+    name=st.text(alphabet=_NAME_ALPHABET, min_size=1, max_size=20),
+    bucket=st.text(alphabet=_NAME_ALPHABET, min_size=1, max_size=20),
+    key=st.text(alphabet=_NAME_ALPHABET + "/.", min_size=1, max_size=30),
+    malformed_uri=st.one_of(
+        st.just("s3://"),
+        st.text(alphabet=_NAME_ALPHABET, min_size=1, max_size=20).map(
+            lambda b: "s3://" + b  # bucket, no key
+        ),
+        st.text(alphabet=_NAME_ALPHABET, min_size=1, max_size=20).map(
+            lambda b: "s3://" + b + "/"  # bucket, empty key
+        ),
+        st.text(alphabet=_NAME_ALPHABET, min_size=1, max_size=20).map(
+            lambda k: "s3:///" + k  # empty bucket
+        ),
+    ),
+    junk=st.binary(min_size=0, max_size=64),
+)
+def test_property_10_load_image_failures_identify_the_source(
+    name, bucket, key, malformed_uri, junk
+):
+    """**Feature: custom-python-frames, Property 10: load_image failures
+    identify the source**
+
+    **Validates: Requirements 6.4**
+    """
+    helpers = load_helpers()
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Non-existent local path.
+        missing_path = os.path.join(tmp_dir, name + ".png")
+        with pytest.raises(ValueError) as missing_error:
+            helpers.load_image(missing_path)
+        assert missing_path in str(missing_error.value)
+
+        # Existing content that does not decode as an image (the prefix
+        # guarantees no valid image magic bytes).
+        undecodable_path = os.path.join(tmp_dir, name + ".bin")
+        with open(undecodable_path, "wb") as f:
+            f.write(b"not-an-image:" + junk)
+        with pytest.raises(ValueError) as decode_error:
+            helpers.load_image(undecodable_path)
+        assert undecodable_path in str(decode_error.value)
+
+    # Malformed s3:// URI.
+    with pytest.raises(ValueError) as uri_error:
+        helpers.load_image(malformed_uri, s3_client=FakeS3Client(b""))
+    assert malformed_uri in str(uri_error.value)
+
+    # S3 client raising on fetch.
+    s3_source = "s3://{0}/{1}".format(bucket, key)
+    with pytest.raises(ValueError) as fetch_error:
+        helpers.load_image(s3_source, s3_client=RaisingS3Client())
+    assert s3_source in str(fetch_error.value)

--- a/test/backend-test/workflow_engine/test_property_python_bridge_contract_violations.py
+++ b/test/backend-test/workflow_engine/test_property_python_bridge_contract_violations.py
@@ -1,0 +1,181 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based test for ``process_frame`` contract violations through
+a real :class:`CustomPythonBridge` subprocess.
+
+Covers:
+
+- **Feature: custom-python-frames, Property 5: process_frame contract
+  violations fail the node identifiably** — Validates: Requirements 3.4, 3.5
+
+A single module-scoped bridge with one violation-dispatching handler is
+shared across all hypothesis examples. Every contract violation kills the
+handler subprocess (the runner exits after reporting ``status: error`` and
+the bridge kills it besides), but ``CustomPythonBridge.process_frame``
+restarts the subprocess on the next invocation, so the bridge object stays
+reusable — each example pays one subprocess start. One violation kind is
+drawn per example to keep that to a single restart, and dims stay small.
+"""
+import os
+import string
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from workflow_engine.python_bridge import (
+    CustomPythonBridge,
+    CustomPythonNodeError,
+)
+
+FORMAT_CHANNELS = {"RGB": 3, "BGR": 3, "RGBA": 4, "GRAY8": 1}
+
+NODE_ID = "prop5-violations"
+
+#: Generous per-frame limit: every example restarts the subprocess, so
+#: every frame pays the numpy/cv2 import cost.
+WALL_CLOCK_LIMIT_SEC = 30.0
+
+#: One handler covering every handler-side violation kind, selected by
+#: the caller through the request metadata (the unsupported-format kind
+#: is runner-side: the handler is never invoked for it).
+VIOLATION_HANDLER = """\
+def process_frame(frame, metadata):
+    kind = metadata["violation"]
+    if kind == "wrong_shape":
+        return np.zeros((frame.shape[0] + 1,) + frame.shape[1:],
+                        dtype=np.uint8)
+    if kind == "wrong_dtype":
+        return frame.astype(np.uint16)
+    if kind == "non_array":
+        return "not-an-array"
+    raise AssertionError("unexpected violation kind %r" % (kind,))
+"""
+
+VIOLATION_KINDS = (
+    "wrong_shape",
+    "wrong_dtype",
+    "non_array",
+    "unsupported_format",
+)
+
+#: Format strings outside the supported set (Requirement 3.5): realistic
+#: GStreamer video formats plus arbitrary short uppercase-ish strings.
+UNSUPPORTED_FORMATS = st.one_of(
+    st.sampled_from(["NV12", "I420", "YUY2", "UYVY", "BGRA", "GRAY16_LE"]),
+    st.text(
+        alphabet=string.ascii_uppercase + string.digits + "_",
+        min_size=0,
+        max_size=8,
+    ).filter(lambda s: s not in FORMAT_CHANNELS),
+)
+
+
+@pytest.fixture(scope="module")
+def violation_bridge(tmp_path_factory):
+    handler_dir = tmp_path_factory.mktemp("prop5")
+    handler_path = os.path.join(str(handler_dir), "handler.py")
+    with open(handler_path, "w") as f:
+        f.write(VIOLATION_HANDLER)
+    bridge = CustomPythonBridge(
+        NODE_ID,
+        handler_path,
+        wall_clock_limit_sec=WALL_CLOCK_LIMIT_SEC,
+    )
+    yield bridge
+    bridge.stop()
+
+
+# ---------------------------------------------------------------------------
+# Feature: custom-python-frames, Property 5: process_frame contract
+# violations fail the node identifiably
+#
+# For any frame and any non-compliant process_frame outcome — a returned
+# array of different shape, a returned array of different dtype, a
+# non-array non-None return, or an input frame whose Pixel_Format is
+# outside the supported set — the CustomPythonBridge raises
+# CustomPythonNodeError carrying the node id and a message describing the
+# mismatch or the unsupported format.
+#
+# **Validates: Requirements 3.4, 3.5**
+# ---------------------------------------------------------------------------
+
+
+@given(
+    width=st.integers(min_value=1, max_value=8),
+    height=st.integers(min_value=1, max_value=8),
+    violation=st.sampled_from(VIOLATION_KINDS),
+    data=st.data(),
+)
+def test_property_5_contract_violations_fail_the_node_identifiably(
+    violation_bridge, width, height, violation, data,
+):
+    """**Feature: custom-python-frames, Property 5: process_frame
+    contract violations fail the node identifiably**
+
+    **Validates: Requirements 3.4, 3.5**
+    """
+    if violation == "unsupported_format":
+        fmt = data.draw(UNSUPPORTED_FORMATS)
+        channels = 1  # frame content is irrelevant: rejected before decode
+    else:
+        fmt = data.draw(st.sampled_from(sorted(FORMAT_CHANNELS)))
+        channels = FORMAT_CHANNELS[fmt]
+    size = width * height * channels
+    frame = data.draw(st.binary(min_size=size, max_size=size))
+
+    with pytest.raises(CustomPythonNodeError) as excinfo:
+        violation_bridge.process_frame(
+            frame,
+            metadata={"violation": violation},
+            width=width,
+            height=height,
+            frame_format=fmt,
+        )
+
+    # The error carries the node id (Requirements 3.4, 3.5).
+    assert excinfo.value.node_id == NODE_ID
+    message = str(excinfo.value)
+    assert NODE_ID in message
+
+    if channels == 1 and violation != "unsupported_format":
+        expected_shape = (height, width)
+    else:
+        expected_shape = (height, width, channels)
+
+    if violation == "wrong_shape":
+        # Message describes the shape mismatch (Requirement 3.4).
+        assert "expected shape {0} and dtype uint8".format(
+            expected_shape
+        ) in message
+        returned_shape = (height + 1, width) if channels == 1 else (
+            height + 1, width, channels
+        )
+        assert "returned an array of shape {0}".format(
+            returned_shape
+        ) in message
+    elif violation == "wrong_dtype":
+        # Message describes the dtype mismatch (Requirement 3.4).
+        assert "dtype uint16" in message
+        assert "expected shape {0} and dtype uint8".format(
+            expected_shape
+        ) in message
+    elif violation == "non_array":
+        # Message describes the non-array return (Requirement 3.4).
+        assert "must return None or a NumPy array" in message
+        assert "got str" in message
+    else:  # unsupported_format
+        # Message names the unsupported format (Requirement 3.5).
+        assert "unsupported frame format" in message
+        assert repr(fmt) in message

--- a/test/backend-test/workflow_engine/test_property_python_bridge_frame_info.py
+++ b/test/backend-test/workflow_engine/test_property_python_bridge_frame_info.py
@@ -1,0 +1,104 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based test for frame info delivery through a real
+:class:`CustomPythonBridge` subprocess.
+
+Covers:
+
+- **Feature: custom-python-frames, Property 6: Frame info delivery** —
+  Validates: Requirements 3.9, 5.6
+
+One long-lived bridge subprocess is shared across all hypothesis examples
+(module-scoped fixture): spawning a subprocess per example would dominate
+the run with numpy/cv2 import time.
+"""
+import os
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from workflow_engine.python_bridge import CustomPythonBridge
+
+FORMAT_CHANNELS = {"RGB": 3, "BGR": 3, "RGBA": 4, "GRAY8": 1}
+
+#: Generous per-frame limit: the first frame of each subprocess pays the
+#: numpy/cv2 import cost.
+WALL_CLOCK_LIMIT_SEC = 30.0
+
+#: Records what the handler observes during the invocation: the frame
+#: info delivered in ``metadata["frame"]`` (Requirement 3.9) and the
+#: triple reported by ``dda_frames.frame_info()`` (Requirement 5.6).
+#: Both snapshots travel back to the bridge caller in the response
+#: metadata; returning None passes the frame bytes through.
+FRAME_INFO_HANDLER = """\
+import dda_frames
+
+
+def process_frame(frame, metadata):
+    metadata["observed_metadata_frame"] = dict(metadata["frame"])
+    metadata["observed_frame_info"] = dda_frames.frame_info()
+    return None
+"""
+
+
+@pytest.fixture(scope="module")
+def frame_info_bridge(tmp_path_factory):
+    handler_dir = tmp_path_factory.mktemp("prop6_frame_info")
+    handler_path = os.path.join(str(handler_dir), "handler.py")
+    with open(handler_path, "w") as f:
+        f.write(FRAME_INFO_HANDLER)
+    bridge = CustomPythonBridge(
+        "prop6-frame-info",
+        handler_path,
+        wall_clock_limit_sec=WALL_CLOCK_LIMIT_SEC,
+    )
+    yield bridge
+    bridge.stop()
+
+
+# ---------------------------------------------------------------------------
+# Feature: custom-python-frames, Property 6: Frame info delivery
+#
+# For any frame width, height, and supported Pixel_Format dispatched by the
+# bridge, the handler observes that exact triple both in metadata["frame"]
+# and from dda_frames.frame_info() during the invocation.
+#
+# **Validates: Requirements 3.9, 5.6**
+# ---------------------------------------------------------------------------
+
+
+@given(
+    width=st.integers(min_value=1, max_value=32),
+    height=st.integers(min_value=1, max_value=32),
+    fmt=st.sampled_from(sorted(FORMAT_CHANNELS)),
+)
+def test_property_6_frame_info_delivery(frame_info_bridge, width, height, fmt):
+    """**Feature: custom-python-frames, Property 6: Frame info delivery**
+
+    **Validates: Requirements 3.9, 5.6**
+    """
+    frame = bytes(width * height * FORMAT_CHANNELS[fmt])
+    expected = {"width": width, "height": height, "format": fmt}
+
+    out_frame, out_meta = frame_info_bridge.process_frame(
+        frame, width=width, height=height, frame_format=fmt
+    )
+
+    assert out_frame == frame
+    # Requirement 3.9: the caps triple is delivered inside metadata["frame"].
+    assert out_meta["observed_metadata_frame"] == expected
+    # Requirement 5.6: dda_frames.frame_info() reports the same triple
+    # while the handler invocation is in progress.
+    assert out_meta["observed_frame_info"] == expected

--- a/test/backend-test/workflow_engine/test_property_python_bridge_legacy_handle.py
+++ b/test/backend-test/workflow_engine/test_property_python_bridge_legacy_handle.py
@@ -1,0 +1,143 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based test for the legacy ``handle`` raw-bytes contract
+through a real :class:`CustomPythonBridge` subprocess.
+
+Covers:
+
+- **Feature: custom-python-frames, Property 2: Legacy handle contract is
+  preserved** — Validates: Requirements 3.6, 3.9
+
+One long-lived bridge subprocess is shared across all hypothesis examples
+(module-scoped fixture): spawning a subprocess per example would dominate
+the run with interpreter startup time.
+"""
+import os
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from workflow_engine.python_bridge import CustomPythonBridge
+
+#: Generous per-frame limit: the first frame of each subprocess pays the
+#: interpreter startup cost.
+WALL_CLOCK_LIMIT_SEC = 30.0
+
+#: Legacy handle-only handler. It proves the received frame bytes are the
+#: dispatched bytes by returning them reversed (so the caller can invert
+#: the transformation), and proves the received metadata (including the
+#: injected ``frame`` info key, Requirement 3.9) round-trips by returning
+#: it with one marker key added (Requirement 3.6).
+LEGACY_HANDLE_HANDLER = """\
+def handle(frame_bytes, metadata):
+    out_meta = dict(metadata)
+    out_meta["handled"] = True
+    return frame_bytes[::-1], out_meta
+"""
+
+
+@pytest.fixture(scope="module")
+def legacy_handle_bridge(tmp_path_factory):
+    handler_dir = tmp_path_factory.mktemp("prop2_legacy_handle")
+    handler_path = os.path.join(str(handler_dir), "handler.py")
+    with open(handler_path, "w") as f:
+        f.write(LEGACY_HANDLE_HANDLER)
+    bridge = CustomPythonBridge(
+        "prop2-legacy-handle",
+        handler_path,
+        wall_clock_limit_sec=WALL_CLOCK_LIMIT_SEC,
+    )
+    yield bridge
+    bridge.stop()
+
+
+# Metadata travels to the handler subprocess and back as JSON, so the
+# generated dicts are constrained to JSON-round-trip-stable values. The
+# top-level key "frame" is reserved for the info the runner injects
+# (Requirement 3.9) and is excluded from generation; "handled" is the
+# handler's own marker and the expected-value computation mirrors the
+# handler, so it needs no exclusion.
+_JSON_VALUES = st.recursive(
+    st.none()
+    | st.booleans()
+    | st.integers(min_value=-(2 ** 53), max_value=2 ** 53)
+    | st.floats(allow_nan=False, allow_infinity=False)
+    | st.text(max_size=20),
+    lambda children: st.lists(children, max_size=3)
+    | st.dictionaries(st.text(max_size=10), children, max_size=3),
+    max_leaves=10,
+)
+
+_METADATA = st.dictionaries(
+    st.text(max_size=10).filter(lambda key: key != "frame"),
+    _JSON_VALUES,
+    max_size=4,
+)
+
+# The handle path is format-agnostic (only process_frame handlers restrict
+# the Pixel_Format, Requirement 3.5), so unsupported formats are included
+# to pin the pre-existing behavior.
+_FORMATS = st.sampled_from(["RGB", "BGR", "RGBA", "GRAY8", "NV12", "I420"])
+
+
+# ---------------------------------------------------------------------------
+# Feature: custom-python-frames, Property 2: Legacy handle contract is
+# preserved
+#
+# For any frame bytes and metadata dict, a handler defining only
+# handle(frame_bytes, metadata) invoked through the CustomPythonBridge
+# receives the frame bytes unchanged, receives the metadata enriched with
+# the frame info key, and its returned (frame_bytes, metadata) round-trips
+# back to the bridge caller exactly as under the pre-existing contract.
+#
+# **Validates: Requirements 3.6, 3.9**
+# ---------------------------------------------------------------------------
+
+
+@given(
+    frame=st.binary(max_size=256),
+    metadata=_METADATA,
+    width=st.integers(min_value=1, max_value=64),
+    height=st.integers(min_value=1, max_value=64),
+    fmt=_FORMATS,
+)
+def test_property_2_legacy_handle_contract_preserved(
+    legacy_handle_bridge, frame, metadata, width, height, fmt
+):
+    """**Feature: custom-python-frames, Property 2: Legacy handle
+    contract is preserved**
+
+    **Validates: Requirements 3.6, 3.9**
+    """
+    out_frame, out_meta = legacy_handle_bridge.process_frame(
+        frame, metadata=metadata, width=width, height=height,
+        frame_format=fmt,
+    )
+
+    # The handler reversed the bytes it received; the output equalling the
+    # reversed input proves both that the handler received the dispatched
+    # bytes unchanged and that its returned frame bytes round-tripped to
+    # the bridge caller (Requirement 3.6).
+    assert out_frame == frame[::-1]
+
+    # The handler returned its received metadata plus a marker key: the
+    # caller-supplied entries survive unchanged, the runner-injected
+    # "frame" info key carries the dispatched caps triple (Requirement
+    # 3.9), and the handler's own addition round-trips (Requirement 3.6).
+    expected_meta = dict(metadata)
+    expected_meta["frame"] = {"width": width, "height": height,
+                              "format": fmt}
+    expected_meta["handled"] = True
+    assert out_meta == expected_meta

--- a/test/backend-test/workflow_engine/test_property_python_bridge_process_frame.py
+++ b/test/backend-test/workflow_engine/test_property_python_bridge_process_frame.py
@@ -1,0 +1,179 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Property-based test for the ``process_frame`` handler contract through
+a real :class:`CustomPythonBridge` subprocess.
+
+Covers:
+
+- **Feature: custom-python-frames, Property 4: process_frame contract
+  round trip** — Validates: Requirements 3.1, 3.2, 3.3
+
+One long-lived bridge subprocess per handler variant is shared across all
+hypothesis examples (module-scoped fixtures): spawning a subprocess per
+example would dominate the run with numpy/cv2 import time.
+"""
+import os
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from workflow_engine.python_bridge import CustomPythonBridge
+
+FORMAT_CHANNELS = {"RGB": 3, "BGR": 3, "RGBA": 4, "GRAY8": 1}
+
+#: Generous per-frame limit: the first frame of each subprocess pays the
+#: numpy/cv2 import cost.
+WALL_CLOCK_LIMIT_SEC = 30.0
+
+#: Identity: asserts the received array's shape/dtype match the caps
+#: (Requirement 3.1) and returns the array unchanged (Requirement 3.2).
+IDENTITY_HANDLER = """\
+FORMAT_CHANNELS = {"RGB": 3, "BGR": 3, "RGBA": 4, "GRAY8": 1}
+
+
+def process_frame(frame, metadata):
+    info = metadata["frame"]
+    channels = FORMAT_CHANNELS[info["format"]]
+    if channels == 1:
+        expected_shape = (info["height"], info["width"])
+    else:
+        expected_shape = (info["height"], info["width"], channels)
+    assert frame.shape == expected_shape, (
+        "shape %r != expected %r" % (frame.shape, expected_shape)
+    )
+    assert frame.dtype == np.uint8, "dtype %r != uint8" % (frame.dtype,)
+    return frame
+"""
+
+#: None return: the input frame passes through unchanged (Requirement 3.3).
+NONE_HANDLER = """\
+def process_frame(frame, metadata):
+    return None
+"""
+
+#: Deterministic transformation: bitwise inversion of every pixel
+#: (Requirement 3.2 — pixels transformed, padding/byte length preserved).
+INVERT_HANDLER = """\
+def process_frame(frame, metadata):
+    return np.bitwise_not(frame)
+"""
+
+
+def _make_bridge(tmp_path_factory, name, handler_source):
+    handler_dir = tmp_path_factory.mktemp("prop4_" + name)
+    handler_path = os.path.join(str(handler_dir), "handler.py")
+    with open(handler_path, "w") as f:
+        f.write(handler_source)
+    return CustomPythonBridge(
+        "prop4-" + name,
+        handler_path,
+        wall_clock_limit_sec=WALL_CLOCK_LIMIT_SEC,
+    )
+
+
+@pytest.fixture(scope="module")
+def identity_bridge(tmp_path_factory):
+    bridge = _make_bridge(tmp_path_factory, "identity", IDENTITY_HANDLER)
+    yield bridge
+    bridge.stop()
+
+
+@pytest.fixture(scope="module")
+def none_bridge(tmp_path_factory):
+    bridge = _make_bridge(tmp_path_factory, "none", NONE_HANDLER)
+    yield bridge
+    bridge.stop()
+
+
+@pytest.fixture(scope="module")
+def invert_bridge(tmp_path_factory):
+    bridge = _make_bridge(tmp_path_factory, "invert", INVERT_HANDLER)
+    yield bridge
+    bridge.stop()
+
+
+# ---------------------------------------------------------------------------
+# Feature: custom-python-frames, Property 4: process_frame contract round trip
+#
+# For any frame dimensions, supported Pixel_Format, pixel content, and row
+# padding, a process_frame handler invoked through the CustomPythonBridge
+# receives a NumPy uint8 array of the shape implied by the caps (rows x
+# columns x channels; 2-D for GRAY8); returning that array unchanged emits
+# output bytes equal to the input bytes (padding included); returning None
+# emits the input bytes unchanged; and returning a deterministic
+# transformation (bitwise inversion) emits bytes whose pixel regions are the
+# transformed pixels while padding bytes and total byte length are preserved.
+#
+# **Validates: Requirements 3.1, 3.2, 3.3**
+# ---------------------------------------------------------------------------
+
+
+@given(
+    width=st.integers(min_value=1, max_value=16),
+    height=st.integers(min_value=1, max_value=16),
+    fmt=st.sampled_from(sorted(FORMAT_CHANNELS)),
+    padding=st.integers(min_value=0, max_value=8),
+    data=st.data(),
+)
+def test_property_4_process_frame_contract_round_trip(
+    identity_bridge, none_bridge, invert_bridge,
+    width, height, fmt, padding, data,
+):
+    """**Feature: custom-python-frames, Property 4: process_frame
+    contract round trip**
+
+    **Validates: Requirements 3.1, 3.2, 3.3**
+    """
+    channels = FORMAT_CHANNELS[fmt]
+    row_bytes = width * channels
+    pixels = data.draw(
+        st.binary(min_size=row_bytes * height, max_size=row_bytes * height)
+    )
+    pad = data.draw(
+        st.binary(min_size=padding * height, max_size=padding * height)
+    )
+    frame = b"".join(
+        pixels[row * row_bytes:(row + 1) * row_bytes]
+        + pad[row * padding:(row + 1) * padding]
+        for row in range(height)
+    )
+
+    # Identity: the handler asserts the received shape/dtype match the
+    # caps (Req 3.1) and the output bytes equal the input bytes, padding
+    # included (Req 3.2).
+    out_frame, _ = identity_bridge.process_frame(
+        frame, width=width, height=height, frame_format=fmt
+    )
+    assert out_frame == frame
+
+    # None return: the input frame passes through unchanged (Req 3.3).
+    out_frame, _ = none_bridge.process_frame(
+        frame, width=width, height=height, frame_format=fmt
+    )
+    assert out_frame == frame
+
+    # Bitwise inversion: pixel regions are inverted, padding bytes and
+    # total byte length are preserved (Req 3.2).
+    stride = row_bytes + padding
+    expected = b"".join(
+        bytes(255 - b for b in pixels[row * row_bytes:(row + 1) * row_bytes])
+        + pad[row * padding:(row + 1) * padding]
+        for row in range(height)
+    )
+    out_frame, _ = invert_bridge.process_frame(
+        frame, width=width, height=height, frame_format=fmt
+    )
+    assert len(out_frame) == stride * height == len(frame)
+    assert out_frame == expected

--- a/test/backend-test/workflow_engine/test_python_bridge_load_image_containment.py
+++ b/test/backend-test/workflow_engine/test_python_bridge_load_image_containment.py
@@ -1,0 +1,87 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Example test for ``load_image`` failure containment through the bridge.
+
+A handler calling ``dda_frames.load_image`` on a missing path raises
+through a real :class:`CustomPythonBridge` subprocess as
+``CustomPythonNodeError`` carrying the node id and the source in its
+message — consistent with existing handler failure containment.
+
+Requirements: 6.5
+"""
+import os
+
+import pytest
+
+from workflow_engine.python_bridge import (
+    CustomPythonBridge,
+    CustomPythonNodeError,
+)
+
+NODE_ID = "load-image-containment-node"
+
+#: Generous per-frame limit: the subprocess pays the numpy/cv2 import
+#: cost on its first frame.
+WALL_CLOCK_LIMIT_SEC = 30.0
+
+#: Handler whose per-frame code loads an image from a path supplied by
+#: the caller through the request metadata.
+LOAD_IMAGE_HANDLER = """\
+import dda_frames
+
+def process_frame(frame, metadata):
+    dda_frames.load_image(metadata["image_path"])
+    return None
+"""
+
+
+def test_load_image_missing_path_contained_as_custom_python_node_error(
+    tmp_path,
+):
+    """A handler calling dda_frames.load_image on a missing local path
+    fails the run through the bridge as CustomPythonNodeError carrying
+    the node id and the source path in its message (Requirement 6.5)."""
+    handler_path = str(tmp_path / "handler.py")
+    with open(handler_path, "w") as f:
+        f.write(LOAD_IMAGE_HANDLER)
+
+    missing_path = str(tmp_path / "no-such-image.png")
+    assert not os.path.exists(missing_path)
+
+    bridge = CustomPythonBridge(
+        NODE_ID,
+        handler_path,
+        wall_clock_limit_sec=WALL_CLOCK_LIMIT_SEC,
+    )
+    try:
+        with pytest.raises(CustomPythonNodeError) as excinfo:
+            bridge.process_frame(
+                b"\x00",
+                metadata={"image_path": missing_path},
+                width=1,
+                height=1,
+                frame_format="GRAY8",
+            )
+    finally:
+        bridge.stop()
+
+    # The error carries the node id (existing containment behavior).
+    assert excinfo.value.node_id == NODE_ID
+    message = str(excinfo.value)
+    assert NODE_ID in message
+
+    # The error message identifies the failing source (Requirement 6.4
+    # message surfaced through the bridge per Requirement 6.5).
+    assert missing_path in message
+    assert "load_image" in message

--- a/test/backend-test/workflow_engine/test_vendored_catalog_mirror.py
+++ b/test/backend-test/workflow_engine/test_vendored_catalog_mirror.py
@@ -1,0 +1,63 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Smoke test: the vendored workflow_core catalog mirror stays byte-identical.
+
+The edge workflow engine ships a vendored copy of the portal's workflow_core
+catalog at ``src/backend/workflow_engine/vendor/workflow_core``. Whenever the
+portal layer copy changes (e.g. new node descriptors such as
+``custom_python_preprocess``), the mirror must be re-synced so both sides of
+the system agree on the node catalog.
+
+Validates: Requirements 1.6, 3.10 (custom-python-frames)
+"""
+
+import hashlib
+from pathlib import Path
+
+PORTAL_RELATIVE = Path(
+    "edge-cv-portal/backend/layers/workflow_core/python/workflow_core/catalog/nodes.py"
+)
+VENDORED_RELATIVE = Path(
+    "src/backend/workflow_engine/vendor/workflow_core/catalog/nodes.py"
+)
+
+
+def _repo_root() -> Path:
+    """Walk up from this file until both catalog copies are present."""
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / PORTAL_RELATIVE).is_file() and (
+            candidate / VENDORED_RELATIVE
+        ).is_file():
+            return candidate
+    raise AssertionError(
+        "Could not locate the repository root containing both "
+        f"{PORTAL_RELATIVE} and {VENDORED_RELATIVE}"
+    )
+
+
+def test_vendored_catalog_nodes_is_byte_identical_to_portal_copy():
+    root = _repo_root()
+    portal_bytes = (root / PORTAL_RELATIVE).read_bytes()
+    vendored_bytes = (root / VENDORED_RELATIVE).read_bytes()
+
+    portal_sha = hashlib.sha256(portal_bytes).hexdigest()
+    vendored_sha = hashlib.sha256(vendored_bytes).hexdigest()
+
+    assert portal_bytes == vendored_bytes, (
+        "Vendored workflow_core catalog mirror is out of sync with the portal "
+        f"layer copy.\n  portal   sha256={portal_sha} ({PORTAL_RELATIVE})\n"
+        f"  vendored sha256={vendored_sha} ({VENDORED_RELATIVE})\n"
+        "Re-sync with: cp "
+        f"{PORTAL_RELATIVE} {VENDORED_RELATIVE}"
+    )

--- a/test/backend-test/workflow_engine/test_workflow_aravis_camera_binding.py
+++ b/test/backend-test/workflow_engine/test_workflow_aravis_camera_binding.py
@@ -1,0 +1,227 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for Aravis binding point resolution in ``resolve_bindings``.
+
+Feature: aravis-camera-input (Requirements 6.1, 6.2, 6.3).
+
+Aravis binding points (``aravisBinding: true``, empty slots) never
+substitute element arguments: resolved bindings contribute to the
+dedicated ``aravis_assignments`` field on ``ResolutionResult``, consumed
+by the executor's Aravis frame feed.
+"""
+import copy
+
+from camera_sync import CameraSourceState
+from workflow_engine.camera_binding import (
+    STATUS_INVALID,
+    STATUS_RESOLVED,
+    resolve_bindings,
+)
+
+
+def make_aravis_document(binding_point=None):
+    """A minimal compiled_pipeline.json-shaped document with one
+    aravis_camera_source node rendered as an appsrc-headed chain (the
+    physical-architecture shape)."""
+    document = {
+        "schemaVersion": 1,
+        "segments": [
+            {
+                "elements": [
+                    {"nodeId": "n2", "type": "appsrc",
+                     "args": {"name": "appsrc_n2"}},
+                    {"nodeId": "n2", "type": "videoconvert", "args": {}},
+                ]
+            }
+        ],
+    }
+    if binding_point is not None:
+        document["bindingPoints"] = [binding_point]
+    return document
+
+
+def make_aravis_binding_point(node_id="n2", parameters=None):
+    """The packager's Aravis binding point shape: aravisBinding marker,
+    empty slots, rendered parameter values."""
+    return {
+        "nodeId": node_id,
+        "nodeType": "aravis_camera_source",
+        "parameters": parameters or {"camera_id": "Aravis-Fake-GV01",
+                                     "gain": 4, "exposure": 5000000},
+        "slots": [],
+        "aravisBinding": True,
+    }
+
+
+def make_aravis_inventory_entry(camera_source_id="cfg-is-1",
+                                camera_id="Aravis-Fake-GV01",
+                                gain=None, exposure=None):
+    """A configured Camera-type entry from ``build_inventory``: params
+    carry the Aravis ``cameraId`` (and gain/exposure when configured)."""
+    params = {"cameraId": camera_id}
+    if gain is not None:
+        params["gain"] = gain
+    if exposure is not None:
+        params["exposure"] = exposure
+    return CameraSourceState(
+        camera_source_id=camera_source_id,
+        name="GenICam line cam",
+        type="Camera",
+        origin="edge-configured",
+        params=params,
+    )
+
+
+class TestAravisCameraSourceIdResolution:
+    def test_resolution_yields_assignment_with_camera_id_params(self):
+        """Requirement 6.1: a cameraSourceId binding resolves against the
+        local inventory into an aravis assignment; the cameraId inventory
+        param aliases to the node's camera_id parameter name."""
+        document = make_aravis_document(make_aravis_binding_point())
+        inventory = {"cfg-is-1": make_aravis_inventory_entry(
+            camera_id="Basler-12345678", gain=10, exposure=16000000)}
+
+        result = resolve_bindings(
+            document, {"n2": {"cameraSourceId": "cfg-is-1"}}, inventory)
+
+        assert result.status == STATUS_RESOLVED
+        assert result.missing == ()
+        assignment = result.aravis_assignments["n2"]
+        assert assignment["cameraSourceId"] == "cfg-is-1"
+        assert assignment["params"]["camera_id"] == "Basler-12345678"
+        assert assignment["params"]["cameraId"] == "Basler-12345678"
+        assert assignment["params"]["gain"] == 10
+        assert assignment["params"]["exposure"] == 16000000
+        # No adapter assignment, and no slot substitution: the rendered
+        # segments run exactly as compiled.
+        assert result.adapter_assignments == {}
+        assert result.document["segments"] == document["segments"]
+
+    def test_input_document_is_never_mutated(self):
+        document = make_aravis_document(make_aravis_binding_point())
+        snapshot = copy.deepcopy(document)
+        inventory = {"cfg-is-1": make_aravis_inventory_entry()}
+
+        resolve_bindings(document, {"n2": {"cameraSourceId": "cfg-is-1"}},
+                         inventory)
+
+        assert document == snapshot
+
+    def test_missing_camera_source_marks_invalid_with_reason(self):
+        """Requirement 6.3: an id with no local inventory entry follows
+        the existing invalid path (missing entry + error reason)."""
+        document = make_aravis_document(make_aravis_binding_point())
+
+        result = resolve_bindings(
+            document, {"n2": {"cameraSourceId": "cfg-gone"}}, {})
+
+        assert result.status == STATUS_INVALID
+        assert result.missing == ({"nodeId": "n2",
+                                   "cameraSourceId": "cfg-gone"},)
+        assert result.errors == ("missing camera source cfg-gone",)
+        assert result.aravis_assignments == {}
+
+
+class TestAravisOverrideResolution:
+    def test_override_yields_assignment_from_override_values(self):
+        """Requirement 6.2: constraint-valid override values become the
+        assignment params without any inventory lookup."""
+        document = make_aravis_document(make_aravis_binding_point())
+
+        result = resolve_bindings(
+            document,
+            {"n2": {"override": {"camera_id": "Basler-12345678",
+                                 "gain": 20, "exposure": 8000000}}},
+            {})
+
+        assert result.status == STATUS_RESOLVED
+        assignment = result.aravis_assignments["n2"]
+        assert assignment["cameraSourceId"] is None
+        assert assignment["params"] == {"camera_id": "Basler-12345678",
+                                        "gain": 20, "exposure": 8000000}
+        assert result.document["segments"] == document["segments"]
+
+    def test_override_violating_catalog_constraints_is_invalid(self):
+        """Requirement 6.2: the vendored aravis_camera_source descriptor
+        declares gain max 100; a violating override marks the resolution
+        invalid with a reason."""
+        document = make_aravis_document(make_aravis_binding_point())
+
+        result = resolve_bindings(
+            document, {"n2": {"override": {"gain": 500}}}, {})
+
+        assert result.status == STATUS_INVALID
+        assert len(result.errors) == 1
+        assert "gain" in result.errors[0]
+        assert result.aravis_assignments == {}
+
+    def test_empty_camera_id_override_is_invalid(self):
+        """camera_id declares min_length 1 in the vendored catalog."""
+        document = make_aravis_document(make_aravis_binding_point())
+
+        result = resolve_bindings(
+            document, {"n2": {"override": {"camera_id": ""}}}, {})
+
+        assert result.status == STATUS_INVALID
+        assert "camera_id" in result.errors[0]
+        assert result.aravis_assignments == {}
+
+
+class TestAravisFreeIdentity:
+    def test_document_without_aravis_points_resolves_as_before(self):
+        """Documents without Aravis binding points produce results
+        identical to the pre-feature behavior: aravis_assignments stays
+        empty and slot substitution proceeds unchanged."""
+        document = {
+            "schemaVersion": 1,
+            "segments": [
+                {
+                    "elements": [
+                        {"nodeId": "n1", "type": "v4l2src",
+                         "args": {"device": "/dev/video0"}},
+                    ]
+                }
+            ],
+            "bindingPoints": [{
+                "nodeId": "n1",
+                "nodeType": "camera_source",
+                "parameters": {"device": "/dev/video0"},
+                "slots": [{"param": "device", "segment": 0,
+                           "element": 0, "arg": "device"}],
+            }],
+        }
+        inventory = {"cfg-is-1": CameraSourceState(
+            camera_source_id="cfg-is-1", name="Line 1 cam", type="Camera",
+            origin="edge-configured",
+            params={"devicePath": "/dev/video2", "cameraId": "cam-1"})}
+
+        result = resolve_bindings(
+            document, {"n1": {"cameraSourceId": "cfg-is-1"}}, inventory)
+
+        assert result.status == STATUS_RESOLVED
+        assert result.aravis_assignments == {}
+        element = result.document["segments"][0]["elements"][0]
+        assert element["args"]["device"] == "/dev/video2"
+
+    def test_document_without_binding_points_has_empty_aravis_assignments(self):
+        """Pre-feature documents pass through untouched with the new
+        field defaulted empty."""
+        document = make_aravis_document()
+
+        result = resolve_bindings(
+            document, {"n2": {"cameraSourceId": "cfg-is-1"}}, {})
+
+        assert result.status == STATUS_RESOLVED
+        assert result.document is document
+        assert result.aravis_assignments == {}

--- a/test/backend-test/workflow_engine/test_workflow_aravis_executor.py
+++ b/test/backend-test/workflow_engine/test_workflow_aravis_executor.py
@@ -1,0 +1,457 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""WorkflowExecutor Aravis frame feed wiring tests.
+
+Feature: aravis-camera-input (Requirements 6.4, 6.5, 6.6).
+
+A fake camera manager and a fake pipeline manager exercise the executor's
+binding-resolution provider, feed planning, frame grab, and Frame_Feed
+push without GStreamer or the gi/Aravis runtime:
+
+- a resolved Aravis assignment grabs from the resolved camera and pushes
+  the frame through ``run_pipeline(launch_string, frame_data)``, running
+  the resolution's substituted document;
+- with no provider (or an unbound resolution) the binding point's
+  rendered default parameters drive the grab;
+- a raising camera manager fails the execution with ``failing_node_id``
+  set to the Aravis node and the camera error;
+- a raising provider falls back to the on-disk document;
+- Aravis-free documents take the exact pre-feature call shape (no
+  frame_data argument at all).
+"""
+import time
+from unittest.mock import patch
+
+import pytest
+
+from workflow_engine_test_utils import (
+    DEVICE_ARCH,
+    make_session_factory,
+    write_artifact_set,
+)
+
+from workflow_engine import gst_plugins
+from workflow_engine.camera_binding import STATUS_RESOLVED, ResolutionResult
+from workflow_engine.models import WorkflowExecution, WorkflowRegistration
+from workflow_engine.pipeline_executor import (
+    EXECUTION_STATUS_COMPLETED,
+    EXECUTION_STATUS_FAILED,
+    EXECUTION_STATUS_PENDING,
+    WorkflowExecutor,
+)
+
+REGISTRATION_ID = "wf-1:3"
+
+
+def make_aravis_document(node_id="n1", parameters=None, extra_points=()):
+    """A compiled_pipeline.json with one Aravis camera source: the
+    compiled appsrc chain plus the packager's aravisBinding point."""
+    if parameters is None:
+        parameters = {"camera_id": "Aravis-Fake-GV01",
+                      "gain": 4, "exposure": 5000000}
+    return {
+        "schemaVersion": 1,
+        "workflowId": "wf-1",
+        "workflowVersion": "3",
+        "targetArch": DEVICE_ARCH,
+        "segments": [
+            {
+                "name": "s0",
+                "elements": [
+                    {"nodeId": node_id, "factory": "appsrc",
+                     "args": {"name": "appsrc_{0}".format(node_id)}},
+                    {"nodeId": node_id, "factory": "videoconvert", "args": {}},
+                    {"nodeId": None, "factory": "fakesink", "args": {}},
+                ],
+            }
+        ],
+        "bindingPoints": [
+            {
+                "nodeId": node_id,
+                "nodeType": "aravis_camera_source",
+                "parameters": dict(parameters),
+                "slots": [],
+                "aravisBinding": True,
+            }
+        ] + list(extra_points),
+        "executorBindings": [],
+        "pluginDependencies": [],
+    }
+
+
+PLAIN_DOC = {
+    "schemaVersion": 1,
+    "workflowId": "wf-1",
+    "workflowVersion": "3",
+    "targetArch": DEVICE_ARCH,
+    "segments": [
+        {
+            "name": "s0",
+            "elements": [
+                {"nodeId": "n1", "factory": "videotestsrc",
+                 "args": {"num-buffers": 1}},
+                {"nodeId": None, "factory": "fakesink", "args": {}},
+            ],
+        }
+    ],
+    "executorBindings": [],
+    "pluginDependencies": [],
+}
+
+
+def make_frame(width=4, height=2, bytes_per_pixel=1):
+    return {
+        "data": b"\x00" * (width * height * bytes_per_pixel),
+        "width": width,
+        "height": height,
+    }
+
+
+class FakePipelineManager:
+    """Records every run_pipeline call exactly as it was made, so the
+    pre-feature call shape (no frame_data argument at all) is
+    distinguishable from an explicit frame push."""
+
+    def __init__(self, tag_values=None, error=None):
+        self.tag_values = tag_values or {}
+        self.error = error
+        self.calls = []
+
+    def run_pipeline(self, pipeline_str, *args, **kwargs):
+        self.calls.append((pipeline_str, args, kwargs))
+        if self.error is not None:
+            raise self.error
+        return dict(self.tag_values)
+
+
+class FakeCameraManager:
+    """Callable frame grabber recording (camera_id, config) calls."""
+
+    def __init__(self, frame=None, error=None):
+        self.frame = frame if frame is not None else make_frame()
+        self.error = error
+        self.calls = []
+
+    def __call__(self, camera_id, config):
+        self.calls.append((camera_id, dict(config)))
+        if self.error is not None:
+            raise self.error
+        return self.frame
+
+
+@pytest.fixture
+def session_factory():
+    return make_session_factory()
+
+
+@pytest.fixture(autouse=True)
+def no_registry_scan():
+    """Never import gi in these tests."""
+    with patch.object(gst_plugins, "_scan_registry", return_value=True):
+        yield
+
+
+def seed_run(session_factory, artifact_path, status="registered"):
+    session = session_factory()
+    try:
+        session.add(
+            WorkflowRegistration(
+                id=REGISTRATION_ID,
+                workflow_id="wf-1",
+                version="3",
+                arch=DEVICE_ARCH,
+                artifact_path=str(artifact_path),
+                status=status,
+                registered_at=int(time.time()),
+            )
+        )
+        session.add(
+            WorkflowExecution(
+                id="exec-1",
+                registration_id=REGISTRATION_ID,
+                started_at=int(time.time()),
+                status=EXECUTION_STATUS_PENDING,
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+    return "exec-1"
+
+
+def get_execution(session_factory, execution_id="exec-1"):
+    session = session_factory()
+    try:
+        return session.get(WorkflowExecution, execution_id)
+    finally:
+        session.close()
+
+
+def make_executor(session_factory, manager, grabber=None, provider=None):
+    return WorkflowExecutor(
+        session_factory=session_factory,
+        pipeline_manager_factory=lambda: manager,
+        binding_resolution_provider=provider,
+        frame_grabber=grabber,
+    )
+
+
+class TestResolvedAssignmentFeed:
+    def test_resolved_assignment_drives_grab_and_frame_push(
+        self, tmp_path, session_factory
+    ):
+        """Requirement 6.4: the provider's resolution supplies both the
+        substituted document and the Aravis assignment; the grab uses the
+        resolved camera id/config and the frame goes through
+        run_pipeline(launch_string, frame_data)."""
+        disk_doc = make_aravis_document()
+        artifact_path = write_artifact_set(tmp_path, compiled=disk_doc)
+        execution_id = seed_run(session_factory, artifact_path)
+
+        # The substituted document differs from disk so the launch string
+        # proves which document ran.
+        substituted = make_aravis_document()
+        substituted["segments"][0]["elements"][2]["args"] = {"silent": True}
+        resolution = ResolutionResult(
+            document=substituted,
+            status=STATUS_RESOLVED,
+            aravis_assignments={
+                "n1": {
+                    "cameraSourceId": "cfg-is-1",
+                    "params": {"camera_id": "Basler-12345678",
+                               "gain": 20, "exposure": 8000000},
+                }
+            },
+        )
+        provider_calls = []
+
+        def provider(registration_id):
+            provider_calls.append(registration_id)
+            return resolution
+
+        frame = make_frame(width=8, height=4)
+        grabber = FakeCameraManager(frame=frame)
+        manager = FakePipelineManager()
+
+        make_executor(
+            session_factory, manager, grabber=grabber, provider=provider
+        ).execute(execution_id)
+
+        assert provider_calls == [REGISTRATION_ID]
+        assert grabber.calls == [
+            ("Basler-12345678", {"gain": 20, "exposure": 8000000})
+        ]
+        assert len(manager.calls) == 1
+        launch, args, kwargs = manager.calls[0]
+        # The Frame_Feed appsrc: named for run_pipeline's lookup, base
+        # caps derived from the frame (width/height are appended from the
+        # frame inside run_pipeline, the classic Camera-type model).
+        assert launch == (
+            "appsrc name=appsrc caps=video/x-raw,format=GRAY8 "
+            "! videoconvert ! fakesink silent=true"
+        )
+        assert args == (frame,)
+        assert set(kwargs) == {"latency_metrics"}
+        assert get_execution(session_factory).status == EXECUTION_STATUS_COMPLETED
+
+    def test_watcher_cached_resolution_document_is_not_mutated(
+        self, tmp_path, session_factory
+    ):
+        """The executor's appsrc rewrite happens on a private copy —
+        the provider's cached document keeps its compiled shape."""
+        artifact_path = write_artifact_set(
+            tmp_path, compiled=make_aravis_document()
+        )
+        execution_id = seed_run(session_factory, artifact_path)
+        resolution = ResolutionResult(
+            document=make_aravis_document(), status=STATUS_RESOLVED
+        )
+
+        make_executor(
+            session_factory,
+            FakePipelineManager(),
+            grabber=FakeCameraManager(),
+            provider=lambda registration_id: resolution,
+        ).execute(execution_id)
+
+        appsrc_args = resolution.document["segments"][0]["elements"][0]["args"]
+        assert appsrc_args == {"name": "appsrc_n1"}
+
+
+class TestRenderedDefaultFeed:
+    def test_no_provider_grabs_with_rendered_default_parameters(
+        self, tmp_path, session_factory
+    ):
+        """Requirement 6.4: without a provider the binding point's
+        rendered camera_id/gain/exposure drive the grab."""
+        artifact_path = write_artifact_set(
+            tmp_path, compiled=make_aravis_document()
+        )
+        execution_id = seed_run(session_factory, artifact_path)
+        grabber = FakeCameraManager()
+        manager = FakePipelineManager()
+
+        make_executor(session_factory, manager, grabber=grabber).execute(
+            execution_id
+        )
+
+        assert grabber.calls == [
+            ("Aravis-Fake-GV01", {"gain": 4, "exposure": 5000000})
+        ]
+        launch, args, kwargs = manager.calls[0]
+        assert args == (grabber.frame,)
+        assert get_execution(session_factory).status == EXECUTION_STATUS_COMPLETED
+
+    def test_rgb_frame_derives_rgb_caps(self, tmp_path, session_factory):
+        artifact_path = write_artifact_set(
+            tmp_path, compiled=make_aravis_document()
+        )
+        execution_id = seed_run(session_factory, artifact_path)
+        grabber = FakeCameraManager(frame=make_frame(bytes_per_pixel=3))
+        manager = FakePipelineManager()
+
+        make_executor(session_factory, manager, grabber=grabber).execute(
+            execution_id
+        )
+
+        launch = manager.calls[0][0]
+        assert "caps=video/x-raw,format=RGB " in launch
+
+
+class TestGrabFailure:
+    def test_raising_camera_manager_fails_with_the_aravis_node(
+        self, tmp_path, session_factory
+    ):
+        """Requirement 6.5: a grab failure fails the execution with
+        failing_node_id set to the Aravis node and the camera error;
+        the pipeline never starts."""
+        artifact_path = write_artifact_set(
+            tmp_path, compiled=make_aravis_document()
+        )
+        execution_id = seed_run(session_factory, artifact_path)
+        grabber = FakeCameraManager(
+            error=Exception(
+                "Unable to get camera frame for camera id: Aravis-Fake-GV01"
+            )
+        )
+        manager = FakePipelineManager()
+
+        make_executor(session_factory, manager, grabber=grabber).execute(
+            execution_id
+        )
+
+        assert manager.calls == []
+        row = get_execution(session_factory)
+        assert row.status == EXECUTION_STATUS_FAILED
+        assert row.failing_node_id == "n1"
+        assert "Unable to get camera frame" in row.error
+        assert row.finished_at is not None
+
+    def test_planning_error_fails_before_the_pipeline_starts(
+        self, tmp_path, session_factory
+    ):
+        """Two Aravis points violate the single Frame_Feed contract:
+        the run fails with the planner's reason, no grab, no pipeline."""
+        document = make_aravis_document(extra_points=[{
+            "nodeId": "n7",
+            "nodeType": "aravis_camera_source",
+            "parameters": {"camera_id": "cam-b"},
+            "slots": [],
+            "aravisBinding": True,
+        }])
+        artifact_path = write_artifact_set(tmp_path, compiled=document)
+        execution_id = seed_run(session_factory, artifact_path)
+        grabber = FakeCameraManager()
+        manager = FakePipelineManager()
+
+        make_executor(session_factory, manager, grabber=grabber).execute(
+            execution_id
+        )
+
+        assert grabber.calls == []
+        assert manager.calls == []
+        row = get_execution(session_factory)
+        assert row.status == EXECUTION_STATUS_FAILED
+        assert "n1" in row.error and "n7" in row.error
+
+
+class TestProviderFallback:
+    def test_raising_provider_falls_back_to_the_disk_document(
+        self, tmp_path, session_factory
+    ):
+        """A provider failure never takes the run down: the on-disk
+        document runs on its rendered defaults."""
+        artifact_path = write_artifact_set(
+            tmp_path, compiled=make_aravis_document()
+        )
+        execution_id = seed_run(session_factory, artifact_path)
+        grabber = FakeCameraManager()
+        manager = FakePipelineManager()
+
+        def broken_provider(registration_id):
+            raise RuntimeError("watcher is gone")
+
+        make_executor(
+            session_factory, manager, grabber=grabber, provider=broken_provider
+        ).execute(execution_id)
+
+        assert grabber.calls == [
+            ("Aravis-Fake-GV01", {"gain": 4, "exposure": 5000000})
+        ]
+        launch = manager.calls[0][0]
+        assert launch == (
+            "appsrc name=appsrc caps=video/x-raw,format=GRAY8 "
+            "! videoconvert ! fakesink"
+        )
+        assert get_execution(session_factory).status == EXECUTION_STATUS_COMPLETED
+
+    def test_raising_provider_never_fails_an_aravis_free_run(
+        self, tmp_path, session_factory
+    ):
+        artifact_path = write_artifact_set(tmp_path, compiled=PLAIN_DOC)
+        execution_id = seed_run(session_factory, artifact_path)
+        manager = FakePipelineManager()
+
+        def broken_provider(registration_id):
+            raise RuntimeError("watcher is gone")
+
+        make_executor(
+            session_factory, manager, provider=broken_provider
+        ).execute(execution_id)
+
+        assert get_execution(session_factory).status == EXECUTION_STATUS_COMPLETED
+
+
+class TestAravisFreePath:
+    def test_aravis_free_document_takes_the_pre_feature_call_shape(
+        self, tmp_path, session_factory
+    ):
+        """Requirement 6.6: no Aravis binding points — no grab, and
+        run_pipeline is invoked without any frame_data argument."""
+        artifact_path = write_artifact_set(tmp_path, compiled=PLAIN_DOC)
+        execution_id = seed_run(session_factory, artifact_path)
+        grabber = FakeCameraManager()
+        manager = FakePipelineManager(tag_values={"is_anomalous": False})
+
+        make_executor(
+            session_factory, manager, grabber=grabber,
+            provider=lambda registration_id: None,
+        ).execute(execution_id)
+
+        assert grabber.calls == []
+        launch, args, kwargs = manager.calls[0]
+        assert launch == "videotestsrc num-buffers=1 ! fakesink"
+        assert args == ()
+        assert set(kwargs) == {"latency_metrics"}
+        assert get_execution(session_factory).status == EXECUTION_STATUS_COMPLETED

--- a/test/backend-test/workflow_engine/test_workflow_aravis_feed.py
+++ b/test/backend-test/workflow_engine/test_workflow_aravis_feed.py
@@ -1,0 +1,225 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the Aravis frame feed planner (``plan_aravis_feeds``).
+
+Feature: aravis-camera-input (Requirement 6.4).
+
+``plan_aravis_feeds`` is pure over a compiled document and an optional
+``ResolutionResult``: a resolved Aravis assignment's params take
+precedence, else the binding point's rendered parameters; a feed with no
+usable camera id fails planning attributed to its node; more than one
+Aravis binding point violates the single-appsrc Frame_Feed contract;
+Aravis-free and legacy documents plan zero feeds.
+"""
+import pytest
+
+from workflow_engine.aravis_feed import (
+    AravisFeed,
+    AravisFeedError,
+    plan_aravis_feeds,
+)
+from workflow_engine.camera_binding import (
+    STATUS_RESOLVED,
+    ResolutionResult,
+)
+
+
+def make_document(*binding_points):
+    """A minimal compiled_pipeline.json-shaped document. Passing no
+    binding points omits the section entirely (the legacy shape)."""
+    document = {
+        "schemaVersion": 1,
+        "segments": [
+            {
+                "elements": [
+                    {"nodeId": "n2", "type": "appsrc",
+                     "args": {"name": "appsrc_n2"}},
+                    {"nodeId": "n2", "type": "videoconvert", "args": {}},
+                ]
+            }
+        ],
+    }
+    if binding_points:
+        document["bindingPoints"] = list(binding_points)
+    return document
+
+
+def make_aravis_point(node_id="n2", parameters=None):
+    """The packager's Aravis binding point shape: aravisBinding marker,
+    empty slots, rendered parameter values."""
+    if parameters is None:
+        parameters = {"camera_id": "Aravis-Fake-GV01",
+                      "gain": 4, "exposure": 5000000}
+    return {
+        "nodeId": node_id,
+        "nodeType": "aravis_camera_source",
+        "parameters": parameters,
+        "slots": [],
+        "aravisBinding": True,
+    }
+
+
+def make_resolution(document, aravis_assignments):
+    return ResolutionResult(
+        document=document,
+        status=STATUS_RESOLVED,
+        aravis_assignments=aravis_assignments,
+    )
+
+
+class TestAssignmentPrecedence:
+    def test_resolved_assignment_params_win_over_rendered_parameters(self):
+        """Requirement 6.4: the resolution's aravis_assignments params
+        are the effective values when present."""
+        document = make_document(make_aravis_point())
+        resolution = make_resolution(document, {
+            "n2": {"cameraSourceId": "cfg-is-1",
+                   "params": {"camera_id": "Basler-12345678",
+                              "gain": 20, "exposure": 8000000}},
+        })
+
+        feeds = plan_aravis_feeds(document, resolution)
+
+        assert feeds == [AravisFeed(
+            node_id="n2", camera_id="Basler-12345678",
+            config={"gain": 20, "exposure": 8000000})]
+
+    def test_camera_id_accepted_under_inventory_cameraId_spelling(self):
+        """Resolved inventory params spell the identity ``cameraId``;
+        the planner accepts either spelling."""
+        document = make_document(make_aravis_point())
+        resolution = make_resolution(document, {
+            "n2": {"cameraSourceId": "cfg-is-1",
+                   "params": {"cameraId": "Basler-12345678"}},
+        })
+
+        feeds = plan_aravis_feeds(document, resolution)
+
+        assert feeds == [AravisFeed(node_id="n2",
+                                    camera_id="Basler-12345678",
+                                    config={})]
+
+    def test_config_carries_only_present_acquisition_params(self):
+        """gain/exposure join the config only when the effective values
+        carry them; None values are treated as absent."""
+        document = make_document(make_aravis_point())
+        resolution = make_resolution(document, {
+            "n2": {"cameraSourceId": "cfg-is-1",
+                   "params": {"camera_id": "cam-1", "gain": 12,
+                              "exposure": None}},
+        })
+
+        feeds = plan_aravis_feeds(document, resolution)
+
+        assert feeds[0].config == {"gain": 12}
+
+
+class TestRenderedParameterFallback:
+    def test_none_resolution_uses_rendered_parameters(self):
+        """Requirement 6.4: with no resolution (bindings never resolved)
+        the binding point's rendered parameters run."""
+        document = make_document(make_aravis_point(
+            parameters={"camera_id": "Aravis-Fake-GV01",
+                        "gain": 4, "exposure": 5000000}))
+
+        feeds = plan_aravis_feeds(document, None)
+
+        assert feeds == [AravisFeed(
+            node_id="n2", camera_id="Aravis-Fake-GV01",
+            config={"gain": 4, "exposure": 5000000})]
+
+    def test_resolution_without_assignment_for_node_falls_back(self):
+        """An unbound Aravis point (resolution present, no assignment
+        for the node) runs on its rendered parameters."""
+        document = make_document(make_aravis_point())
+        resolution = make_resolution(document, {})
+
+        feeds = plan_aravis_feeds(document, resolution)
+
+        assert feeds == [AravisFeed(
+            node_id="n2", camera_id="Aravis-Fake-GV01",
+            config={"gain": 4, "exposure": 5000000})]
+
+
+class TestEmptyCameraIdError:
+    def test_empty_rendered_camera_id_fails_naming_the_node(self):
+        document = make_document(make_aravis_point(
+            parameters={"camera_id": "", "gain": 4}))
+
+        with pytest.raises(AravisFeedError) as excinfo:
+            plan_aravis_feeds(document, None)
+
+        assert excinfo.value.node_id == "n2"
+        assert "n2" in str(excinfo.value)
+        assert "camera_id" in str(excinfo.value)
+
+    def test_missing_camera_id_in_assignment_fails_naming_the_node(self):
+        """An assignment whose params carry no camera identity is a
+        planning failure attributed to the node (rendered parameters are
+        not consulted once an assignment exists)."""
+        document = make_document(make_aravis_point())
+        resolution = make_resolution(document, {
+            "n2": {"cameraSourceId": "cfg-is-1",
+                   "params": {"gain": 10}},
+        })
+
+        with pytest.raises(AravisFeedError) as excinfo:
+            plan_aravis_feeds(document, resolution)
+
+        assert excinfo.value.node_id == "n2"
+        assert "n2" in str(excinfo.value)
+
+
+class TestMultipleAravisPoints:
+    def test_two_aravis_points_fail_with_reason_naming_both_nodes(self):
+        """The single-frame appsrc Frame_Feed contract supports exactly
+        one Aravis camera source per workflow."""
+        document = make_document(
+            make_aravis_point(node_id="n2"),
+            make_aravis_point(node_id="n5",
+                              parameters={"camera_id": "cam-b"}),
+        )
+
+        with pytest.raises(AravisFeedError) as excinfo:
+            plan_aravis_feeds(document, None)
+
+        assert excinfo.value.node_id is None
+        message = str(excinfo.value)
+        assert "n2" in message
+        assert "n5" in message
+        assert "2" in message
+
+
+class TestAravisFreeDocuments:
+    def test_legacy_document_without_binding_points_plans_zero_feeds(self):
+        """Requirement 6.6: pre-feature documents (no bindingPoints
+        section) plan zero feeds."""
+        assert plan_aravis_feeds(make_document(), None) == []
+
+    def test_document_with_only_non_aravis_points_plans_zero_feeds(self):
+        document = make_document({
+            "nodeId": "n1",
+            "nodeType": "camera_source",
+            "parameters": {"device": "/dev/video0"},
+            "slots": [{"param": "device", "segment": 0,
+                       "element": 0, "arg": "device"}],
+        })
+
+        assert plan_aravis_feeds(document, None) == []
+
+    def test_empty_binding_points_list_plans_zero_feeds(self):
+        document = make_document()
+        document["bindingPoints"] = []
+
+        assert plan_aravis_feeds(document, None) == []

--- a/test/backend-test/workflow_engine/test_workflow_python_bridge_dispatch.py
+++ b/test/backend-test/workflow_engine/test_workflow_python_bridge_dispatch.py
@@ -1,0 +1,260 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Example tests for handler entry-point dispatch, pre-imports, and
+library imports through a real :class:`CustomPythonBridge` subprocess
+(custom-python-frames Requirements 3.7, 3.8, 4.1-4.5, 5.1, 5.7).
+
+Sibling of ``test_workflow_python_bridge.py``, following its patterns:
+real handler subprocesses over the framed stdin/stdout protocol, one
+bridge per test with a generous wall-clock limit (the first frame pays
+the numpy/cv2 import cost).
+"""
+import os
+
+import pytest
+
+from workflow_engine.python_bridge import (
+    CustomPythonBridge,
+    CustomPythonNodeError,
+)
+
+NODE_ID = "pynode"
+
+#: Generous per-frame limit: the first frame of each subprocess pays the
+#: numpy/cv2 import cost.
+WALL_CLOCK_LIMIT_SEC = 30.0
+
+
+def write_file(tmp_path, code, name="handler.py"):
+    path = os.path.join(str(tmp_path), name)
+    with open(path, "w") as f:
+        f.write(code)
+    return path
+
+
+def make_bridge(handler_path, **kwargs):
+    kwargs.setdefault("wall_clock_limit_sec", WALL_CLOCK_LIMIT_SEC)
+    return CustomPythonBridge(NODE_ID, handler_path, **kwargs)
+
+
+# A 2x2 RGB frame (12 bytes) for tests dispatching through the
+# process_frame path, which needs valid caps.
+RGB_FRAME = bytes(range(12))
+RGB_CAPS = {"width": 2, "height": 2, "frame_format": "RGB"}
+
+
+# ---------------------------------------------------------------------------
+# Entry-point dispatch (Requirements 3.7, 3.8)
+# ---------------------------------------------------------------------------
+
+
+class TestEntryPointDispatch:
+    def test_process_frame_wins_when_both_entry_points_defined(
+        self, tmp_path
+    ):
+        # process_frame passes the frame through (None return) and tags
+        # the metadata; handle would reverse the bytes and tag
+        # differently. The output proves process_frame ran and handle
+        # was ignored (Requirement 3.7).
+        handler = (
+            "def process_frame(frame, metadata):\n"
+            "    metadata['entry'] = 'process_frame'\n"
+            "    return None\n"
+            "\n"
+            "def handle(frame_bytes, metadata):\n"
+            "    metadata['entry'] = 'handle'\n"
+            "    return frame_bytes[::-1], metadata\n"
+        )
+        bridge = make_bridge(write_file(tmp_path, handler))
+        try:
+            out_frame, out_meta = bridge.process_frame(RGB_FRAME, **RGB_CAPS)
+        finally:
+            bridge.stop()
+        assert out_frame == RGB_FRAME
+        assert out_meta["entry"] == "process_frame"
+
+    def test_neither_entry_point_names_both_and_the_node(self, tmp_path):
+        # A module that loads fine but defines no entry point fails the
+        # run with an error naming both accepted entry points
+        # (Requirement 3.8).
+        bridge = make_bridge(write_file(tmp_path, "x = 1\n"))
+        try:
+            with pytest.raises(CustomPythonNodeError) as excinfo:
+                bridge.process_frame(b"frame")
+        finally:
+            bridge.stop()
+        assert excinfo.value.node_id == NODE_ID
+        message = str(excinfo.value)
+        assert "process_frame" in message
+        assert "handle" in message
+
+    def test_non_callable_entry_points_name_both_and_the_node(
+        self, tmp_path
+    ):
+        # Bound but non-callable names do not count as entry points
+        # (Requirement 3.8).
+        handler = "process_frame = 1\nhandle = 'nope'\n"
+        bridge = make_bridge(write_file(tmp_path, handler))
+        try:
+            with pytest.raises(CustomPythonNodeError) as excinfo:
+                bridge.process_frame(b"frame")
+        finally:
+            bridge.stop()
+        assert excinfo.value.node_id == NODE_ID
+        message = str(excinfo.value)
+        assert "process_frame" in message
+        assert "handle" in message
+
+
+# ---------------------------------------------------------------------------
+# Pre-imported cv2/np and device library imports (Requirements 4.1-4.5)
+# ---------------------------------------------------------------------------
+
+
+class TestPreImportsAndLibraryImports:
+    def test_handler_uses_cv2_and_np_without_import_statements(
+        self, tmp_path
+    ):
+        # cv2 and np are bound in the handler module's namespace before
+        # its code executes (Requirements 4.1, 4.2): no import
+        # statements anywhere in the handler.
+        handler = (
+            "CV2_VERSION = cv2.__version__\n"  # top-level use, no import
+            "\n"
+            "def process_frame(frame, metadata):\n"
+            "    metadata['cv2_version'] = CV2_VERSION\n"
+            "    metadata['numpy_is_np'] = numpy is np\n"
+            "    return np.bitwise_not(frame)\n"
+        )
+        bridge = make_bridge(write_file(tmp_path, handler))
+        try:
+            out_frame, out_meta = bridge.process_frame(RGB_FRAME, **RGB_CAPS)
+        finally:
+            bridge.stop()
+        assert out_frame == bytes(255 - b for b in RGB_FRAME)
+        assert out_meta["cv2_version"]
+        assert out_meta["numpy_is_np"] is True
+
+    def test_handler_imports_stdlib_and_sibling_module(self, tmp_path):
+        # A standard import statement resolves stdlib modules through
+        # the device interpreter (Requirement 4.4) and modules shipped
+        # beside handler.py in the node's artifact directory
+        # (Requirement 4.5).
+        write_file(
+            tmp_path,
+            "def marker():\n    return 'sibling-ok'\n",
+            name="sibling_helper.py",
+        )
+        handler = (
+            "import base64\n"
+            "import sibling_helper\n"
+            "\n"
+            "def handle(frame_bytes, metadata):\n"
+            "    out = dict(metadata)\n"
+            "    out['encoded'] = base64.b64encode(frame_bytes)"
+            ".decode('ascii')\n"
+            "    out['sibling'] = sibling_helper.marker()\n"
+            "    return frame_bytes, out\n"
+        )
+        bridge = make_bridge(write_file(tmp_path, handler))
+        try:
+            out_frame, out_meta = bridge.process_frame(b"abc")
+        finally:
+            bridge.stop()
+        assert out_frame == b"abc"
+        assert out_meta["encoded"] == "YWJj"
+        assert out_meta["sibling"] == "sibling-ok"
+
+    def test_blocked_cv2_import_still_runs_a_handle_only_handler(
+        self, tmp_path
+    ):
+        # The runner prepends the handler's directory to sys.path, so an
+        # import-raising cv2.py stub beside handler.py blocks the cv2
+        # pre-import inside this subprocess. The binding is left absent
+        # and a handle-only handler that never references cv2 runs
+        # unaffected (Requirement 4.3).
+        write_file(
+            tmp_path,
+            "raise ImportError('cv2 blocked for this test')\n",
+            name="cv2.py",
+        )
+        handler = (
+            "def handle(frame_bytes, metadata):\n"
+            "    out = dict(metadata)\n"
+            "    out['cv2_bound'] = 'cv2' in globals()\n"
+            "    return frame_bytes, out\n"
+        )
+        bridge = make_bridge(write_file(tmp_path, handler))
+        try:
+            out_frame, out_meta = bridge.process_frame(b"frame")
+        finally:
+            bridge.stop()
+        assert out_frame == b"frame"
+        assert out_meta["cv2_bound"] is False
+
+
+# ---------------------------------------------------------------------------
+# dda_frames availability (Requirements 5.1, 5.7)
+# ---------------------------------------------------------------------------
+
+
+class TestDdaFramesImport:
+    def test_import_dda_frames_with_only_handler_py_shipped(self, tmp_path):
+        # `import dda_frames` resolves without the node shipping any
+        # additional files (Requirement 5.1); it works from a
+        # handle-based handler just as from a process_frame one
+        # (Requirement 5.7).
+        handler = (
+            "import dda_frames\n"
+            "\n"
+            "def handle(frame_bytes, metadata):\n"
+            "    out = dict(metadata)\n"
+            "    out['formats'] = sorted(dda_frames.FORMAT_CHANNELS)\n"
+            "    out['info'] = dda_frames.frame_info()\n"
+            "    return frame_bytes, out\n"
+        )
+        handler_path = write_file(tmp_path, handler)
+        assert os.listdir(str(tmp_path)) == ["handler.py"]
+        bridge = make_bridge(handler_path)
+        try:
+            out_frame, out_meta = bridge.process_frame(
+                b"frame", width=4, height=2, frame_format="GRAY8"
+            )
+        finally:
+            bridge.stop()
+        assert out_frame == b"frame"
+        assert out_meta["formats"] == ["BGR", "GRAY8", "RGB", "RGBA"]
+        assert out_meta["info"] == {
+            "width": 4, "height": 2, "format": "GRAY8",
+        }
+
+    def test_import_dda_frames_from_a_process_frame_handler(self, tmp_path):
+        # The same helper module serves process_frame handlers
+        # (Requirement 5.7): to_bytes(frame) of the received array
+        # equals the dispatched (unpadded) frame bytes.
+        handler = (
+            "import dda_frames\n"
+            "\n"
+            "def process_frame(frame, metadata):\n"
+            "    metadata['roundtrip'] = "
+            "dda_frames.to_bytes(frame) == bytes(range(12))\n"
+            "    return None\n"
+        )
+        bridge = make_bridge(write_file(tmp_path, handler))
+        try:
+            out_frame, out_meta = bridge.process_frame(RGB_FRAME, **RGB_CAPS)
+        finally:
+            bridge.stop()
+        assert out_frame == RGB_FRAME
+        assert out_meta["roundtrip"] is True

--- a/test/backend-test/workflow_engine/test_workflow_python_bridge_frames.py
+++ b/test/backend-test/workflow_engine/test_workflow_python_bridge_frames.py
@@ -1,0 +1,283 @@
+# Copyright 2025 Amazon Web Services, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Example tests for the frame-based Custom Python handler contract:
+entry-point dispatch, pre-imported cv2/np bindings, device/stdlib/sibling
+imports, and the injected ``dda_frames`` helper module.
+
+All tests run real handler subprocesses through
+:class:`CustomPythonBridge`, mirroring ``test_workflow_python_bridge.py``.
+
+Covers Requirements 3.7, 3.8, 4.1, 4.2, 4.3, 4.4, 4.5, 5.1, 5.7.
+"""
+import os
+
+import pytest
+
+from workflow_engine.python_bridge import (
+    CustomPythonBridge,
+    CustomPythonNodeError,
+)
+
+NODE_ID = "pyframes"
+
+#: Generous per-frame limit: the first frame of a subprocess pays the
+#: numpy/cv2 import cost.
+WALL_CLOCK_LIMIT_SEC = 30.0
+
+# A 2x2 BGR frame (12 bytes, no row padding) used by the dispatch tests.
+WIDTH, HEIGHT, FORMAT = 2, 2, "BGR"
+FRAME = bytes(range(WIDTH * HEIGHT * 3))
+INVERTED_FRAME = bytes(255 - b for b in FRAME)
+
+
+def write_handler(tmp_path, code, name="handler.py"):
+    path = os.path.join(str(tmp_path), name)
+    with open(path, "w") as f:
+        f.write(code)
+    return path
+
+
+def make_bridge(handler_path, **kwargs):
+    kwargs.setdefault("wall_clock_limit_sec", WALL_CLOCK_LIMIT_SEC)
+    return CustomPythonBridge(NODE_ID, handler_path, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Entry-point dispatch (Requirements 3.7, 3.8)
+# ---------------------------------------------------------------------------
+
+
+BOTH_ENTRY_POINTS_HANDLER = """\
+def process_frame(frame, metadata):
+    metadata["entry"] = "process_frame"
+    return np.bitwise_not(frame)
+
+
+def handle(frame_bytes, metadata):
+    return b"HANDLE-MUST-NOT-WIN", {"entry": "handle"}
+"""
+
+
+class TestEntryPointDispatch:
+    def test_process_frame_wins_when_both_are_defined(self, tmp_path):
+        """When ``handler.py`` defines both entry points, ``process_frame``
+        is invoked and ``handle`` is ignored (Requirement 3.7)."""
+        bridge = make_bridge(
+            write_handler(tmp_path, BOTH_ENTRY_POINTS_HANDLER)
+        )
+        try:
+            out_frame, out_meta = bridge.process_frame(
+                FRAME, width=WIDTH, height=HEIGHT, frame_format=FORMAT
+            )
+        finally:
+            bridge.stop()
+        assert out_frame == INVERTED_FRAME
+        assert out_frame != b"HANDLE-MUST-NOT-WIN"
+        assert out_meta["entry"] == "process_frame"
+
+    def test_neither_entry_point_names_both_in_the_error(self, tmp_path):
+        """A handler defining neither entry point fails the run with a
+        ``CustomPythonNodeError`` naming ``process_frame`` and ``handle``
+        (Requirement 3.8)."""
+        bridge = make_bridge(write_handler(tmp_path, "x = 1\n"))
+        with pytest.raises(CustomPythonNodeError) as excinfo:
+            bridge.process_frame(
+                FRAME, width=WIDTH, height=HEIGHT, frame_format=FORMAT
+            )
+        assert excinfo.value.node_id == NODE_ID
+        message = str(excinfo.value)
+        assert "process_frame" in message
+        assert "handle" in message
+
+
+# ---------------------------------------------------------------------------
+# Pre-imported cv2 / np / numpy bindings (Requirements 4.1, 4.2, 4.3)
+# ---------------------------------------------------------------------------
+
+
+#: Uses cv2, np, and numpy at module top level and per frame without a
+#: single import statement.
+PREIMPORTED_HANDLER = """\
+CV2_VERSION = cv2.__version__
+NUMPY_VERSION = numpy.__version__
+ONES = np.ones((1,), dtype=np.uint8)
+
+
+def process_frame(frame, metadata):
+    metadata["cv2_version"] = CV2_VERSION
+    metadata["numpy_version"] = NUMPY_VERSION
+    inverted = cv2.bitwise_not(frame)
+    assert isinstance(inverted, np.ndarray)
+    return inverted
+"""
+
+
+class TestPreImportedBindings:
+    def test_handler_uses_cv2_and_np_without_import_statements(
+        self, tmp_path
+    ):
+        """cv2, np, and numpy are bound in the handler module namespace
+        before the handler code executes (Requirements 4.1, 4.2)."""
+        bridge = make_bridge(write_handler(tmp_path, PREIMPORTED_HANDLER))
+        try:
+            out_frame, out_meta = bridge.process_frame(
+                FRAME, width=WIDTH, height=HEIGHT, frame_format=FORMAT
+            )
+        finally:
+            bridge.stop()
+        assert out_frame == INVERTED_FRAME
+        assert out_meta["cv2_version"]
+        assert out_meta["numpy_version"]
+
+    def test_blocked_cv2_still_runs_a_handle_only_handler(
+        self, tmp_path, monkeypatch
+    ):
+        """With cv2 unimportable in the subprocess (an import-raising stub
+        on PYTHONPATH), a handler that does not reference cv2 still loads
+        and runs (Requirement 4.3)."""
+        stub_dir = tmp_path / "stubs"
+        stub_dir.mkdir()
+        (stub_dir / "cv2.py").write_text(
+            'raise ImportError("cv2 blocked for this test")\n'
+        )
+        existing = os.environ.get("PYTHONPATH", "")
+        monkeypatch.setenv(
+            "PYTHONPATH",
+            str(stub_dir) + (os.pathsep + existing if existing else ""),
+        )
+        handler = (
+            "def handle(frame_bytes, metadata):\n"
+            "    try:\n"
+            "        import cv2  # noqa: F401\n"
+            "        blocked = False\n"
+            "    except ImportError:\n"
+            "        blocked = True\n"
+            "    return frame_bytes[::-1], {'cv2_blocked': blocked}\n"
+        )
+        handler_dir = tmp_path / "node"
+        handler_dir.mkdir()
+        bridge = make_bridge(write_handler(handler_dir, handler))
+        try:
+            out_frame, out_meta = bridge.process_frame(b"abc")
+        finally:
+            bridge.stop()
+        assert out_frame == b"cba"
+        # The stub really did block cv2 inside the subprocess.
+        assert out_meta["cv2_blocked"] is True
+
+
+# ---------------------------------------------------------------------------
+# Device-interpreter and sibling-module imports (Requirements 4.4, 4.5)
+# ---------------------------------------------------------------------------
+
+
+SIBLING_MODULE = """\
+def reverse(data):
+    return data[::-1]
+"""
+
+IMPORTING_HANDLER = """\
+import base64
+
+import frame_ops
+
+
+def handle(frame_bytes, metadata):
+    encoded = base64.b64encode(frame_bytes).decode("ascii")
+    return frame_ops.reverse(frame_bytes), {"b64": encoded}
+"""
+
+
+class TestHandlerImports:
+    def test_stdlib_and_sibling_module_imports_resolve(self, tmp_path):
+        """A standard import resolves libraries of the device interpreter
+        (stdlib ``base64``, Requirement 4.4) and modules shipped beside
+        ``handler.py`` in the node's artifact directory (``frame_ops``,
+        Requirement 4.5)."""
+        import base64
+
+        write_handler(tmp_path, SIBLING_MODULE, name="frame_ops.py")
+        bridge = make_bridge(write_handler(tmp_path, IMPORTING_HANDLER))
+        try:
+            out_frame, out_meta = bridge.process_frame(b"payload")
+        finally:
+            bridge.stop()
+        assert out_frame == b"daolyap"
+        assert out_meta["b64"] == base64.b64encode(b"payload").decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# dda_frames injection (Requirements 5.1, 5.7)
+# ---------------------------------------------------------------------------
+
+
+#: handle-contract handler importing dda_frames — only handler.py shipped.
+DDA_FRAMES_HANDLE_HANDLER = """\
+import dda_frames
+
+
+def handle(frame_bytes, metadata):
+    info = metadata["frame"]
+    array = dda_frames.to_array(
+        frame_bytes, info["width"], info["height"], info["format"]
+    )
+    return dda_frames.to_bytes(array), {"shape": list(array.shape)}
+"""
+
+#: process_frame-contract handler importing dda_frames.
+DDA_FRAMES_PROCESS_HANDLER = """\
+import dda_frames
+
+
+def process_frame(frame, metadata):
+    metadata["info"] = dda_frames.frame_info()
+    return None
+"""
+
+
+class TestDdaFramesInjection:
+    def test_import_dda_frames_with_only_handler_py_shipped(self, tmp_path):
+        """``import dda_frames`` succeeds although the node ships only
+        ``handler.py`` — the runner injects the module (Requirement 5.1);
+        available under the ``handle`` contract (Requirement 5.7)."""
+        assert os.listdir(str(tmp_path)) == []
+        bridge = make_bridge(
+            write_handler(tmp_path, DDA_FRAMES_HANDLE_HANDLER)
+        )
+        assert os.listdir(str(tmp_path)) == ["handler.py"]
+        try:
+            out_frame, out_meta = bridge.process_frame(
+                FRAME, width=WIDTH, height=HEIGHT, frame_format=FORMAT
+            )
+        finally:
+            bridge.stop()
+        assert out_frame == FRAME
+        assert out_meta["shape"] == [HEIGHT, WIDTH, 3]
+
+    def test_dda_frames_available_to_process_frame_handlers(self, tmp_path):
+        """The same helper module serves ``process_frame`` handlers alike
+        (Requirements 5.1, 5.7)."""
+        bridge = make_bridge(
+            write_handler(tmp_path, DDA_FRAMES_PROCESS_HANDLER)
+        )
+        try:
+            out_frame, out_meta = bridge.process_frame(
+                FRAME, width=WIDTH, height=HEIGHT, frame_format=FORMAT
+            )
+        finally:
+            bridge.stop()
+        assert out_frame == FRAME
+        assert out_meta["info"] == {
+            "width": WIDTH, "height": HEIGHT, "format": FORMAT,
+        }


### PR DESCRIPTION
## Summary

Three specs addressing six reported bugs/gaps in the workflow designer and edge pipeline:

### 1. Workflow designer bugfixes (`43480e2`)
- **Temperature omitted when unset**: Bedrock workflow generation no longer passes `temperature` when no value is configured (newer models like Opus reject it as deprecated). Settings form accepts blank.
- **Category-driven default ports**: node-designer wizards derive default input/output port arrangements from the node category (input types get no input port), with a requirements line in the port guidance panel.
- **Opt-in module import**: node import view starts with nothing selected instead of check-all.

### 2. Custom Python frame processing (`555823c`)
- New `custom_python_preprocess` node type (VideoFrames in/out) alongside postprocess.
- `process_frame(frame, metadata)` ndarray contract in the Python bridge with a `dda_frames` helper module (`to_array`/`to_bytes`/`frame_info`/`load_image` incl. s3://), cv2/numpy pre-bound.
- Thread-cap env fix (OPENBLAS/OMP/OPENCV=1) so numpy imports don't hang under the 512MB RLIMIT_AS sandbox on many-core hosts.
- Vendored workflow_core mirror synced with a byte-equality smoke test.

### 3. Aravis camera input (`4d24df6`)
- New `aravis_camera_source` node type (camera_id/gain/exposure, appsrc-headed device mappings) in both mirrored catalog copies.
- Edge Aravis discovery with deterministic stable ids, wired into the CameraDiscovery loop; inventory merge of configured Image_Sources with discovered Aravis cameras.
- Portal: Aravis camera picker in the workflow builder (synced with edge registry), packaging binding points, deployment type-compatibility validation, and binding matrix filtering.
- Edge: binding resolution (`aravis_assignments`), frame-feed planning, and WorkflowExecutor appsrc frame feed via camera_manager.

## Testing
- Portal backend pytest: 1206 passed
- Frontend vitest: 660 passed; `npm run build` clean
- Edge suites (workflow_engine, camera_discovery, camera_sync): 402 passed, 3 skipped
- All correctness properties from the three specs implemented as hypothesis/fast-check property tests
- Vendored workflow_core mirror verified byte-identical to the portal layer copy

## Notes
- Pre-existing, unrelated: `tests/test_captures.py` ordering interaction with `layers/shared/python/test_s3_paths.py` (passes in the normal scoped run); vendored-layer pytest collection errors on unscoped `pytest` from `edge-cv-portal/backend`.